### PR TITLE
Ignore files with empty basename, like .DS_Store etc

### DIFF
--- a/packages/nextra/src/loader.js
+++ b/packages/nextra/src/loader.js
@@ -14,7 +14,8 @@ function getLocaleFromFilename(name) {
 }
 
 function removeExtension(name) {
-  return name.match(/^([^.]+)/)[1]
+  const p = name.match(/^([^.]+)/)
+  return p != null ? p[1] : ''
 }
 
 function getFileName(resourcePath) {


### PR DESCRIPTION
If there is a file with empty basename in the `pages` directory, will break the building process. Ignore them to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shuding/nextra/62)
<!-- Reviewable:end -->
