### PR TITLE
polish: contain code line inside code box

### DIFF
--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -298,6 +298,9 @@ pre .prism-code {
 .dark pre .prism-code {
   --c-highlight: #3d4b61;
 }
+pre .prism-code .token-line {
+  white-space: pre-line;
+}
 pre .prism-code .token.plain,
 pre .prism-code .token.builtin,
 pre .prism-code .token.char,


### PR DESCRIPTION
before vs after

<img width="400" src="https://user-images.githubusercontent.com/4800338/112866223-23aaa680-90ec-11eb-8079-3d87fa98982b.png">

<img width="400" src="https://user-images.githubusercontent.com/4800338/112866285-34f3b300-90ec-11eb-82ce-1ffee4c8152d.png">

~~not sure if it's the same thing wanted in #77~~