### PR TITLE
Stripe-like search input

### DIFF
--- a/packages/nextra-theme-docs/src/search.js
+++ b/packages/nextra-theme-docs/src/search.js
@@ -100,24 +100,36 @@ const Search = ({ directories = [] }) => {
   const renderList = show && results.length > 0
 
   return (
-    <div className="nextra-search relative w-full md:w-64">
+    <div className="relative w-full nextra-search md:w-64">
       {renderList && (
-        <div className="search-overlay z-10" onClick={() => setShow(false)} />
+        <div className="z-10 search-overlay" onClick={() => setShow(false)} />
       )}
-      <input
-        onChange={e => {
-          setSearch(e.target.value)
-          setShow(true)
-        }}
-        className="appearance-none border rounded py-2 px-3 leading-tight focus:outline-none focus:ring w-full"
-        type="search"
-        placeholder='Search ("/" to focus)'
-        onKeyDown={handleKeyDown}
-        onFocus={() => setShow(true)}
-        ref={input}
-      />
+
+      <div className="relative flex items-center">
+        <input
+          onChange={e => {
+            setSearch(e.target.value)
+            setShow(true)
+          }}
+          className="block w-full px-3 py-2 leading-tight border rounded appearance-none focus:outline-none focus:ring"
+          type="search"
+          placeholder="Search documentation..."
+          onKeyDown={handleKeyDown}
+          onFocus={() => setShow(true)}
+          onBlur={() => setShow(false)}
+          ref={input}
+          spellCheck={false}
+        />
+        {show ? null : (
+          <div className="hidden sm:flex absolute inset-y-0 right-0 py-1.5 pr-1.5">
+            <kbd className="inline-flex items-center px-2 font-sans text-sm font-medium text-gray-400 border border-gray-200 rounded bg-gray-50">
+              /
+            </kbd>
+          </div>
+        )}
+      </div>
       {renderList && (
-        <ul className="shadow-md list-none p-0 m-0 absolute left-0 md:right-0 rounded mt-1 border top-100 divide-y z-20 w-full md:w-auto">
+        <ul className="absolute left-0 z-20 w-full p-0 m-0 mt-1 list-none border divide-y rounded shadow-md md:right-0 top-100 md:w-auto">
           {results.map((res, i) => {
             return (
               <Item

--- a/packages/nextra-theme-docs/src/stork-search.js
+++ b/packages/nextra-theme-docs/src/stork-search.js
@@ -175,16 +175,16 @@ export default function Search() {
   const renderList = show && results.length > 0
 
   return (
-    <div className="nextra-search nextra-stork relative w-full md:w-64">
+    <div className="relative w-full nextra-search nextra-stork md:w-64">
       {renderList && (
-        <div className="search-overlay z-10" onClick={() => setShow(false)} />
+        <div className="z-10 search-overlay" onClick={() => setShow(false)} />
       )}
       <input
         onChange={e => {
           setSearch(e.target.value)
           setShow(true)
         }}
-        className="appearance-none border rounded py-2 px-3 leading-tight focus:outline-none focus:ring w-full"
+        className="w-full px-3 py-2 leading-tight border rounded appearance-none focus:outline-none focus:ring"
         type="search"
         placeholder='Search ("/" to focus)'
         onKeyDown={handleKeyDown}
@@ -195,8 +195,35 @@ export default function Search() {
         ref={input}
         spellCheck={false}
       />
+
+      <div className="relative flex items-center">
+        <input
+          onChange={e => {
+            setSearch(e.target.value)
+            setShow(true)
+          }}
+          className="block w-full px-3 py-2 leading-tight border rounded appearance-none focus:outline-none focus:ring"
+          type="search"
+          placeholder="Search documentation..."
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            load()
+            setShow(true)
+          }}
+          onBlur={() => setShow(false)}
+          ref={input}
+          spellCheck={false}
+        />
+        {show ? null : (
+          <div className="hidden sm:flex absolute inset-y-0 right-0 py-1.5 pr-1.5">
+            <kbd className="inline-flex items-center px-2 font-sans text-sm font-medium text-gray-400 border border-gray-200 rounded bg-gray-50">
+              /
+            </kbd>
+          </div>
+        )}
+      </div>
       {renderList && (
-        <ul className="p-0 m-0 mt-1 top-full absolute divide-y z-20">
+        <ul className="absolute z-20 p-0 m-0 mt-1 divide-y top-full">
           {results.map((res, i) => {
             return (
               <Item


### PR DESCRIPTION
Polishing the search input a bit. 
        
![Kapture 2021-11-12 at 08 41 45](https://user-images.githubusercontent.com/4060187/141476440-d6ce9a81-30d4-4dc6-a29e-f4e97d6cfb2a.gif)

I wonder if we should switch this to <kbd> ⌘</kbd> + <kbd>K</kbd> to mimic algolia doc search. The reason I prefer this over <kbd>/</kbd> is because it doesn't interfere with interactive react/html/mdx playgrounds.

<img width="306" alt="CleanShot 2021-11-12 at 08 43 49@2x" src="https://user-images.githubusercontent.com/4060187/141476674-3c881ec1-f936-471d-83de-8467c9edbabf.png">
