### PR TITLE
Support Cusdis in nextra-theme-blog

### DIFF
--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -25,7 +25,7 @@
     "@tailwindcss/typography": "^0.2.0",
     "github-slugger": "^1.3.0",
     "prism-react-renderer": "^1.1.1",
-    "react-cusdis": "^1.0.1"
+    "react-cusdis": "^2.0.0"
   },
   "peerDependencies": {
     "next": ">=9.5.3",

--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -24,7 +24,8 @@
     "@mdx-js/react": "^1.6.18",
     "@tailwindcss/typography": "^0.2.0",
     "github-slugger": "^1.3.0",
-    "prism-react-renderer": "^1.1.1"
+    "prism-react-renderer": "^1.1.1",
+    "react-cusdis": "^1.0.1"
   },
   "peerDependencies": {
     "next": ">=9.5.3",

--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -25,7 +25,7 @@
     "@tailwindcss/typography": "^0.2.0",
     "github-slugger": "^1.3.0",
     "prism-react-renderer": "^1.1.1",
-    "react-cusdis": "^2.0.0"
+    "react-cusdis": "^2.0.1"
   },
   "peerDependencies": {
     "next": ">=9.5.3",

--- a/packages/nextra-theme-blog/src/index.js
+++ b/packages/nextra-theme-blog/src/index.js
@@ -13,6 +13,9 @@ import getTitle from './utils/get-title'
 import getTags from './utils/get-tags'
 import sortDate from './utils/sort-date'
 
+// comments
+import { ReactCusdis } from 'react-cusdis'
+
 const Layout = ({
   config,
   meta,
@@ -20,6 +23,7 @@ const Layout = ({
   postList,
   back,
   title,
+  comments,
   children
 }) => {
   const [titleNode, contentNodes] = getTitle(children)
@@ -44,6 +48,7 @@ const Layout = ({
         </MDXTheme>
         {postList}
 
+        {comments}
         {config.footer}
       </article>
     </React.Fragment>
@@ -144,6 +149,25 @@ export default (opts, _config) => {
         : null) ||
       ''
 
+    let comments
+
+    if (config.cusdis) {
+      if (!config.cusdis.appId) {
+        console.warn('[cusdis]', '`appId` is required')
+      } else {
+        comments = (
+          <ReactCusdis
+            attrs={{
+              host: config.cusdis.host || 'https://cusdis.com',
+              appId: config.cusdis.appId,
+              pageId: router.pathname,
+              pageTitle: title
+            }}
+          />
+        )
+      }
+    }
+
     const postList = posts ? (
       <ul>
         {posts.map(post => {
@@ -197,6 +221,7 @@ export default (opts, _config) => {
         navPages={navPages}
         back={back}
         title={title}
+        comments={comments}
         {...opts}
         {...props}
       />

--- a/packages/nextra-theme-blog/src/index.js
+++ b/packages/nextra-theme-blog/src/index.js
@@ -161,6 +161,7 @@ export default (opts, _config) => {
       } else {
         comments = (
           <ReactCusdis
+            lang={config.cusdis.lang}
             style={{
               marginTop: '4rem'
             }}

--- a/packages/nextra-theme-blog/src/index.js
+++ b/packages/nextra-theme-blog/src/index.js
@@ -45,10 +45,10 @@ const Layout = ({
         <MDXTheme>
           {contentNodes}
           {type === 'post' ? config.postFooter : null}
+          {type === 'post' ? comments : null}
         </MDXTheme>
         {postList}
 
-        {comments}
         {config.footer}
       </article>
     </React.Fragment>
@@ -157,6 +157,9 @@ export default (opts, _config) => {
       } else {
         comments = (
           <ReactCusdis
+            style={{
+              marginTop: '4rem'
+            }}
             attrs={{
               host: config.cusdis.host || 'https://cusdis.com',
               appId: config.cusdis.appId,

--- a/packages/nextra-theme-blog/src/index.js
+++ b/packages/nextra-theme-blog/src/index.js
@@ -3,6 +3,7 @@ import ReactDOMServer from 'react-dom/server'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import dynamic from 'next/dynamic'
 
 import Meta from './meta'
 import Nav from './nav'
@@ -14,7 +15,10 @@ import getTags from './utils/get-tags'
 import sortDate from './utils/sort-date'
 
 // comments
-import { ReactCusdis } from 'react-cusdis'
+const ReactCusdis = dynamic(
+  () => import('react-cusdis').then(mod => mod.ReactCusdis),
+  { ssr: false }
+)
 
 const Layout = ({
   config,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,6 +2363,11 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.0.0"
 
+cusdis@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cusdis/-/cusdis-1.1.0.tgz#74c81d8b8735869744d77507b057dd47f04e3bc2"
+  integrity sha512-0K+NC3XAiJ6QbxuwFlPRM2s0rIdYpgLzgRmLTca0YC/digPVxX+3X24KJfamuQQsOuJXj5pFuZLQ6Fp2Kg6TJw==
+
 data-uri-to-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
@@ -5377,6 +5382,13 @@ raw-body@2.4.1:
     http-errors "1.7.3"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-cusdis@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-cusdis/-/react-cusdis-1.0.1.tgz#12979ba8a2ab10aee42b68ae563f03fe2001a1c5"
+  integrity sha512-2BrqH2oKKnvyEse07lhcy/BKpXprvceOiWGuD7z/+ew/MOEAeXXayVAIuPqCS0vifZFrsQY5HuvdwoDgvhbHJQ==
+  dependencies:
+    cusdis "^1.0.0"
 
 react-dom@17:
   version "17.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,11 +2363,6 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.0.0"
 
-cusdis@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/cusdis/-/cusdis-1.1.0.tgz#74c81d8b8735869744d77507b057dd47f04e3bc2"
-  integrity sha512-0K+NC3XAiJ6QbxuwFlPRM2s0rIdYpgLzgRmLTca0YC/digPVxX+3X24KJfamuQQsOuJXj5pFuZLQ6Fp2Kg6TJw==
-
 data-uri-to-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
@@ -5383,12 +5378,10 @@ raw-body@2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-cusdis@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-cusdis/-/react-cusdis-1.0.1.tgz#12979ba8a2ab10aee42b68ae563f03fe2001a1c5"
-  integrity sha512-2BrqH2oKKnvyEse07lhcy/BKpXprvceOiWGuD7z/+ew/MOEAeXXayVAIuPqCS0vifZFrsQY5HuvdwoDgvhbHJQ==
-  dependencies:
-    cusdis "^1.0.0"
+react-cusdis@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-cusdis/-/react-cusdis-2.0.0.tgz#81f6dc0efc1fc84d924c206281e45a305aec9c5d"
+  integrity sha512-kvy+hvjtxyQZcAQ7TzpihXYRTXmEtZMSUO9fFYu9tdd2FZI8/fgLRyIEKvsQqKVXqJV3ntfCG1KGPgLd7IAU6w==
 
 react-dom@17:
   version "17.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5378,10 +5378,10 @@ raw-body@2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-cusdis@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-cusdis/-/react-cusdis-2.0.0.tgz#81f6dc0efc1fc84d924c206281e45a305aec9c5d"
-  integrity sha512-kvy+hvjtxyQZcAQ7TzpihXYRTXmEtZMSUO9fFYu9tdd2FZI8/fgLRyIEKvsQqKVXqJV3ntfCG1KGPgLd7IAU6w==
+react-cusdis@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-cusdis/-/react-cusdis-2.0.1.tgz#88d8a8e88be9c8a80b33974d151311c3378acc7a"
+  integrity sha512-8oWF5GdsKUx+l9A58GkYJc6yiYNiF7vw9cZHGLcX0z2MyznwLXizBgPfIFvVV7kdsapdjeium/Ox1J3rR+ZQnw==
 
 react-dom@17:
   version "17.0.1"


### PR DESCRIPTION
I add a `comments` props in `Layout`, so if we want to add another comment widget, we can just pass different `comments` component to the `Layout`

### Usage:

In `theme.config.js`:

```js
export default {
  cusdis: {
    appId: 'xxx',
    host: 'https://cusdis.com', // optional
    lang: 'zh-cn', // optional
  }
}
```

### Preview:

![image](https://user-images.githubusercontent.com/914329/116001236-0ce16c00-a626-11eb-95af-5b61c95c4684.png)
