### PR TITLE
Discussion: Feedback for MDX compilation failure

### DIFF
--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -55,7 +55,8 @@ export async function compileMdx(
   } = {
     unstable_staticImage: false,
     unstable_flexsearch: false
-  }
+  },
+  resourcePath: string
 ) {
   let structurizedData = {}
   const compiler = createCompiler({
@@ -78,10 +79,16 @@ export async function compileMdx(
       attachMeta
     ].filter(Boolean)
   })
-  const result = await compiler.process(source)
-  return {
-    result: String(result),
-    ...(compiler.data('headingMeta') as HeadingMeta),
-    structurizedData
+  try {
+    const result = await compiler.process(source)
+    return {
+      result: String(result),
+      ...(compiler.data('headingMeta') as HeadingMeta),
+      structurizedData
+    }
+  } catch (err) {
+    console.error(`\nError compiling ${resourcePath}`)
+    console.error(`${err}\n`)
+    throw err
   }
 }

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -101,7 +101,7 @@ export default async function (
     await compileMdx(content, mdxOptions, {
       unstable_staticImage,
       unstable_flexsearch
-    })
+    }, resourcePath)
   content = result
   content = content.replace('export default MDXContent;', '')
 


### PR DESCRIPTION
With a syntax error in a markdown/MDX file, the build gives no feedback as to what authored file is the cause of the problem. Could this be addressed  through a strategy along the lines of the proposal in this PR? This will report the file at fault, and an attempt at the line location (unfortunately an attempt that usually doesn't match up with the actual line, for reasons I don't understand).

For example:
```
raidocs:build: info  - Loaded env from /home/robbear/dev/robbear/rai-ux/raidocs/site/.env.production
raidocs:build: info  - Checking validity of types...
raidocs:build: warn  - The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config
raidocs:build: info  - Creating an optimized production build...
raidocs:build: 
raidocs:build: Error compiling /home/robbear/dev/robbear/rai-ux/raidocs/site/pages/rel/primer/basic_syntax.md
raidocs:build: 17:3: Could not parse expression with acorn: Unexpected token
raidocs:build: 
raidocs:build: (node:2594893) UnhandledPromiseRejectionWarning
raidocs:build: (Use `node --trace-warnings ...` to show where the warning was created)
raidocs:build: (node:2594893) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
raidocs:build: (node:2594893) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Are there other approaches you're thinking about for giving MDX debugging feedback?