### PR TITLE
Accept mdx options

### DIFF
--- a/packages/nextra/src/index.js
+++ b/packages/nextra/src/index.js
@@ -3,6 +3,10 @@ const markdownExtensions = ['md', 'mdx']
 const markdownExtensionTest = /\.mdx?$/
 
 export default (theme, themeConfig) => (nextConfig = {}) => {
+  const config = typeof theme === "string" ? {
+    theme,
+    themeConfig
+  } : theme;
   const locales = nextConfig.i18n ? nextConfig.i18n.locales : null
   const defaultLocale = nextConfig.i18n ? nextConfig.i18n.defaultLocale : null
 
@@ -33,11 +37,12 @@ export default (theme, themeConfig) => (nextConfig = {}) => {
           use: [
             options.defaultLoaders.babel,
             {
-              loader: '@mdx-js/loader'
+              loader: '@mdx-js/loader',
+              options: config.mdxOptions
             },
             {
               loader: 'nextra/loader',
-              options: { theme, themeConfig, locales, defaultLocale }
+              options: { theme: config.theme, themeConfig: config.themeConfig, locales, defaultLocale }
             }
           ]
         })

--- a/packages/nextra/src/index.js
+++ b/packages/nextra/src/index.js
@@ -10,7 +10,7 @@ export default (theme, themeConfig) => (nextConfig = {}) => {
   const locales = nextConfig.i18n ? nextConfig.i18n.locales : null
   const defaultLocale = nextConfig.i18n ? nextConfig.i18n.defaultLocale : null
 
-  let pageExtensions = [...defaultExtensions]
+  let pageExtensions = nextConfig.pathExtensions || [...defaultExtensions]
   if (locales) {
     console.log('You have i18n enabled for Nextra.')
     if (!defaultLocale) {
@@ -26,11 +26,10 @@ export default (theme, themeConfig) => (nextConfig = {}) => {
   }
 
   return Object.assign(
-    {
-      pageExtensions
-    },
+    {},
     nextConfig,
     {
+      pageExtensions,
       webpack(config, options) {
         config.module.rules.push({
           test: markdownExtensionTest,

--- a/packages/nextra/src/index.js
+++ b/packages/nextra/src/index.js
@@ -10,7 +10,7 @@ export default (theme, themeConfig) => (nextConfig = {}) => {
   const locales = nextConfig.i18n ? nextConfig.i18n.locales : null
   const defaultLocale = nextConfig.i18n ? nextConfig.i18n.defaultLocale : null
 
-  let pageExtensions = nextConfig.pathExtensions || [...defaultExtensions]
+  let pageExtensions = nextConfig.pageExtensions || [...defaultExtensions]
   if (locales) {
     console.log('You have i18n enabled for Nextra.')
     if (!defaultLocale) {


### PR DESCRIPTION
I made a change to support more options to accept mdx-js/loader options: e.g. remarkPlugins and rehypePlugins.

```js
// this still works
const withNextra = require("nextra")("./theme", "./theme.config.js")

// also object can be accepted
const withNextra = require("nextra")({
  theme: "./theme",
  themeConfig: "./theme.config.js",
  mdxOptions: {
    remarkPlugins: [require("remark-emoji")]
  }
})
```

Note: If #75 is merged first, the type definition needs to be modified as well.