### PR TITLE
Fix dependency resolving

### DIFF
--- a/packages/nextra/src/content-dump.ts
+++ b/packages/nextra/src/content-dump.ts
@@ -19,7 +19,9 @@ let cacheDirExist = false
 try {
   statSync(cacheDir)
   cacheDirExist = true
-} catch (err) {}
+} catch (err) {
+  mkdirSync(cacheDir, { recursive: true })
+}
 
 function initFromCache(filename: string) {
   if (!cached.has(filename)) {


### PR DESCRIPTION
Since Webpack doesn't have glob dependency support for loaders, we're now doing the following:

```js
  if (!isProductionBuild) {
    // Add the entire directory `pages` as the dependency
    // so we can generate the correct page map.
    this.addContextDependency(pagesDir)
  } else {
    // We only add meta files as dependencies for prodution build,
    // so we can do incremental builds.
    Object.entries(fileMap).forEach(([filePath, { name, meta, locale }]) => {
      if (
        name === 'meta.json' &&
        meta &&
        (!fileLocale || locale === fileLocale)
      ) {
        this.addDependency(filePath)
      }
    })
  }
```