### PR TITLE
Added support for mdx transclusion

### DIFF
--- a/examples/docs/pages/meta.en.json
+++ b/examples/docs/pages/meta.en.json
@@ -1,4 +1,5 @@
 {
   "index": "Akira",
-  "nextra": "Nextra"
+  "nextra": "Nextra",
+	"transclusion-example": "Transclusion Example"
 }

--- a/examples/docs/pages/transclusion-example.en.mdx
+++ b/examples/docs/pages/transclusion-example.en.mdx
@@ -1,0 +1,25 @@
+import TranscludeTest from './nextra/test.en.mdx' 
+
+# Akira
+
+Akira (Japanese: アキラ) is a 1988 Japanese animated `post-apocalyptic cyberpunk` action film
+directed by Katsuhiro Otomo, produced by Ryōhei Suzuki and Shunzō Katō, and written by Otomo
+and Izo Hashimoto, based on Otomo's 1982 manga of the same name. The film had a production
+budget of ¥700 million ($5.5 million), making it the most expensive anime film at the time
+(until it was surpassed a year later by Kiki's Delivery Service).
+
+```js
+// test js
+console.log('hello, world')
+```
+
+```scala
+// test scala (custom prism language)
+object Hello {
+    def main(args: Array[String]) = {
+        println("hello, world")
+    }
+}
+```
+
+<TranscludeTest />

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -377,11 +377,9 @@ var isMain = true;
 export default (opts, config) => props => {
 	var LayoutOutput;
 	if (isMain) {
-		console.log("this is the main one");
 		isMain = false;
 		LayoutOutput = LayoutMain;
 	} else {
-		console.log("this is the transcluded one");
 		LayoutOutput = LayoutTranscluded;
 	}
   return (

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -324,24 +324,14 @@ const LayoutMain = ({ filename, config: _config, pageMap, meta, children }) => {
   )
 }
 
-const LayoutTranscluded = ({ filename, config: _config, pageMap, meta, children }) => {
+
+// const LayoutMain = ({ filename, config: _config, pageMap, meta, children }) => {
+const LayoutTranscluded = ({ children }) => {
+
   const [menu, setMenu] = useState(false)
-  const router = useRouter()
-  const { route, asPath, locale, defaultLocale } = router
-  const fsPath = getFSRoute(asPath, locale).split('#')[0]
-
-  const directories = useMemo(() => cleanupAndReorder(pageMap, locale, defaultLocale), [pageMap, locale, defaultLocale])
-  const flatDirectories = useMemo(() => flatten(directories), [directories])
-  const config = Object.assign({}, defaultConfig, _config)
-
-  const filepath = route.slice(0, route.lastIndexOf('/') + 1)
-  const filepathWithName = filepath + filename
   const titles = React.Children.toArray(children).filter(child =>
     titleType.includes(child.props.mdxType)
   )
-  const titleEl = titles.find(child => child.props.mdxType === 'h1')
-  const title =
-    meta.title || (titleEl ? innerText(titleEl.props.children) : 'Untitled')
   const anchors = titles
     .filter(child => child.props.mdxType === 'h2')
     .map(child => child.props.children)
@@ -357,17 +347,6 @@ const LayoutTranscluded = ({ filename, config: _config, pageMap, meta, children 
       document.body.classList.remove('overflow-hidden')
     }
   }, [menu])
-
-  const currentIndex = useMemo(
-    () => flatDirectories.findIndex(dir => dir.route === fsPath),
-    [flatDirectories, fsPath]
-  )
-  
-  const isRTL = useMemo(() => {
-    if (!config.i18n) return config.direction === 'rtl' || null
-    const localeConfig = config.i18n.find(l => l.locale === locale)
-    return localeConfig && localeConfig.direction === 'rtl'
-  }, [config.i18n, locale])
 
   return <Theme>{children}</Theme>
 }


### PR DESCRIPTION
MDX itself features transclusion, seen in their [Getting Started](https://mdxjs.com/getting-started) page:

--------
#### Documents

You can embed MDX documents in other documents. This is also known as [transclusion](https://en.wikipedia.org/wiki/Transclusion). You can achieve this by importing an .mdx (or .md) file:
```
import License from './license.md'
import Contributing from './docs/contributing.mdx'

# Hello, world!

<License />

---

<Contributing />
```
(source: https://mdxjs.com/getting-started)

--------

This PR adds support for transclusion, and also adds sidebar support (all h2 headers in the imported mdx/md file will show up in the sidebar as if they were a h2 header of the main mdx file)