### PR TITLE
breaking: Rename unstable_contentDump to unstable_flexsearch

### DIFF
--- a/examples/docs/src/theme.config.js
+++ b/examples/docs/src/theme.config.js
@@ -27,7 +27,6 @@ export default {
     </>
   ),
   search: true,
-  unstable_stork: false,
   unstable_faviconGlyph: '✦',
   prevLinks: true,
   nextLinks: true,

--- a/examples/swr-site/next.config.js
+++ b/examples/swr-site/next.config.js
@@ -1,8 +1,7 @@
 const withNextra = require("nextra")({
   theme: "nextra-theme-docs",
   themeConfig: "./theme.config.js",
-  unstable_stork: false,
-  unstable_contentDump: true,
+  unstable_flexsearch: true,
   unstable_staticImage: true,
 });
 

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -47,10 +47,10 @@ export async function compileMdx(
   mdxOptions: LoaderOptions['mdxOptions'] = {},
   nextraOptions: {
     unstable_staticImage: boolean
-    unstable_contentDump: boolean
+    unstable_flexsearch: boolean
   } = {
     unstable_staticImage: false,
-    unstable_contentDump: false
+    unstable_flexsearch: false
   }
 ) {
   let structurizedData = {}
@@ -62,7 +62,7 @@ export async function compileMdx(
       remarkGfm,
       remarkHeadings,
       ...(nextraOptions.unstable_staticImage ? [remarkStaticImage] : []),
-      ...(nextraOptions.unstable_contentDump
+      ...(nextraOptions.unstable_flexsearch
         ? [structurize(structurizedData)]
         : [])
     ].filter(Boolean),

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -29,7 +29,7 @@ export default async function (
     theme,
     themeConfig,
     defaultLocale,
-    unstable_contentDump,
+    unstable_flexsearch,
     unstable_staticImage,
     mdxOptions,
     pageMapCache
@@ -94,18 +94,18 @@ export default async function (
   }
 
   if (isProductionBuild && indexContentEmitted.has(filename)) {
-    unstable_contentDump = false
+    unstable_flexsearch = false
   }
 
   const { result, titleText, headings, hasH1, structurizedData } =
     await compileMdx(content, mdxOptions, {
       unstable_staticImage,
-      unstable_contentDump
+      unstable_flexsearch
     })
   content = result
   content = content.replace('export default MDXContent;', '')
 
-  if (unstable_contentDump) {
+  if (unstable_flexsearch) {
     // We only add .MD and .MDX contents
     if (extension.test(filename) && data.searchable !== false) {
       await addPage({

--- a/packages/nextra/src/plugin.ts
+++ b/packages/nextra/src/plugin.ts
@@ -107,7 +107,7 @@ class NextraPlugin {
     compiler.hooks.beforeCompile.tapAsync(
       'NextraPlugin',
       async (_, callback) => {
-        if (this.config && this.config.unstable_contentDump) {
+        if (this.config && this.config.unstable_flexsearch) {
           // Restore the search data from the cache.
           restoreCache()
         }

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -7,7 +7,7 @@ export interface LoaderOptions {
   locales: string[]
   defaultLocale: string
   unstable_staticImage: boolean
-  unstable_contentDump: boolean
+  unstable_flexsearch: boolean
   mdxOptions: Pick<ProcessorOptions, 'rehypePlugins' | 'remarkPlugins'>
   pageMapCache: PageMapCache
 }
@@ -46,7 +46,7 @@ type Theme = string
 export type NextraConfig = {
   theme: Theme
   themeConfig: string
-  unstable_contentDump: boolean
+  unstable_flexsearch: boolean
   unstable_staticImage?: boolean
 }
 


### PR DESCRIPTION
In preparation for 2.0 stable release, we will rename it to just `flexsearch` soon.