### PR TITLE
add exports

### DIFF
--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -11,6 +11,12 @@
     "index.js",
     "style.css"
   ],
+  "exports": {
+    "./style.css": "./style.css",
+    ".": {
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "yarn run build:tailwind && yarn run build:layout",
     "build:layout": "node scripts/build.js",


### PR DESCRIPTION
Got error after upgrade
```
Server Error
SyntaxError: Unexpected token 'export'

This error happened while generating the page. Any console logs will be displayed in the terminal window.
Call Stack
<unknown>
/Users/promer94/workspace/blog/node_modules/.pnpm/nextra-theme-blog (2.0.0-beta.2_f195614718841b3c14a81ac95268ce58/node_modules/nextra-theme-blog/index.js (1)
Object.compileFunction
node:vm (352:18)
wrapSafe
node:internal/modules/cjs/loader (1031:15)
Module._compile
node:internal/modules/cjs/loader (1065:27)
Object.Module._extensions..js
node:internal/modules/cjs/loader (1153:10)
Module.load
node:internal/modules/cjs/loader (981:32)
Function.Module._load
node:internal/modules/cjs/loader (822:12)
Module.require
node:internal/modules/cjs/loader (1005:19)
```