### PR TITLE
Fixed fresh loading from URLs containing header tags

### DIFF
--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -177,7 +177,7 @@ const Layout = ({ filename, config: _config, pageMap, meta, children }) => {
   const [menu, setMenu] = useState(false)
   const router = useRouter()
   const { route, asPath, locale, defaultLocale } = router
-  const fsPath = getFSRoute(asPath, locale)
+  const fsPath = getFSRoute(asPath, locale).split('#')[0]
 
   const directories = useMemo(() => cleanupAndReorder(pageMap, locale, defaultLocale), [pageMap, locale, defaultLocale])
   const flatDirectories = useMemo(() => flatten(directories), [directories])

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -44,8 +44,8 @@ const getFSRoute = (asPath, locale) => {
 
 function Folder({ item, anchors }) {
   const { asPath, locale } = useRouter()
-  const routeOriginal = getFSRoute(asPath, locale) + '/'
-	const route = routeOriginal.split('#')[0] + '/';
+  const routeOriginal = getFSRoute(asPath, locale)
+	const route = routeOriginal.split('#')[0] + '/'
   const active = route === item.route + '/'
   const { defaultMenuCollapsed } = useContext(MenuContext)
   const open = TreeState[item.route] ?? !defaultMenuCollapsed

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -44,7 +44,8 @@ const getFSRoute = (asPath, locale) => {
 
 function Folder({ item, anchors }) {
   const { asPath, locale } = useRouter()
-  const route = getFSRoute(asPath, locale) + '/'
+  const routeOriginal = getFSRoute(asPath, locale) + '/'
+	const route = routeOriginal.split('#')[0] + '/';
   const active = route === item.route + '/'
   const { defaultMenuCollapsed } = useContext(MenuContext)
   const open = TreeState[item.route] ?? !defaultMenuCollapsed


### PR DESCRIPTION
Bug is seen when fresh-loading a page from a URL that contains header tags:
```
http://localhost:3000/foo#bar
```
(as opposed to without header tags: `http://localhost:3000/foo`)

1. Next/Prev Links at the footer will become just one Next Link, which will point to the first file in meta.json
2. Sidebar tree will not expand for the current page

This PR fixes that