### PR TITLE
Fix sidebar for `trailingSlash: true`

### DIFF
--- a/packages/nextra-theme-docs/src/sidebar.js
+++ b/packages/nextra-theme-docs/src/sidebar.js
@@ -17,8 +17,8 @@ const TreeState = new Map()
 function Folder({ item, anchors }) {
   const { asPath, locale } = useRouter()
   const routeOriginal = getFSRoute(asPath, locale)
-  const route = routeOriginal.split('#')[0] + '/'
-  const active = route === item.route + '/'
+  const route = routeOriginal.split('#')[0]
+  const active = route === item.route + '/' || route + '/' === item.route + '/'
   const { defaultMenuCollapsed } = useMenuContext()
   const open = TreeState[item.route] ?? !defaultMenuCollapsed
   const [_, render] = useState(false)
@@ -54,8 +54,8 @@ function Folder({ item, anchors }) {
 function File({ item, anchors }) {
   const { setMenu } = useMenuContext()
   const { asPath, locale } = useRouter()
-  const route = getFSRoute(asPath, locale) + '/'
-  const active = route === item.route + '/'
+  const route = getFSRoute(asPath, locale)
+  const active = route === item.route + '/' || route + '/' === item.route + '/'
   const slugger = new Slugger()
   const activeAnchor = useActiveAnchor()
 


### PR DESCRIPTION
This will fix the sidebar for the case that `trailingSlash` is enabled in `next.config.js` (That option adds an `/` to the end of the routes and thus makes `next export` more useful).

Before:
![Screenshot_20211105_202845](https://user-images.githubusercontent.com/48161361/140567718-4efbcafc-247a-4d92-80b6-4d20377a07a6.png)

After:
![Screenshot_20211105_202751](https://user-images.githubusercontent.com/48161361/140567733-1f654625-42e4-488a-a936-e2399b1095dc.png)

Of course everything still works as expected when `trailingSlash` is off.