### PR TITLE
fix(docs): added an anchor link to fix the issue

### DIFF
--- a/pages/get-started.mdx
+++ b/pages/get-started.mdx
@@ -77,6 +77,7 @@ export default function Nextra({ Component, pageProps }) {
 
 import Callout from 'nextra-theme-docs/callout'
 
+<span id="sidebar-and-anchor-links" />
 <Callout>
   Any `.md` or `.mdx` file will turn into a doc page and be displayed in
   sidebar. You can also create a `meta.json` file to customize the page order

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -4,7 +4,7 @@ import Bleed from 'nextra-theme-docs/bleed'
 
 **Nextra** is a [Next.js](https://nextjs.org) based static site generator.
 
-It supports Markdown and React components ([MDX](/mdx)), automatically generated [sidebar and anchor links](/docs/anchors), file-system based routing, built-in syntax highlighting, image optimization, custom layouts, i18n, and all the features you love about Next.js.
+It supports Markdown and React components ([MDX](/mdx)), automatically generated [sidebar and anchor links](/get-started#sidebar-and-anchor-links), file-system based routing, built-in syntax highlighting, image optimization, custom layouts, i18n, and all the features you love about Next.js.
 
 Here's what you will get in 1 minute:
 


### PR DESCRIPTION
Actually the link in the Introduction Page is returning a 404 error.