### PR TITLE
Updated to auto prefix entire output

### DIFF
--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -63,6 +63,7 @@
     "esbuild": "^0.14.0",
     "postcss": "^8.2.1",
     "postcss-cli": "^8.3.1",
+    "postcss-scopify": "0.1.9",
     "tailwindcss": "^2.2.4",
     "nextra": "workspace:*"
   }

--- a/packages/nextra-theme-docs/postcss.config.js
+++ b/packages/nextra-theme-docs/postcss.config.js
@@ -2,6 +2,7 @@ module.exports = ctx => ({
   plugins: [
     require('tailwindcss'),
     require('autoprefixer'),
-    ctx.env === 'production' ? require('cssnano') : false
+    ctx.env === 'production' ? require('cssnano') : false,
+    require('postcss-scopify')('.nextra-container')
   ]
 })


### PR DESCRIPTION
Auto prefixed the entire output to be based on the top level class inside of the theme. This prevents styles from creeping over into global styles.

Fixes #247 