### PR TITLE
Normalize option names

### DIFF
--- a/examples/docs/theme.config.js
+++ b/examples/docs/theme.config.js
@@ -1,5 +1,5 @@
 export default {
-  repository: 'https://github.com/shuding/nextra',
+  github: 'https://github.com/shuding/nextra',
   docsRepositoryBase:
     'https://github.com/shuding/nextra/tree/core/examples/docs/pages',
   titleSuffix: ' – Nextra',

--- a/examples/docs/theme.config.js
+++ b/examples/docs/theme.config.js
@@ -1,7 +1,7 @@
 export default {
   repository: 'https://github.com/shuding/nextra',
-  branch: 'core',
-  path: '/examples/docs',
+  docsRepositoryBase:
+    'https://github.com/shuding/nextra/tree/core/examples/docs/pages',
   titleSuffix: ' – Nextra',
   logo: (
     <>
@@ -31,8 +31,7 @@ export default {
   prevLinks: true,
   nextLinks: true,
   footer: true,
-  footerEditOnGitHubLink: true,
-  footerEditOnGitHubText: ({ locale }) =>
+  footerEditLink: ({ locale }) =>
     locale === 'zh' ? '前往 GitHub 编辑此页' : 'Edit this page on GitHub',
   footerText: <>MIT {new Date().getFullYear()} © Shu Ding.</>,
   i18n: [

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -33,6 +33,7 @@
     "intersection-observer": "^0.12.0",
     "match-sorter": "^4.2.0",
     "next-themes": "^0.0.8",
+    "parse-git-url": "^1.0.1",
     "prism-react-renderer": "^1.1.1",
     "react-innertext": "^1.1.5",
     "title": "^3.4.2"

--- a/packages/nextra-theme-docs/src/footer.js
+++ b/packages/nextra-theme-docs/src/footer.js
@@ -1,17 +1,29 @@
 import React from 'react'
-import ArrowRight from './arrow-right'
+import cn from 'classnames'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import cn from 'classnames'
+import parseGitUrl from 'parse-git-url'
 
+import ArrowRight from './arrow-right'
 import renderComponent from './utils/render-component'
 
 const NextLink = ({ route, title, isRTL }) => {
   return (
     <Link href={route}>
-      <a className={cn('text-lg font-medium p-4 -m-4 no-underline text-gray-600 hover:text-blue-600 flex items-center', { 'ml-2': !isRTL, 'mr-2': isRTL })} title={title}>
+      <a
+        className={cn(
+          'text-lg font-medium p-4 -m-4 no-underline text-gray-600 hover:text-blue-600 flex items-center',
+          { 'ml-2': !isRTL, 'mr-2': isRTL }
+        )}
+        title={title}
+      >
         {title}
-        <ArrowRight className={cn('transform inline flex-shrink-0', { 'rotate-180 mr-1': isRTL, 'ml-1': !isRTL })} />
+        <ArrowRight
+          className={cn('transform inline flex-shrink-0', {
+            'rotate-180 mr-1': isRTL,
+            'ml-1': !isRTL
+          })}
+        />
       </a>
     </Link>
   )
@@ -20,46 +32,53 @@ const NextLink = ({ route, title, isRTL }) => {
 const PrevLink = ({ route, title, isRTL }) => {
   return (
     <Link href={route}>
-      <a className={cn('text-lg font-medium p-4 -m-4 no-underline text-gray-600 hover:text-blue-600 flex items-center', { 'mr-2': !isRTL, 'ml-2': isRTL })} title={title}>
-        <ArrowRight className={cn('transform inline flex-shrink-0', { 'rotate-180 mr-1': !isRTL, 'ml-1': isRTL })} />
+      <a
+        className={cn(
+          'text-lg font-medium p-4 -m-4 no-underline text-gray-600 hover:text-blue-600 flex items-center',
+          { 'mr-2': !isRTL, 'ml-2': isRTL }
+        )}
+        title={title}
+      >
+        <ArrowRight
+          className={cn('transform inline flex-shrink-0', {
+            'rotate-180 mr-1': !isRTL,
+            'ml-1': isRTL
+          })}
+        />
         {title}
       </a>
     </Link>
   )
 }
 
-// Make sure path is a valid url path,
-// adding / in front or in the back if missing
-const fixPath = path => {
-  const pathWithFrontSlash = path.startsWith('/') ? path : `/${path}`
-  const pathWithBackSlash = pathWithFrontSlash.endsWith('/')
-    ? pathWithFrontSlash
-    : `${pathWithFrontSlash}/`
+const createEditUrl = (repository, filepath) => {
+  const repo = parseGitUrl(repository)
+  if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
-  return pathWithBackSlash
+  switch (repo.type) {
+    case 'github':
+      return `https://github.com/${repo.owner}/${repo.name}/blob/${
+        repo.branch || 'main'
+      }/${repo.subdir || 'pages'}${filepath}`
+    case 'gitlab':
+      return `https://gitlab.com/${repo.owner}/${repo.name}/-/blob/${
+        repo.branch || 'master'
+      }/${repo.subdir || 'pages'}${filepath}`
+  }
+
+  return '#'
 }
 
-const createEditUrl = (repository, branch, path, filepathWithName) => {
-  const normalizedPath = fixPath(path)
-  return `${repository}/tree/${branch}${normalizedPath}pages${filepathWithName}`
-}
-
-const EditOnGithubLink = ({
-  repository,
-  branch,
-  path,
-  footerEditOnGitHubText,
-  filepathWithName
-}) => {
-  const href = createEditUrl(repository, branch, path, filepathWithName)
+const EditPageLink = ({ repository, text, filepath }) => {
+  const url = createEditUrl(repository, filepath)
   const { locale } = useRouter()
   return (
-    <a className="text-sm" href={href} target="_blank">
-      {footerEditOnGitHubText
-        ? renderComponent(footerEditOnGitHubText, {
+    <a className="text-sm" href={url} target="_blank">
+      {text
+        ? renderComponent(text, {
             locale
           })
-        : 'Edit this page on GitHub'}
+        : 'Edit this page'}
     </a>
   )
 }
@@ -98,13 +117,11 @@ const Footer = ({
             {renderComponent(config.footerText, { locale })}
           </span>
           <div className="mt-6" />
-          {config.footerEditOnGitHubLink ? (
-            <EditOnGithubLink
-              repository={config.docsRepository || config.repository}
-              branch={config.branch}
-              path={config.path}
-              footerEditOnGitHubText={config.footerEditOnGitHubText}
-              filepathWithName={filepathWithName}
+          {config.footerEditLink ? (
+            <EditPageLink
+              filepath={filepathWithName}
+              repository={config.docsRepositoryBase}
+              text={config.footerEditLink}
             />
           ) : null}
         </div>

--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -276,10 +276,10 @@ const Layout = ({ filename, config: _config, pageMap, meta, children }) => {
             <LocaleSwitch options={config.i18n} isRTL={isRTL} />
           ) : null}
 
-          {config.repository ? (
+          {config.github ? (
             <a
               className="text-current p-2"
-              href={config.repository}
+              href={config.github}
               target="_blank"
             >
               <GitHubIcon height={24} />

--- a/packages/nextra-theme-docs/src/misc/default.config.js
+++ b/packages/nextra-theme-docs/src/misc/default.config.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export default {
-  repository: 'https://github.com/shuding/nextra',
+  github: 'https://github.com/shuding/nextra',
   docsRepositoryBase: 'https://github.com/shuding/nextra',
   titleSuffix: ' – Nextra',
   nextLinks: true,

--- a/packages/nextra-theme-docs/src/misc/default.config.js
+++ b/packages/nextra-theme-docs/src/misc/default.config.js
@@ -2,9 +2,7 @@ import React from 'react'
 
 export default {
   repository: 'https://github.com/shuding/nextra',
-  docsRepository: 'https://github.com/shuding/nextra',
-  branch: 'master',
-  path: '/',
+  docsRepositoryBase: 'https://github.com/shuding/nextra',
   titleSuffix: ' – Nextra',
   nextLinks: true,
   prevLinks: true,
@@ -14,7 +12,7 @@ export default {
   font: true,
   footer: true,
   footerText: `MIT ${new Date().getFullYear()} © Nextra.`,
-  footerEditOnGitHubLink: true,
+  footerEditLink: 'Edit this page',
   logo: (
     <React.Fragment>
       <span className="mr-2 font-extrabold hidden md:inline">Nextra</span>
@@ -36,7 +34,7 @@ export default {
       <meta property="og:description" content="Nextra: the next docs builder" />
       <meta name="apple-mobile-web-app-title" content="Nextra" />
     </React.Fragment>
-  ),
+  )
   // direction: 'ltr',
   // i18n: [{ locale: 'en-US', text: 'English', direction: 'ltr' }],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4964,6 +4964,11 @@ parse-entities@^2.0.0:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+parse-git-url@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-git-url/-/parse-git-url-1.0.1.tgz#92bdaf615a7e24d32bea3bf955ee90a9050aeb57"
+  integrity sha512-Zukjztu09UXpXV/Q+4vgwyVPzUBkUvDjlqHlpG+swv/zYzed/5Igw/33rIEJxFDRc5LxvEqYDVDzhBfnOLWDYw==
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"


### PR DESCRIPTION
This PR updates the following options:
- `repository` → `github`, because it's explicitly a link to GitHub, not GitLab or other repository URLs.
- `docsRepository` → `docsRepositoryBase`, so it can include branch and subpath information.
- `branch`, `path` → removed, they're included in the option above and their namings are also confusing.
- `footerEditOnGitHubLink`, `footerEditOnGitHubText` → `footerEditLink`, it's not necessarily a GitHub link.