### PR TITLE
Fix broken "nav" pages

### DIFF
--- a/packages/nextra-theme-docs/src/index.js
+++ b/packages/nextra-theme-docs/src/index.js
@@ -121,7 +121,7 @@ const Layout = ({ filename, pageMap, meta, children }) => {
                   filepathWithName={filepathWithName}
                   navLinks={null}
                 >
-                  {content}
+                  {children}
                 </Body>
               </div>
             </ActiveAnchor>


### PR DESCRIPTION
This fixes some issues on pages with the type `nav` in the `meta.json`. Currently, the next links, syntax highlighting and probably other things aren't working on those pages because of what I assume is a typo.