### PR TITLE
Add option to change the Git icon in the top right corner

### DIFF
--- a/packages/nextra-theme-docs/src/misc/default.config.js
+++ b/packages/nextra-theme-docs/src/misc/default.config.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 export default {
-  gitLink: 'https://github.com/shuding/nextra',
   docsRepositoryBase: 'https://github.com/shuding/nextra',
   titleSuffix: ' – Nextra',
   nextLinks: true,

--- a/packages/nextra-theme-docs/src/misc/default.config.js
+++ b/packages/nextra-theme-docs/src/misc/default.config.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export default {
-  github: 'https://github.com/shuding/nextra',
+  gitLink: 'https://github.com/shuding/nextra',
   docsRepositoryBase: 'https://github.com/shuding/nextra',
   titleSuffix: ' – Nextra',
   nextLinks: true,

--- a/packages/nextra-theme-docs/src/navbar.js
+++ b/packages/nextra-theme-docs/src/navbar.js
@@ -81,14 +81,14 @@ export default function Navbar({
         <LocaleSwitch options={config.i18n} isRTL={isRTL} />
       ) : null}
 
-      {(config.github || config.gitLink) !== null ? (
+      {config.projectLink || config.github ? (
         <a
           className="text-current p-2"
-          href={config.github || config.gitLink}
+          href={config.projectLink || config.github}
           target="_blank"
         >
-          {config.gitIcon ? (
-            renderComponent(config.gitIcon, { locale })
+          {config.projectLinkIcon ? (
+            renderComponent(config.projectLinkIcon, { locale })
           ) : (
             <GitHubIcon height={24} />
           )}

--- a/packages/nextra-theme-docs/src/navbar.js
+++ b/packages/nextra-theme-docs/src/navbar.js
@@ -13,7 +13,12 @@ import GitHubIcon from './github-icon'
 import ThemeSwitch from './theme-switch'
 import LocaleSwitch from './locale-switch'
 
-export default function Navbar({ config, isRTL, flatDirectories, flatPageDirectories }) {
+export default function Navbar({
+  config,
+  isRTL,
+  flatDirectories,
+  flatPageDirectories
+}) {
   const { locale, asPath } = useRouter()
   const activeRoute = getFSRoute(asPath, locale).split('#')[0]
   const { menu, setMenu } = useMenuContext()
@@ -76,9 +81,17 @@ export default function Navbar({ config, isRTL, flatDirectories, flatPageDirecto
         <LocaleSwitch options={config.i18n} isRTL={isRTL} />
       ) : null}
 
-      {config.github ? (
-        <a className="text-current p-2" href={config.github} target="_blank">
-          <GitHubIcon height={24} />
+      {(config.github || config.gitLink) !== null ? (
+        <a
+          className="text-current p-2"
+          href={config.github || config.gitLink}
+          target="_blank"
+        >
+          {config.gitIcon ? (
+            renderComponent(config.gitIcon, { locale })
+          ) : (
+            <GitHubIcon height={24} />
+          )}
         </a>
       ) : null}
 


### PR DESCRIPTION
This adds the new config option `gitIcon` to change the icon in the top right corner and replaces the `github` option with `gitLink` (for uniform naming, but the old option will still work).

Closes #175 

Example config:
```ts
import Gitlab from "@geist-ui/react-icons/gitlab";

const themeConfig = {
  gitLink: "https://gitlab.com/librewolf-community/browser",
  gitIcon: <Gitlab />,
// ...
 ```

Result:
![Screenshot_20210923_182318](https://user-images.githubusercontent.com/48161361/134546083-e1c3d7b9-20ec-40ad-85a8-64dfe5394049.png)

