### PR TITLE
Fix Sidebar Issues

### DIFF
--- a/packages/nextra-theme-docs/src/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/sidebar.tsx
@@ -22,8 +22,7 @@ interface FolderProps {
 
 function Folder({ item, anchors }: FolderProps) {
   const { asPath, locale } = useRouter()
-  const routeOriginal = getFSRoute(asPath, locale)
-  const route = routeOriginal.split('#')[0]
+  const route = getFSRoute(asPath, locale).split('#')[0]
   const active = route === item.route + '/' || route + '/' === item.route + '/'
   const { defaultMenuCollapsed } = useMenuContext()
   const open = TreeState[item.route] ?? !defaultMenuCollapsed
@@ -69,7 +68,7 @@ interface FileProps {
 function File({ item, anchors }: FileProps) {
   const { setMenu } = useMenuContext()
   const { asPath, locale } = useRouter()
-  const route = getFSRoute(asPath, locale)
+  const route = getFSRoute(asPath, locale).split('#')[0]
   const active = route === item.route + '/' || route + '/' === item.route + '/'
   const slugger = new Slugger()
   const activeAnchor = useActiveAnchor()

--- a/packages/nextra-theme-docs/src/utils/normalize-pages.tsx
+++ b/packages/nextra-theme-docs/src/utils/normalize-pages.tsx
@@ -88,7 +88,7 @@ export default function normalizePages({
   const flatPageDirectories: PageItem[] = []
 
   let activeType: string | undefined = undefined
-  let activeIndex: number  = 0
+  let activeIndex: number = 0
 
   list
     .filter(
@@ -118,7 +118,7 @@ export default function normalizePages({
       // If the doc is under the active page root.
       const isCurrentDocsTree = type === 'docs' && route.startsWith(docsRoot)
 
-      if (a.route === route) {
+      if (a.route === route || a.route + '/' === route) {
         activeType = type
         switch (type) {
           case 'nav':


### PR DESCRIPTION
* Fix: Currently the sidebar isn't hidden on `nav` pages when the next.js option `trailingSlash: true` is enabled. 
* Fix: Clicking on a `a` to an anchor on the same page will lead to the current page being un-highlighted in the sidebar.

Kind of extends #236 