### PR TITLE
Add anchors and hash to all headers, add Prettier

### DIFF
--- a/.nextra/styles.css
+++ b/.nextra/styles.css
@@ -26,13 +26,13 @@ h3 {
   @apply text-2xl font-semibold tracking-tight mt-8;
 }
 h4 {
-  @apply text-xl font-semibold;
+  @apply text-xl font-semibold tracking-tight mt-8;
 }
 h5 {
-  @apply text-lg font-semibold;
+  @apply text-lg font-semibold tracking-tight mt-8;
 }
 h6 {
-  @apply text-base font-semibold;
+  @apply text-base font-semibold tracking-tight mt-8;
 }
 a {
   @apply text-blue-600 underline;
@@ -92,4 +92,11 @@ content li {
   display: inline-block;
   position: absolute;
   width: 1px;
+}
+.subheading-anchor + a:hover .anchor-icon {
+  opacity: 1;
+}
+.anchor-icon {
+  opacity: 0;
+  @apply ml-2 text-gray-600;
 }

--- a/.nextra/theme.js
+++ b/.nextra/theme.js
@@ -5,75 +5,139 @@ import Highlight, { defaultProps } from 'prism-react-renderer'
 
 const THEME = {
   plain: {
-    color: "#000",
-    backgroundColor: "transparent"
+    color: '#000',
+    backgroundColor: 'transparent',
   },
-  styles: [{
-    types: ["keyword"],
-    style: {
-      color: "#ff0078",
-      fontWeight: "bold"
-    }
-  }, {
-    types: ["comment"],
-    style: {
-      color: "#999",
-      fontStyle: "italic"
-    }
-  }, {
-    types: ["string", "url"],
-    style: {
-      color: "#028265"
-    }
-  }, {
-    types: ["variable"],
-    style: {
-      color: "#c6c5fe"
-    }
-  }, {
-    types: ["builtin", "char", "constant"],
-    style: {
-      color: "#000"
-    }
-  }, {
-    types: ["attr-name"],
-    style: {
-      color: "#d9931e",
-      fontStyle: "normal"
-    }
-  }, {
-    types: ["punctuation", "operator"],
-    style: {
-      color: "#333"
-    }
-  }, {
-    types: ["number", "function"],
-    style: {
-      color: "#0076ff"
-    }
-  }, {
-    types: ["boolean", "regex"],
-    style: {
-      color: "#d9931e"
-    }
-  }]
+  styles: [
+    {
+      types: ['keyword'],
+      style: {
+        color: '#ff0078',
+        fontWeight: 'bold',
+      },
+    },
+    {
+      types: ['comment'],
+      style: {
+        color: '#999',
+        fontStyle: 'italic',
+      },
+    },
+    {
+      types: ['string', 'url'],
+      style: {
+        color: '#028265',
+      },
+    },
+    {
+      types: ['variable'],
+      style: {
+        color: '#c6c5fe',
+      },
+    },
+    {
+      types: ['builtin', 'char', 'constant'],
+      style: {
+        color: '#000',
+      },
+    },
+    {
+      types: ['attr-name'],
+      style: {
+        color: '#d9931e',
+        fontStyle: 'normal',
+      },
+    },
+    {
+      types: ['punctuation', 'operator'],
+      style: {
+        color: '#333',
+      },
+    },
+    {
+      types: ['number', 'function'],
+      style: {
+        color: '#0076ff',
+      },
+    },
+    {
+      types: ['boolean', 'regex'],
+      style: {
+        color: '#d9931e',
+      },
+    },
+  ],
 }
 
-// h2 with an achor link
-const H2 = ({ children, ...props }) => {
+// Anchor links
+
+const HeaderLink = ({ tag: Tag, children, ...props }) => {
   const slug = slugify(children || '')
-  return <h2 {...props}>
-    <span className="subheading-anchor" id={slug}/>
-    <a href={'#' + slug} className="text-current no-underline no-outline">{children}</a>
-  </h2>
+  return (
+    <Tag {...props}>
+      <span className="subheading-anchor" id={slug} />
+      <a href={'#' + slug} className="text-current no-underline no-outline">
+        {children}
+        <span className="anchor-icon" aria-hidden>#</span>
+      </a>
+    </Tag>
+  )
+}
+
+const H2 = ({ children, ...props }) => {
+  return (
+    <HeaderLink tag="h2" {...props}>
+      {children}
+    </HeaderLink>
+  )
+}
+
+const H3 = ({ children, ...props }) => {
+  return (
+    <HeaderLink tag="h3" {...props}>
+      {children}
+    </HeaderLink>
+  )
+}
+
+const H4 = ({ children, ...props }) => {
+  return (
+    <HeaderLink tag="h4" {...props}>
+      {children}
+    </HeaderLink>
+  )
+}
+
+const H5 = ({ children, ...props }) => {
+  return (
+    <HeaderLink tag="h5" {...props}>
+      {children}
+    </HeaderLink>
+  )
+}
+
+const H6 = ({ children, ...props }) => {
+  return (
+    <HeaderLink tag="h6" {...props}>
+      {children}
+    </HeaderLink>
+  )
 }
 
 const A = ({ children, ...props }) => {
   const isExternal = props.href?.startsWith('https://')
   if (isExternal) {
-    return <a target="_blank" {...props}>{children}</a>
+    return (
+      <a target="_blank" {...props}>
+        {children}
+      </a>
+    )
   }
-  return <Link href={props.href}><a {...props}>{children}</a></Link>
+  return (
+    <Link href={props.href}>
+      <a {...props}>{children}</a>
+    </Link>
+  )
 }
 
 const Code = ({ children, className, highlight, ...props }) => {
@@ -83,31 +147,48 @@ const Code = ({ children, className, highlight, ...props }) => {
 
   // https://mdxjs.com/guides/syntax-highlighting#all-together
   const language = className.replace(/language-/, '')
-  return <Highlight {...defaultProps} code={children.trim()} language={language} theme={THEME}>
-    {({className, style, tokens, getLineProps, getTokenProps}) => (
-      <code className={className} style={{ ...style }}>
-        {tokens.map((line, i) => (
-          <div key={i} {...getLineProps({line, key: i})} style={
-            highlightedLines.includes(i + 1) ? {
-              background: '#cce0f5',
-              margin: '0 -1rem',
-              padding: '0 1rem'
-            } : null
-          }>
-            {line.map((token, key) => (
-              <span key={key} {...getTokenProps({token, key})} />
-            ))}
-          </div>
-        ))}
-      </code>
-    )}
-  </Highlight>
+  return (
+    <Highlight
+      {...defaultProps}
+      code={children.trim()}
+      language={language}
+      theme={THEME}
+    >
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <code className={className} style={{ ...style }}>
+          {tokens.map((line, i) => (
+            <div
+              key={i}
+              {...getLineProps({ line, key: i })}
+              style={
+                highlightedLines.includes(i + 1)
+                  ? {
+                      background: '#cce0f5',
+                      margin: '0 -1rem',
+                      padding: '0 1rem',
+                    }
+                  : null
+              }
+            >
+              {line.map((token, key) => (
+                <span key={key} {...getTokenProps({ token, key })} />
+              ))}
+            </div>
+          ))}
+        </code>
+      )}
+    </Highlight>
+  )
 }
 
 const components = {
   h2: H2,
+  h3: H3,
+  h4: H4,
+  h5: H5,
+  h6: H6,
   a: A,
-  code: Code
+  code: Code,
 }
 
 export default ({ children }) => {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.next
+node_modules

--- a/package.json
+++ b/package.json
@@ -20,8 +20,13 @@
     "@mdx-js/loader": "^1.6.5",
     "babel-plugin-macros": "^2.8.0",
     "postcss-preset-env": "^6.7.0",
+    "prettier": "^2.0.5",
     "preval.macro": "^5.0.0",
     "tailwindcss": "^1.4.6",
     "title": "^3.4.2"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
   }
 }

