### PR TITLE
Correct github edit path

### DIFF
--- a/examples/docs/theme.config.js
+++ b/examples/docs/theme.config.js
@@ -1,7 +1,7 @@
 export default {
   repository: 'https://github.com/shuding/nextra',
   branch: 'core',
-  path: '/examples/docs',
+  path: '/examples/docs/pages',
   titleSuffix: ' – Nextra',
   logo: (
     <>

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -156,7 +156,7 @@ const Layout = ({ filename, config: _config, pageMap, meta, children }) => {
   const flatDirectories = useMemo(() => flatten(directories), [directories])
   const config = Object.assign({}, defaultConfig, _config)
 
-  const filepath = route.slice(0, route.lastIndexOf('/') + 1)
+  const filepath = route.slice(1, route.lastIndexOf('/') + 1)
   const filepathWithName = filepath + filename
   const titles = React.Children.toArray(children).filter(child =>
     titleType.includes(child.props.mdxType)


### PR DESCRIPTION
Problem: Editing a page on Github currently leads to the wrong path (because `pages` is not specified in `path`). Moreover, there's a double `//` in the generated path because `normalizedPath` ends with `/` and `filepathWithName` begins with `/`; although this is still resolved correctly I think filepathWithName doesn't have to begin with `/`. 