### PR TITLE
add titleSuffix config to blog theme

### DIFF
--- a/packages/nextra-theme-blog/src/index.js
+++ b/packages/nextra-theme-blog/src/index.js
@@ -28,7 +28,10 @@ const Layout = ({
   return (
     <React.Fragment>
       <Head>
-        <title>{title}</title>
+        <title>
+          {title}
+          {config.titleSuffix}
+        </title>
         {config.head || null}
       </Head>
       <article className="container prose prose-sm md:prose">
@@ -59,6 +62,7 @@ export default (opts, _config) => {
           CC BY-NC 4.0 2020 © Shu Ding.
         </small>
       ),
+      titleSuffix: null,
       postFooter: null
     },
     _config


### PR DESCRIPTION
This PR brings the "titleSuffix" to the "blog" theme. It's similar to the one in the "docs" theme.

For example, with `titleSuffix: "- Shudin"`, the page https://shud.in/art will have the title "Arts - Shudin" instead of just "Arts". This only applies for the title inside "head" tag.

Implementation notes:
- There is no default value in order to be backward compatible (do you want me to change it to "- Nextra" like in the "docs" theme?)
- There is no "renderComponent" utility in the "blog" project so I just render the titleSuffix naively. Please tell me if this needs change.

Thank you