### PR TITLE
Add `unstable_faviconGlyph` option to the docs theme

### DIFF
--- a/examples/docs/theme.config.js
+++ b/examples/docs/theme.config.js
@@ -27,6 +27,7 @@ export default {
   ),
   search: true,
   unstable_stork: true,
+  unstable_faviconGlyph: '👋',
   prevLinks: true,
   nextLinks: true,
   footer: true,

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -261,7 +261,7 @@ const Layout = ({ filename, config: _config, pageMap, meta, children }) => {
 
           {config.customSearch ||
             (config.search ? (
-              config.UNSTABLE_stork ? (
+              config.unstable_stork ? (
                 <StorkSearch />
               ) : (
                 <Search directories={flatDirectories} />

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -238,6 +238,12 @@ const Layout = ({ filename, config: _config, pageMap, meta, children }) => {
           />
         ) : null}
         {renderComponent(config.head, { locale })}
+        {config.unstable_faviconGlyph ? (
+          <link
+            rel="icon"
+            href={`data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text x='50' y='.9em' font-size='90' text-anchor='middle'>${config.unstable_faviconGlyph}</text><style>text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";fill:black}@media(prefers-color-scheme:dark){text{fill:white}}</style></svg>`}
+          />
+        ) : null}
       </Head>
       <div
         className={cn('nextra-container main-container flex flex-col', {
@@ -255,7 +261,7 @@ const Layout = ({ filename, config: _config, pageMap, meta, children }) => {
 
           {config.customSearch ||
             (config.search ? (
-              config.unstable_stork ? (
+              config.UNSTABLE_stork ? (
                 <StorkSearch />
               ) : (
                 <Search directories={flatDirectories} />


### PR DESCRIPTION
When this option is set, the value will be displayed as a `<text>` content of SVG inside the favicon. The color will be adjusted based on the preferred color scheme.

Demo: https://twitter.com/shuding_/status/1411619791127908353