### PR TITLE
fix(search): add fallback bg-color for search result

### DIFF
--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -216,7 +216,8 @@ article {
     width: 100vw;
   }
   ul {
-    @apply rounded-xl backdrop-blur-lg bg-white text-gray-100 ring-1 ring-black ring-opacity-5 overflow-hidden overscroll-contain shadow-xl list-none;
+    /* Using bg-white as background-color when the browser didn't support backdrop-filter */
+    @apply rounded-xl bg-white text-gray-100 ring-1 ring-black ring-opacity-5 overflow-hidden overscroll-contain shadow-xl list-none;
     li {
       @apply text-gray-800 break-words mx-2.5 px-2.5 py-2 rounded-md;
       .highlight {
@@ -228,9 +229,15 @@ article {
       @apply text-prime-500 bg-prime-400 bg-opacity-[.1];
     }
   }
-  .dark & {
+  @supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
     ul {
-      @apply bg-neutral-800 backdrop-blur-xl bg-opacity-60 text-gray-100 ring-white ring-opacity-10 divide-gray-200/10;
+      @apply rounded-xl backdrop-blur-lg bg-white bg-opacity-[.7] text-gray-100 ring-1 ring-black ring-opacity-5 overflow-hidden overscroll-contain shadow-xl list-none;
+    }
+  }
+  .dark & {
+    /* Using bg-white as background-color when the browser didn't support backdrop-filter */
+    ul {
+      @apply bg-neutral-800 text-gray-100 ring-white ring-opacity-10 divide-gray-200/10;
       li {
         @apply text-gray-300;
         .highlight {
@@ -240,6 +247,13 @@ article {
       li.active,
       a:focus li {
         @apply text-prime-500 bg-prime-500 bg-opacity-[.1];
+      }
+    }
+  }
+  @supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+    .dark & {
+      ul {
+        @apply bg-neutral-800 backdrop-blur-xl bg-opacity-60 text-gray-100 ring-white ring-opacity-10 divide-gray-200/10;
       }
     }
   }

--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -216,7 +216,7 @@ article {
     width: 100vw;
   }
   ul {
-    @apply rounded-xl backdrop-blur-lg bg-white bg-opacity-[.7] text-gray-100 ring-1 ring-black ring-opacity-5 overflow-hidden overscroll-contain shadow-xl list-none;
+    @apply rounded-xl backdrop-blur-lg bg-white text-gray-100 ring-1 ring-black ring-opacity-5 overflow-hidden overscroll-contain shadow-xl list-none;
     li {
       @apply text-gray-800 break-words mx-2.5 px-2.5 py-2 rounded-md;
       .highlight {


### PR DESCRIPTION
## Screenshots

### Firefox

| Light | Dark |
| ------ | ----- |
|![Screenshot 2022-02-17 at 14-10-30 React Hooks for Data Fetching – SWR](https://user-images.githubusercontent.com/10325111/154417678-9d1f792b-3db7-482d-9c4a-38fa36541765.png)|![Screenshot 2022-02-17 at 14-10-15 React Hooks for Data Fetching – SWR](https://user-images.githubusercontent.com/10325111/154417673-1463220b-e213-40a9-983d-3fad7d575e5f.png)|

### Safari

| Light | Dark |
| ------ | ----- |
|<img width="1552" alt="截圖 2022-02-17 下午2 09 29" src="https://user-images.githubusercontent.com/10325111/154417825-f3089163-df39-48b1-a275-0cac153ca8d3.png">|<img width="1552" alt="截圖 2022-02-17 下午2 09 40" src="https://user-images.githubusercontent.com/10325111/154417832-7df68aa8-8d2c-4ee2-b15b-37374a382fb4.png">|

## Description

Hi @shuding, thank you for creating an amazing static site generator.

I found a little style issue on the search result and try to fix it, not sure change is good or not, feel free to give me any suggestions, thank you.

Signed-off-by: Jie Peng <im@jiepeng.me>