### PR TITLE
fix(loader): JSON parse throwing if isn't valid

### DIFF
--- a/packages/nextra/src/loader.js
+++ b/packages/nextra/src/loader.js
@@ -21,6 +21,17 @@ function getFileName (resourcePath) {
   return removeExtension(path.basename(resourcePath))
 }
 
+const parseJsonFile = (path) => {
+  let parsed
+  try {
+    parsed = JSON.parse(file)
+  } catch (err) {
+    throw Error(`Error parsing ${path}, make sure it's a valid JSON \n` + err)
+  }
+
+  return parsed
+}
+
 async function getPageMap(currentResourcePath) {
   const extension = /\.(mdx?|jsx?)$/
   const mdxExtension = /\.mdx?$/
@@ -31,7 +42,7 @@ async function getPageMap(currentResourcePath) {
     const files = await fs.readdir(dir, { withFileTypes: true })
 
     // go through the directory
-    const items = 
+    const items =
       (await Promise.all(
         files
           .map(async f => {
@@ -72,11 +83,13 @@ async function getPageMap(currentResourcePath) {
 
               return {
                 name: removeExtension(f.name),
-                route: fileRoute, 
+                route: fileRoute,
                 locale: getLocaleFromFilename(f.name)
               }
             } else if (metaExtension.test(f.name)) {
-              const meta = JSON.parse(await fs.readFile(filePath, 'utf-8'))
+              const metaContent = await fs.readFile(path, 'utf-8')
+              const meta = parseJsonFile(metaContent)
+
               const locale = f.name.match(metaExtension)[1]
 
               return {

--- a/packages/nextra/src/loader.js
+++ b/packages/nextra/src/loader.js
@@ -22,7 +22,7 @@ function getFileName (resourcePath) {
 }
 
 const parseJsonFile = (content, path) => {
-  let parsed
+  let parsed = {}
   try {
     parsed = JSON.parse(content)
   } catch (err) {

--- a/packages/nextra/src/loader.js
+++ b/packages/nextra/src/loader.js
@@ -21,12 +21,12 @@ function getFileName (resourcePath) {
   return removeExtension(path.basename(resourcePath))
 }
 
-const parseJsonFile = (path) => {
+const parseJsonFile = (content, path) => {
   let parsed
   try {
-    parsed = JSON.parse(file)
+    parsed = JSON.parse(content)
   } catch (err) {
-    throw Error(`Error parsing ${path}, make sure it's a valid JSON \n` + err)
+    console.error(`Error parsing ${path}, make sure it's a valid JSON \n` + err)
   }
 
   return parsed
@@ -87,8 +87,8 @@ async function getPageMap(currentResourcePath) {
                 locale: getLocaleFromFilename(f.name)
               }
             } else if (metaExtension.test(f.name)) {
-              const metaContent = await fs.readFile(path, 'utf-8')
-              const meta = parseJsonFile(metaContent)
+              const content = await fs.readFile(filePath, 'utf-8')
+              const meta = parseJsonFile(content, filePath)
 
               const locale = f.name.match(metaExtension)[1]
 


### PR DESCRIPTION
For some reason when I cloned nextra-docs meta.json files were considered "META" from my editor and I kept doing silly mistakes.

-- Not sure why the deploy failed, but I would assume it's because It's not on my vercel account?