### PR TITLE
[nextra-theme-blog] Allow forcing a theme

### DIFF
--- a/packages/nextra-theme-blog/src/index.tsx
+++ b/packages/nextra-theme-blog/src/index.tsx
@@ -242,8 +242,8 @@ const NextraBlog = (opts: PageOpt, _config: NextraBlogTheme) => {
     return (
       <ThemeProvider
         attribute="class"
-        defaultTheme="system"
-        enableSystem={true}
+        defaultTheme={config.forceTheme ? config.forceTheme : "system"}
+        enableSystem={config.forceTheme ? false : true}
       >
         <Layout
           config={config}

--- a/packages/nextra-theme-blog/src/types.ts
+++ b/packages/nextra-theme-blog/src/types.ts
@@ -16,6 +16,7 @@ export interface NextraBlogTheme {
     lang: string
   }
   darkMode?: boolean
+  forceTheme?: string
   navs?: {
     url: string
     name: string


### PR DESCRIPTION
I wasn't able to override the system theme with some script and figured this would be a good way to force it if you want light or dark. Currently, it defaults to system preference even with `darkMode` set to `false` or not configured. 