### PR TITLE
Add types script to prepublishOnly

### DIFF
--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -17,7 +17,7 @@
     "build": "node scripts/build.js",
     "dev": "node scripts/dev.js",
     "types": "tsc --project tsconfig.type.json",
-    "prepublishOnly": "rm -rf dist && yarn build"
+    "prepublishOnly": "rm -rf dist && yarn build && yarn types"
   },
   "dependencies": {
     "@mdx-js/mdx": "^2.0.0-rc.2",


### PR DESCRIPTION
Alpha versions dist folder doesn't have an type file - https://unpkg.com/browse/nextra@2.0.0-alpha.16/dist/