### PR TITLE
use remark-gfm v3.0.1

### DIFF
--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -24,7 +24,7 @@
     "download": "^8.0.0",
     "graceful-fs": "^4.2.6",
     "gray-matter": "^4.0.3",
-    "remark-gfm": "^1.0.0",
+    "remark-gfm": "^3.0.1",
     "remark-mdx-code-meta": "^1.0.0",
     "slash": "^3.0.0",
     "typescript": "^4.5.2"


### PR DESCRIPTION
Hello.
I found footnotes not working in the [nextra blog sample](https://demo.vercel.blog/posts/markdown). So I want to add a footnote.
After changing the [remark-gfm version to 3](https://github.com/remarkjs/remark-gfm/releases/tag/3.0.0), the footnote function works.

![image](https://user-images.githubusercontent.com/830864/147416188-cbd84bf0-fb25-4dc3-949c-2ae1cbfed55b.png)
