### PR TITLE
Fix two typos in Configuration Docs

### DIFF
--- a/pages/themes/docs/configuration.mdx
+++ b/pages/themes/docs/configuration.mdx
@@ -24,7 +24,7 @@ The URL that the button in the top right will point to.
 
 Changes the icon that is shown in the top right.
 
-**Type:** `string`\
+**Type:** `ReactNode`\
 **Default:** GitHub icon
 
 **Example:**
@@ -69,7 +69,7 @@ Specifies if a search box should be shown in the top right.
 
 ## `customSearch`
 
-A custom component do display instead of the search bar in the top right, for example Algolia.
+A custom component to display instead of the search bar in the top right, for example Algolia.
 
 **Type:** `ReactNode`
 


### PR DESCRIPTION
Fixes two typos in Configuration Docs. I am sorry for the inconvenience, I didn't notice them in the original PR.