### PR TITLE
Code example error

### DIFF
--- a/pages/themes/docs/callout.mdx
+++ b/pages/themes/docs/callout.mdx
@@ -51,7 +51,7 @@ import Callout from 'nextra-theme-docs/callout'
 ```mdx
 import Callout from 'nextra-theme-docs/callout'
 
-<Callout type="warning" emoji="️🚫">
+<Callout type="error" emoji="️🚫">
   This is a dangerous feature that can cause everything to explode.
 </Callout>
 ```


### PR DESCRIPTION
The last callout (explaining `error`) has type `warning` instead of `error` .