### PR TITLE
fix: og protocol peropty in meta

### DIFF
--- a/examples/docs/theme.config.js
+++ b/examples/docs/theme.config.js
@@ -18,10 +18,10 @@ export default {
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta httpEquiv="Content-Language" content="en" />
       <meta name="description" content="Nextra: the next site builder" />
-      <meta name="og:description" content="Nextra: the next site builder" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@shuding_" />
-      <meta name="og:title" content="Nextra: the next site builder" />
+      <meta property="og:title" content="Nextra: the next site builder" />
+      <meta property="og:description" content="Nextra: the next site builder" />
       <meta name="apple-mobile-web-app-title" content="Nextra" />
     </>
   ),

--- a/packages/nextra-theme-docs/src/misc/default.config.js
+++ b/packages/nextra-theme-docs/src/misc/default.config.js
@@ -28,10 +28,10 @@ export default {
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta httpEquiv="Content-Language" content="en" />
       <meta name="description" content="Nextra: the next docs builder" />
-      <meta name="og:description" content="Nextra: the next docs builder" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@shuding_" />
-      <meta name="og:title" content="Nextra: the next docs builder" />
+      <meta property="og:title" content="Nextra: the next docs builder" />
+      <meta property="og:description" content="Nextra: the next docs builder" />
       <meta name="apple-mobile-web-app-title" content="Nextra" />
     </React.Fragment>
   ),


### PR DESCRIPTION
follow og protocol, use `property` and `content` to describe pairs
reference: https://ogp.me