### PR TITLE
the head config to support function in doc theme

### DIFF
--- a/packages/nextra-theme-docs/src/head.tsx
+++ b/packages/nextra-theme-docs/src/head.tsx
@@ -24,7 +24,7 @@ export default function Head({ title, locale, meta }: HeadProps) {
         {title}
         {renderComponent(config.titleSuffix, { locale, config, title, meta })}
       </title>
-      {renderComponent(config.head, { locale, config, title, meta })}
+      {renderComponent(config.head, { locale, config, title, meta }, true)}
       {config.unstable_faviconGlyph ? (
         <link
           rel="icon"


### PR DESCRIPTION
@shuding I was solving my issue described here #379, and I found what is the issue.

This PR will add a support for passing a function in `config.head` configuration for Docs theme.

To support `config.head` as a function we need to have latest code from `core` branch for `renderComponent` metod:

```
const renderComponent = <T,>(
  ComponentOrNode: React.FC<T> | React.ReactNode,
  props: T,
  functionOnly?: boolean
) => {
  if (!ComponentOrNode) return null
  if (typeof ComponentOrNode === 'function') {
    if (functionOnly) return ComponentOrNode(props)
    return <ComponentOrNode {...props} />
  }
  return ComponentOrNode
}
```
Note that this is not a function we have in latest tag (`v2.0.0-beta.5`). The `functionOnly` is added later.

Important part is we have `functionOnly` and in case it is true we return ` ComponentOrNode(props)`. And that is what will make config.head as a function to be rendered into the Head.

Also we need to do what my PR suggest to call `renderComponent` with the `functionOnly` = `true`, because only in that case we will support both cases for `config.head`: function and Element.

Example of the `config.head` as a function we will support after this PR, and releasing new tag.

```
  head: ({title, meta}) => (
    <>
      <meta name="description" content={meta.description ? meta.description: "Default description"} />
    </>
  ),
```