### PR TITLE
usee cross-env to set env vars

### DIFF
--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -21,11 +21,11 @@
   "scripts": {
     "build": "pnpm build:layout & pnpm build:tailwind",
     "build:layout": "node scripts/build.js",
-    "build:tailwind": "NODE_ENV=production pnpm postcss src/styles.css -o style.css --verbose",
+    "build:tailwind": "cross-env NODE_ENV=production pnpm postcss src/styles.css -o style.css --verbose",
     "types": "tsc -p tsconfig.types.json",
     "dev": "concurrently \"pnpm dev:layout\" \"pnpm dev:tailwind\"",
     "dev:layout": "node scripts/dev.js",
-    "dev:tailwind": "TAILWIND_MODE=watch pnpm postcss src/styles.css -o style.css --watch",
+    "dev:tailwind": "cross-env TAILWIND_MODE=watch pnpm postcss src/styles.css -o style.css --watch",
     "prepublishOnly": "rm -rf dist && pnpm build"
   },
   "dependencies": {
@@ -40,6 +40,7 @@
     "react-dom": ">=16.13.1"
   },
   "devDependencies": {
-    "nextra": "workspace:*"
+    "nextra": "workspace:*",
+    "cross-env": "^7.0.2"
   }
 }

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -28,10 +28,10 @@
     "dev": "concurrently \"pnpm dev:layout\" \"pnpm dev:tailwind\"",
     "build": "pnpm build:tailwind && pnpm build:layout",
     "build:layout": "node scripts/build.js",
-    "build:tailwind": "NODE_ENV=production pnpm postcss src/styles.css -o style.css --verbose",
+    "build:tailwind": "cross-env NODE_ENV=production pnpm postcss src/styles.css -o style.css --verbose",
     "types": "tsc -p tsconfig.types.json",
     "dev:layout": "node scripts/dev.js",
-    "dev:tailwind": "TAILWIND_MODE=watch pnpm postcss src/styles.css -o style.css --watch",
+    "dev:tailwind": "cross-env TAILWIND_MODE=watch pnpm postcss src/styles.css -o style.css --watch",
     "prepublishOnly": "rm -rf dist && pnpm build",
     "test": "vitest --run"
   },
@@ -58,6 +58,7 @@
     "@types/flexsearch": "^0.7.2",
     "@types/react": "^17.0.39",
     "autoprefixer": "^10.2.6",
+    "cross-env": "^7.0.2",
     "nextra": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,7 @@ importers:
   packages/nextra-theme-blog:
     specifiers:
       '@mdx-js/react': ^2.0.0
+      cross-env: ^7.0.2
       github-slugger: ^1.3.0
       next-themes: ^0.0.15
       nextra: workspace:*
@@ -129,6 +130,7 @@ importers:
       next-themes: 0.0.15_caa633a00319350dbda42996613fe26c
       react-cusdis: 2.1.3_react-dom@17.0.2+react@17.0.2
     devDependencies:
+      cross-env: 7.0.3
       nextra: link:../nextra
 
   packages/nextra-theme-docs:
@@ -140,6 +142,7 @@ importers:
       '@types/react': ^17.0.39
       autoprefixer: ^10.2.6
       classnames: ^2.2.6
+      cross-env: ^7.0.2
       flexsearch: ^0.7.21
       focus-visible: ^5.1.0
       github-slugger: ^1.4.0
@@ -166,6 +169,7 @@ importers:
       '@types/flexsearch': 0.7.2
       '@types/react': 17.0.39
       autoprefixer: 10.4.1_postcss@8.4.5
+      cross-env: 7.0.3
       nextra: link:../nextra
 
 packages:
@@ -1156,6 +1160,14 @@ packages:
       yaml: 1.10.2
     dev: true
 
+  /cross-env/7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: true
+
   /cross-spawn/5.1.0:
     resolution: {integrity: sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=}
     dependencies:
@@ -1163,6 +1175,15 @@ packages:
       shebang-command: 1.2.0
       which: 1.3.1
     dev: false
+
+  /cross-spawn/7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: true
 
   /css-color-names/0.0.4:
     resolution: {integrity: sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=}
@@ -2452,7 +2473,6 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
-    dev: false
 
   /jest-worker/27.4.6:
     resolution: {integrity: sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==}
@@ -3408,6 +3428,11 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /path-key/3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: true
+
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
@@ -4160,10 +4185,22 @@ packages:
       shebang-regex: 1.0.0
     dev: false
 
+  /shebang-command/2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: true
+
   /shebang-regex/1.0.0:
     resolution: {integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=}
     engines: {node: '>=0.10.0'}
     dev: false
+
+  /shebang-regex/3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+    dev: true
 
   /shiki/0.10.1:
     resolution: {integrity: sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==}
@@ -4991,6 +5028,14 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: false
+
+  /which/2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: true
 
   /wrap-ansi/7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}


### PR DESCRIPTION
Found this "bug" where you can't build on windows on a fresh clone because it doesn't recognize that you're trying to set an env var. This should work cross-platform