### PR TITLE
fix(Search): check for active results on `Enter` key

### DIFF
--- a/packages/nextra-theme-docs/src/search.js
+++ b/packages/nextra-theme-docs/src/search.js
@@ -65,7 +65,7 @@ const Search = ({ directories = [] }) => {
         moveActiveItem(UP)
       }
 
-      if (key === 'Enter') {
+      if (key === 'Enter' && results && results[active]) {
         router.push(results[active].route)
       }
     },


### PR DESCRIPTION
This fixes a minor bug when there are no active results, this PR checks if there are results and if there is an `results[active]`