### PR TITLE
Bugfix(docs): Change docs to blog theme

### DIFF
--- a/pages/themes/blog/index.mdx
+++ b/pages/themes/blog/index.mdx
@@ -20,7 +20,7 @@ Similar to the docs theme, you can install the blog theme with the following com
 ```jsx
 // next.config.js
 const withNextra = require('nextra')({
-  theme: 'nextra-theme-docs',
+  theme: 'nextra-theme-blog',
   themeConfig: './theme.config.js',
   // optional: add `unstable_staticImage: true` to enable Nextra's auto image import
 })


### PR DESCRIPTION
# Blog Theme
The blog install should use the blog theme, not the docs theme. Not sure if there are other issues that could be fixed related to this, but I found a small gotcha in the docs.