### PR TITLE
Safer turbo caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
           "^build"
         ],
         "outputs": [
-          "dist/**",
+          "dist/**/*.js",
+          "dist/**/*.css",
           ".next/**",
           "style.css",
           "index.js",
@@ -52,7 +53,7 @@
           "^types"
         ],
         "outputs": [
-          "dist/**"
+          "dist/**/*.d.ts"
         ]
       },
       "dev": {


### PR DESCRIPTION
having both `types` and `dist` caching with ** is probably not right, so restricting to respective extensions