### PR TITLE
Fixing routes so they work in Windows

### DIFF
--- a/packages/nextra/src/loader.js
+++ b/packages/nextra/src/loader.js
@@ -31,10 +31,10 @@ async function getPageMap(currentResourcePath) {
       await Promise.all(
         files.map(async f => {
           const filePath = path.resolve(dir, f.name)
-          const fileRoute = path.join(
+          const fileRoute = slash(path.join(
             route,
             removeExtension(f.name).replace(/^index$/, '')
-          )
+          ))
 
           if (f.isDirectory()) {
             if (fileRoute === "/api") return null


### PR DESCRIPTION
Addresses https://github.com/shuding/nextra/issues/214

build nextra site on Windows

Before: 
Click on nav links; no `active` class name added (because routes don't match)

After:
Active nav link has the `active` class