### PR TITLE
fix sort-date

### DIFF
--- a/packages/nextra-theme-blog/src/utils/sort-date.ts
+++ b/packages/nextra-theme-blog/src/utils/sort-date.ts
@@ -4,5 +4,5 @@ export default (a: PageMapItem, b: PageMapItem) => {
   if (!a.frontMatter || !a.frontMatter.date) return -1
   if (!b.frontMatter || !b.frontMatter.date) return -1
   
-  return new Date(a.frontMatter.date) - new Date(b.frontMatter.date);
+  return new Date(b.frontMatter.date) - new Date(a.frontMatter.date);
 }

--- a/packages/nextra-theme-blog/src/utils/sort-date.ts
+++ b/packages/nextra-theme-blog/src/utils/sort-date.ts
@@ -3,5 +3,6 @@ import { PageMapItem } from 'nextra'
 export default (a: PageMapItem, b: PageMapItem) => {
   if (!a.frontMatter || !a.frontMatter.date) return -1
   if (!b.frontMatter || !b.frontMatter.date) return -1
-  return new Date(a.frontMatter.date) > new Date(b.frontMatter.date) ? -1 : 1
+  
+  return new Date(a.frontMatter.date) - new Date(b.frontMatter.date);
 }


### PR DESCRIPTION
The comparison function needs to return 0 when elements are equal. Otherwise, when dates are equal (as in a previous version of the blog example), the ordering of the navbar becomes non-deterministic between engines.