### PR TITLE
add the output once and not while cached

### DIFF
--- a/packages/nextra/src/stork-index.js
+++ b/packages/nextra/src/stork-index.js
@@ -88,6 +88,8 @@ export async function buildStorkIndex (storkPath, locales) {
   for (const locale of locales) {
     const tomlFile = path.join(assetDir, `index-${locale}.toml`)
     let toml = await fs.readFile(tomlFile, 'utf-8')
+    const index = toml.indexOf("[output]")
+    if(index < 0) return
     toml += '[output]\n'
     toml += `filename = "${path.join(assetDir, `index-${locale}.st`)}"\n`
     toml += `excerpts_per_result = 1\n`


### PR DESCRIPTION
Image 1 - First Vercel build - Runs the `addStorkIndex` & creates the `.toml` file - No issues in this case.

Image 2 - Second Vercel build - Seems the nextra loader is cached & doesn't run the `addStorkIndex` & hence no `.toml` file.

![image](https://user-images.githubusercontent.com/39694575/113826573-f28f3d80-979f-11eb-9fde-a1500e32b565.png)
![image](https://user-images.githubusercontent.com/39694575/113826680-15215680-97a0-11eb-8632-8dd28628ded4.png)


I think now that the PR changes is not required. Because to fix the above issue, we removed the `.toml` file from gitignore. So when the `.toml` file is not created, `[output]` just gets appended to the same `.toml` file.
