### PR TITLE
documentation error fix

### DIFF
--- a/pages/blog/get-started.mdx
+++ b/pages/blog/get-started.mdx
@@ -29,7 +29,7 @@ export default {
 4. Create `pages/_app.js` and include the theme stylesheet:
 
 ```jsx
-import 'nextra-theme-blog/style.css'
+import 'nextra-theme-docs/style.css'
 
 export default function Nextra({ Component, pageProps }) {
   return <Component {...pageProps} />


### PR DESCRIPTION
Hello. 
I have just started to use nextra, it`s really inspiring, thanks!
Reading the documentation meet a simple error that break my brains for a while.
It's written to use wrong import:

`import 'nextra-theme-blog/style.css'`  
instead of:
`import 'nextra-theme-docs/style.css'`  

That`s follow with error import when starting project from the scratch instead of copy the repository.

Hope this save some time to somebody in the future.
Thanks.