### PR TITLE
Typo fix in themes/blog/index.mdx

### DIFF
--- a/pages/themes/blog/index.mdx
+++ b/pages/themes/blog/index.mdx
@@ -20,7 +20,7 @@ Similar to the docs theme, you can install the blog theme with the following com
 ```jsx
 // next.config.js
 const withNextra = require('nextra')({
-  theme: 'nextra-theme-docs',
+  theme: 'nextra-theme-blog',
   themeConfig: './theme.config.js',
   // optional: add `unstable_staticImage: true` to enable Nextra's auto image import
 })


### PR DESCRIPTION
Correction to `theme` value of the `nextConfig` object. It was set to `nextra-theme-docs`.