### PR TITLE
Rename nextra/ssg to nextra/data

### DIFF
--- a/examples/swr-site/pages/docs/change-log.en-US.mdx
+++ b/examples/swr-site/pages/docs/change-log.en-US.mdx
@@ -1,15 +1,20 @@
 import Markdown from 'markdown-to-jsx'
-import { useSSG } from 'nextra/ssg'
+import { useData } from 'nextra/data'
 
 export const getStaticProps = ({ params }) => {
   return fetch(`https://api.github.com/repos/vercel/swr/releases`)
     .then(res => res.json())
     // we keep the most recent 5 releases here
-    .then(releases => ({ props: { ssg: releases.slice(0, 5) }, revalidate: 10 }))
+    .then(releases => ({
+      props: {
+        releases: releases.slice(0, 5)
+      },
+      revalidate: 60
+    }))
 }
 
 export const ReleasesRenderer = () => {
-  const releases = useSSG()
+  const releases = useData('releases')
   return <Markdown>{
     releases.map(release => {
       const body = release.body

--- a/packages/nextra/data.js
+++ b/packages/nextra/data.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/ssg')

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -7,6 +7,7 @@
     "dist/*",
     "index.js",
     "ssg.js",
+    "data.js",
     "loader.js",
     "locales.js",
     "context.js"

--- a/packages/nextra/src/ssg.ts
+++ b/packages/nextra/src/ssg.ts
@@ -5,8 +5,8 @@ import React, {
   useContext
 } from 'react'
 
-export const SSGContext = createContext<boolean>(false)
-export const useSSG = () => useContext(SSGContext)
+export const SSGContext = createContext<any>(false)
+export const useSSG = (key = 'ssg') => useContext(SSGContext)?.[key]
 
 export const withSSG = <T extends { ssg: boolean } = any>(
   Page: FunctionComponent<T> | ComponentClass<T>
@@ -14,10 +14,16 @@ export const withSSG = <T extends { ssg: boolean } = any>(
   function WithSSG(props: T) {
     return React.createElement(
       SSGContext.Provider,
-      { value: props.ssg },
+      { value: props },
       React.createElement(Page, props)
     )
   }
   WithSSG.withLayout = (Page as any).withLayout
   return WithSSG
 }
+
+// Make sure nextra/ssg remains functional, but we now recommend this new API.
+
+export const DataContext = SSGContext
+export const useData = useSSG
+export const withData = withSSG


### PR DESCRIPTION
Simply because this can be used for SSR/ISR. The prop is not limited to `ssg` as long as a key is passed.

But we are keeping the old API support too.