### PR TITLE
Support for adding index page for directories

### DIFF
--- a/examples/swr-site/pages/blog.en-US.mdx
+++ b/examples/swr-site/pages/blog.en-US.mdx
@@ -1,0 +1,22 @@
+---
+searchable: false
+---
+
+# Blog
+
+import { getPagesUnderRoute } from 'nextra/context'
+import Link from 'next/link'
+
+{getPagesUnderRoute('/blog').map(page => {
+  // Alias `<a>` to avoid it being replaced by MDX components.
+  const A = 'a'
+  return <div>
+    <Link href={page.route}>
+      <A style={{
+        color: '#000',
+      }}>{page.meta.title || page.frontMatter?.title || page.name}</A>
+    </Link>
+    <p>{page.frontMatter?.description}</p>
+    <p>{page.date}</p>
+  </div>
+})}

--- a/examples/swr-site/pages/docs/advanced.en-US.mdx
+++ b/examples/swr-site/pages/docs/advanced.en-US.mdx
@@ -1,0 +1,3 @@
+# Advanced features!
+
+You can create this index page now!

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -48,7 +48,7 @@
     "github-slugger": "^1.4.0",
     "intersection-observer": "^0.12.0",
     "match-sorter": "^4.2.0",
-    "next-themes": "^0.0.15",
+    "next-themes": "^0.2.0-beta.0",
     "parse-git-url": "^1.0.1",
     "react-innertext": "^1.1.5",
     "title": "^3.4.2"

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -183,7 +183,7 @@ const Layout: React.FC<LayoutProps> = ({
 
 export default (opts: PageOpt, config: DocsThemeConfig) => {
   const extendedConfig = Object.assign({}, defaultConfig, config)
-  return (props: any) => {
+  return function (props: any) {
     return (
       <ThemeConfigContext.Provider value={extendedConfig}>
         <ThemeProvider

--- a/packages/nextra-theme-docs/src/navbar.tsx
+++ b/packages/nextra-theme-docs/src/navbar.tsx
@@ -46,7 +46,9 @@ export default function Navbar({ flatDirectories, items }: NavBarProps) {
 
               // If it's a directory
               if (page.children) {
-                href = page.firstChildRoute ?? href
+                href =
+                  (page.withIndexPage ? page.route : page.firstChildRoute) ||
+                  href
               }
 
               const isActive =

--- a/packages/nextra-theme-docs/src/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/sidebar.tsx
@@ -276,7 +276,10 @@ export default function Sidebar({
               </div>
             ) : null}
             {config.darkMode ? (
-              <div className={cn('grow-0 relative', { locale: config.i18n })}>
+              <div
+                className={cn('grow-0 relative', { locale: config.i18n })}
+                key="theme-switch"
+              >
                 <ThemeSwitch />
               </div>
             ) : null}

--- a/packages/nextra-theme-docs/src/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/sidebar.tsx
@@ -31,7 +31,7 @@ function Folder({ item, anchors }: FolderProps) {
   const active = route === item.route + '/' || route + '/' === item.route + '/'
   const { defaultMenuCollapsed } = useMenuContext()
   const open = TreeState[item.route] ?? !defaultMenuCollapsed
-  const [_, render] = useState(false)
+  const rerender = useState({})[1]
 
   useEffect(() => {
     if (active) {
@@ -39,23 +39,33 @@ function Folder({ item, anchors }: FolderProps) {
     }
   }, [active])
 
+  const link = (
+    <a
+      onClick={() => {
+        if (item.withIndexPage) {
+          // If it's focused, we toggle it. Otherwise always open it.
+          TreeState[item.route] = active ? !open : true
+          rerender({})
+          return
+        }
+        if (active) return
+        TreeState[item.route] = !open
+        rerender({})
+      }}
+    >
+      <span className="flex items-center justify-between gap-2">
+        {item.title}
+        <ArrowRight
+          height="1em"
+          className={cn(open ? 'rotate-90' : '', 'transition-transform')}
+        />
+      </span>
+    </a>
+  )
+
   return (
-    <li className={open ? 'active' : ''}>
-      <button
-        onClick={() => {
-          if (active) return
-          TreeState[item.route] = !open
-          render(x => !x)
-        }}
-      >
-        <span className="flex items-center justify-between gap-2">
-          {item.title}
-          <ArrowRight
-            height="1em"
-            className={cn(open ? 'rotate-90' : '', 'transition-transform')}
-          />
-        </span>
-      </button>
+    <li className={cn({ open, active })}>
+      {item.withIndexPage ? <Link href={item.route}>{link}</Link> : link}
       <div
         style={{
           display: open ? 'initial' : 'none'

--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -72,9 +72,9 @@ blockquote:not(:first-child),
 
 /* Content Typography */
 article {
+  min-height: calc(100vh - 64px);
   &.full {
     width: 100%;
-    min-height: calc(100vh - 64px);
     &.expand {
       width: 100vw;
       margin: 0 calc(50% - 50vw);

--- a/packages/nextra-theme-docs/src/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/theme-switch.tsx
@@ -18,13 +18,11 @@ function ThemeSwitch({ lite = true }) {
       }}
       selected={{
         key: theme || '',
-        name: mounted ? (
+        name: (
           <div className="flex items-center gap-2 capitalize">
-            {renderedTheme === 'dark' ? <Moon /> : <Sun />}
-            {lite ? '' : <span>{theme}</span>}
+            {mounted && renderedTheme === 'dark' ? <Moon /> : <Sun />}
+            {lite ? '' : <span>{mounted ? theme : 'light'}</span>}
           </div>
-        ) : (
-          <div className="flex items-center gap-2 capitalize" />
         )
       }}
       options={[

--- a/packages/nextra-theme-docs/src/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/theme-switch.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { memo } from 'react'
 import { useTheme } from 'next-themes'
 
 import Menu from './select'
 import Sun from './icons/sun'
 import Moon from './icons/moon'
 
-export default function ThemeSwitch({ lite = true }) {
+function ThemeSwitch({ lite = true }) {
   const { theme, setTheme, systemTheme } = useTheme()
   const renderedTheme = theme === 'system' ? systemTheme : theme
   const [mounted, setMounted] = React.useState(false)
@@ -24,7 +24,7 @@ export default function ThemeSwitch({ lite = true }) {
             {lite ? '' : <span>{theme}</span>}
           </div>
         ) : (
-          ''
+          <div className="flex items-center gap-2 capitalize" />
         )
       }}
       options={[
@@ -44,3 +44,5 @@ export default function ThemeSwitch({ lite = true }) {
     ></Menu>
   )
 }
+
+export default memo(ThemeSwitch)

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -135,7 +135,7 @@ export default async function (
     `}\n` +
     `
     const __nextra_content__ = <MDXContent/>
-    const __nextra_layout__ = __nextra_withLayout__({
+    const NextraLayout = __nextra_withSSG__(__nextra_withLayout__({
       filename: "${slash(filename)}",
       route: "${slash(route)}",
       meta: ${JSON.stringify(data)},
@@ -143,14 +143,11 @@ export default async function (
       titleText: ${JSON.stringify(titleText)},
       headings: ${JSON.stringify(headings)},
       hasH1: ${JSON.stringify(hasH1)}
-    }, ${layoutConfig ? '__nextra_layoutConfig__' : 'null'})
+    }, ${layoutConfig ? '__nextra_layoutConfig__' : 'null'}))
     `
 
   const suffix = `export default function NextraPage (props) {
-  return __nextra_withSSG__(__nextra_layout__)({
-    ...props,
-    children: __nextra_content__
-  })
+  return <NextraLayout {...props}>{__nextra_content__}</NextraLayout>
 }`
 
   // Add imports and exports to the source

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -132,20 +132,24 @@ export default async function (
     `globalThis.__nextra_internal__ = {\n` +
     `  pageMap: __nextra_pageMap__,\n` +
     `  route: ${JSON.stringify(route)},\n` +
-    `}\n`
+    `}\n` +
+    `
+    const __nextra_content__ = <MDXContent/>
+    const __nextra_layout__ = __nextra_withLayout__({
+      filename: "${slash(filename)}",
+      route: "${slash(route)}",
+      meta: ${JSON.stringify(data)},
+      pageMap: __nextra_pageMap__,
+      titleText: ${JSON.stringify(titleText)},
+      headings: ${JSON.stringify(headings)},
+      hasH1: ${JSON.stringify(hasH1)}
+    }, ${layoutConfig ? '__nextra_layoutConfig__' : 'null'})
+    `
 
   const suffix = `export default function NextraPage (props) {
-  return __nextra_withSSG__(__nextra_withLayout__({
-    filename: "${slash(filename)}",
-    route: "${slash(route)}",
-    meta: ${JSON.stringify(data)},
-    pageMap: __nextra_pageMap__,
-    titleText: ${JSON.stringify(titleText)},
-    headings: ${JSON.stringify(headings)},
-    hasH1: ${JSON.stringify(hasH1)}
-  }, ${layoutConfig ? '__nextra_layoutConfig__' : 'null'}))({
+  return __nextra_withSSG__(__nextra_layout__)({
     ...props,
-    children: <MDXContent/>
+    children: __nextra_content__
   })
 }`
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
       github-slugger: ^1.4.0
       intersection-observer: ^0.12.0
       match-sorter: ^4.2.0
-      next-themes: ^0.0.15
+      next-themes: ^0.2.0-beta.0
       nextra: workspace:*
       parse-git-url: ^1.0.1
       react-innertext: ^1.1.5
@@ -159,7 +159,7 @@ importers:
       github-slugger: 1.4.0
       intersection-observer: 0.12.0
       match-sorter: 4.2.1
-      next-themes: 0.0.15_caa633a00319350dbda42996613fe26c
+      next-themes: 0.2.0-beta.0_caa633a00319350dbda42996613fe26c
       parse-git-url: 1.0.1
       react-innertext: 1.1.5_a0c521d4794c7ad97f5f4c1c4a7d5818
       title: 3.4.3
@@ -3195,6 +3195,18 @@ packages:
     resolution: {integrity: sha512-LTmtqYi03c4gMTJmWwVK9XkHL7h0/+XrtR970Ujvtu3s0kZNeJN24aJsi4rkZOI8i19+qq6f8j+8Duwy5jqcrQ==}
     peerDependencies:
       next: '*'
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      next: 12.1.0_react-dom@17.0.2+react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /next-themes/0.2.0-beta.0_caa633a00319350dbda42996613fe26c:
+    resolution: {integrity: sha512-vzF6V1cWo6LVuMZkTpsP3+7roc14X8VTRgyiZT/6TWzcd7sLdE+y/6F1WiXEvKg+IqwdUb8g3KwC20Fo1yUYqw==}
+    peerDependencies:
+      next: '>=11.1.1'
       react: '*'
       react-dom: '*'
     dependencies:


### PR DESCRIPTION
If you have a directory `/blog`, together with a page `/blog.mdx`, the page now becomes the index page of that directory.

Check the "Advanced" folder and "Blog" page of the deployed demo for more details.