### PR TITLE
Expose the page map starting from the current level

### DIFF
--- a/packages/nextra/context.js
+++ b/packages/nextra/context.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/context')

--- a/packages/nextra/scripts/build.js
+++ b/packages/nextra/scripts/build.js
@@ -3,7 +3,12 @@ const package = require('../package.json')
 
 // Build CJS entrypoints
 esbuild.buildSync({
-  entryPoints: ['src/index.js', 'src/ssg.ts', 'src/locales.ts'],
+  entryPoints: [
+    'src/index.js',
+    'src/ssg.ts',
+    'src/locales.ts',
+    'src/context.ts'
+  ],
   platform: 'node',
   bundle: true,
   format: 'cjs',

--- a/packages/nextra/scripts/dev.js
+++ b/packages/nextra/scripts/dev.js
@@ -5,7 +5,12 @@ console.log('Watching...')
 
 // Build CJS entrypoints
 esbuild.build({
-  entryPoints: ['src/index.js', 'src/ssg.ts', 'src/locales.ts'],
+  entryPoints: [
+    'src/index.js',
+    'src/ssg.ts',
+    'src/locales.ts',
+    'src/context.ts'
+  ],
   platform: 'node',
   bundle: true,
   format: 'cjs',

--- a/packages/nextra/src/context.ts
+++ b/packages/nextra/src/context.ts
@@ -1,0 +1,82 @@
+interface Page {
+  name: string
+  route: string
+  children?: Page[]
+  meta: {
+    type?: string
+    title?: string
+    hidden?: boolean
+  }
+  frontMatter?: any
+}
+
+function getContext(name: string) {
+  if (!(globalThis as any).__nextra_internal__) {
+    throw new Error(
+      `Nextra context not found. Please make sure you are using "${name}" of "nextra/context" on a Nextra page.`
+    )
+  }
+  return (globalThis as any).__nextra_internal__
+}
+
+function normalizeMeta(meta: any) {
+  if (typeof meta === 'string') {
+    meta = {
+      title: meta
+    }
+  }
+  return meta
+}
+
+function filter(pageMap: any, activeLevel?: string) {
+  let activeLevelPages: Page[] | undefined
+  let meta = pageMap.find((item: any) => item.name === 'meta.json')?.meta || {}
+  const metaKeys = Object.keys(meta)
+
+  const items: Page[] = []
+  for (const item of pageMap) {
+    if (item.name === 'meta.json') continue
+    const page: Page = {
+      ...item,
+      meta: normalizeMeta(meta[item.name])
+    }
+    if (item.children) {
+      const filteredChildren = filter(item.children, activeLevel)
+      page.children = filteredChildren[0]
+      if (filteredChildren[1]) {
+        activeLevelPages = filteredChildren[1]
+      }
+    }
+    items.push(page)
+    if (page.route === activeLevel) {
+      activeLevelPages = items
+    }
+  }
+
+  return [
+    items.sort((a, b) => {
+      const indexA = metaKeys.indexOf(a.name)
+      const indexB = metaKeys.indexOf(b.name)
+      if (indexA === -1 && indexB === -1) return a.name < b.name ? -1 : 1
+      if (indexA === -1) return 1
+      if (indexB === -1) return -1
+      return indexA - indexB
+    }),
+    activeLevelPages
+  ]
+}
+
+export function getAllPages() {
+  const internal = getContext('getAllPages')
+  return filter(internal.pageMap)[0]
+}
+
+export function getCurrentLevelPages() {
+  const internal = getContext('getCurrentLevelPages')
+  return filter(internal.pageMap, internal.route)[1] || []
+}
+
+export function getPagesUnderRoute(route: string) {
+  const internal = getContext('getPagesUnderRoute')
+  return filter(internal.pageMap, route)[1] || []
+}

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -124,14 +124,14 @@ export default async function (
     `import withLayout from '${layout}'\n` +
     `import { withSSG } from 'nextra/ssg'\n` +
     `${layoutConfig ? `import layoutConfig from '${layoutConfig}'` : ''}\n` +
-    `const NEXTRA_PAGE_MAP = ${JSON.stringify(pageMap)}\n`
+    `const unstable_pageMap = ${JSON.stringify(pageMap)}\n`
 
   const suffix = `export default function NextraPage (props) {
   return withSSG(withLayout({
     filename: "${slash(filename)}",
     route: "${slash(route)}",
     meta: ${JSON.stringify(data)},
-    pageMap: NEXTRA_PAGE_MAP,
+    pageMap: unstable_pageMap,
     titleText: ${JSON.stringify(titleText)},
     headings: ${JSON.stringify(headings)},
     hasH1: ${JSON.stringify(hasH1)}

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -121,21 +121,29 @@ export default async function (
   }
 
   const prefix =
-    `import withLayout from '${layout}'\n` +
-    `import { withSSG } from 'nextra/ssg'\n` +
-    `${layoutConfig ? `import layoutConfig from '${layoutConfig}'` : ''}\n` +
-    `const unstable_pageMap = ${JSON.stringify(pageMap)}\n`
+    `import __nextra_withLayout__ from '${layout}'\n` +
+    `import { withSSG as __nextra_withSSG__ } from 'nextra/ssg'\n` +
+    `${
+      layoutConfig
+        ? `import __nextra_layoutConfig__ from '${layoutConfig}'`
+        : ''
+    }\n\n` +
+    `const __nextra_pageMap__ = ${JSON.stringify(pageMap)}\n` +
+    `globalThis.__nextra_internal__ = {\n` +
+    `  pageMap: __nextra_pageMap__,\n` +
+    `  route: ${JSON.stringify(route)},\n` +
+    `}\n`
 
   const suffix = `export default function NextraPage (props) {
-  return withSSG(withLayout({
+  return __nextra_withSSG__(__nextra_withLayout__({
     filename: "${slash(filename)}",
     route: "${slash(route)}",
     meta: ${JSON.stringify(data)},
-    pageMap: unstable_pageMap,
+    pageMap: __nextra_pageMap__,
     titleText: ${JSON.stringify(titleText)},
     headings: ${JSON.stringify(headings)},
     hasH1: ${JSON.stringify(hasH1)}
-  }, ${layoutConfig ? 'layoutConfig' : 'null'}))({
+  }, ${layoutConfig ? '__nextra_layoutConfig__' : 'null'}))({
     ...props,
     children: <MDXContent/>
   })


### PR DESCRIPTION
Resolves #368.

The following APIs are now supported inside your MDX files:

```
import { getAllPages, getCurrentLevelPages, getPagesUnderRoute } from 'nextra/context'

{console.log(getAllPages())}
{console.log(getCurrentLevelPages())}
{console.log(getPagesUnderRoute('/blog'))}
```

This will be extremely helpful for building an index page. The blog theme can be refactored based on this.