--- a/pages/headers.md
+++ b/pages/headers.md
@@ -1,0 +1,31 @@
+# Headers
+
+An example of multi-level anchor headers.
+
+## API Options
+
+```js
+const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
+```
+
+### Parameters
+
+- `key`: a unique key string for the request (or a function / array / null) [(advanced usage)](/docs/conditional-fetching)
+- `fetcher`: (_optional_) a Promise returning function to fetch your data [(details)](/docs/data-fetching)
+- `options`: (_optional_) an object of options for this SWR hook
+
+### key
+
+Either a function that resolves to a value, or a value. The value can be a string, array, or null.
+
+#### Function usage
+
+Function that resolves to a value.
+
+##### Throwing
+
+If the function throws, the key value will be assumed `null`.
+
+###### null
+
+`null` is a value in JavaScript.

--- a/pages/meta.json
+++ b/pages/meta.json
@@ -1,6 +1,7 @@
 {
   "index": "Nextra",
   "docs": "Docs",
-  "mdx": "MDX Supoprt",
-  "anchors": "Anchor Links"
+  "mdx": "MDX Support",
+  "anchors": "Anchor Links",
+  "headers": "Header Levels"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5412,6 +5412,11 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"


### PR DESCRIPTION
- Standardizes the spacing for all header elements (h1 through h6)
- Adds a hash link to each of them
- Show `#` on hover, as per feedback
- Added Prettier config

pages/headers has an example.

