### PR TITLE
Update loader.js

### DIFF
--- a/packages/nextra/src/loader.js
+++ b/packages/nextra/src/loader.js
@@ -32,7 +32,7 @@ async function getPageMap(currentResourcePath) {
           )
 
           if (f.isDirectory()) {
-            if (f.name === "api") return null
+            if (fileRoute === "/api") return null
 
             const children = await getFiles(filePath, fileRoute)
             if (!children.length) return null

--- a/packages/nextra/src/loader.js
+++ b/packages/nextra/src/loader.js
@@ -32,6 +32,8 @@ async function getPageMap(currentResourcePath) {
           )
 
           if (f.isDirectory()) {
+            if (f.name === "api") return null
+
             const children = await getFiles(filePath, fileRoute)
             if (!children.length) return null
 


### PR DESCRIPTION
[As per Nextjs documentation](https://nextjs.org/docs/api-routes/introduction)

> Any file inside the folder pages/api is mapped to /api/* and will be treated as an API endpoint instead of a page. They are server-side only bundles and won't increase your client-side bundle size.

The `/pages/api/` directory shouldn't produce a route/sidemenu item. If API is needed as a title, `meta.json` can produce the mapping.

Really loving this project - thanks @shuding <3