### PR TITLE
Add `layout` option and `*` fallback of meta.json

### DIFF
--- a/examples/swr-site/pages/docs/advanced/meta.en-US.json
+++ b/examples/swr-site/pages/docs/advanced/meta.en-US.json
@@ -1,4 +1,9 @@
 {
+  "*": {
+    "theme": {
+      "footer": false
+    }
+  },
   "cache": "Cache",
   "performance": "Performance",
   "react-native": "React Native",

--- a/examples/swr-site/pages/meta.en-US.json
+++ b/examples/swr-site/pages/meta.en-US.json
@@ -17,7 +17,7 @@
     "title": "Examples",
     "type": "page",
     "theme": {
-      "full": true
+      "layout": "full"
     }
   },
   "blog": {

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -52,7 +52,7 @@ const Body: React.FC<BodyProps> = ({
   return (
     <React.Fragment>
       <SkipNavContent />
-      {themeContext.full ? (
+      {themeContext.layout === 'full' ? (
         <article
           className={cn(
             'nextra-body full relative overflow-x-hidden',
@@ -61,6 +61,10 @@ const Body: React.FC<BodyProps> = ({
         >
           <MDXTheme>{children}</MDXTheme>
         </article>
+      ) : themeContext.layout === 'raw' ? (
+        <div className="nextra-body full relative overflow-x-hidden expand">
+          {children}
+        </div>
       ) : (
         <article className="nextra-body relative pb-8 w-full max-w-full flex min-w-0 pr-[calc(env(safe-area-inset-right)-1.5rem)]">
           <main className="mx-auto max-w-4xl px-6 md:px-8 pt-4 z-10 min-w-0 w-full">
@@ -119,6 +123,8 @@ const Content: React.FC<LayoutProps> = ({
   const [menu, setMenu] = useState(false)
   const themeContext = { ...activeThemeContext, ...meta }
 
+  const hideSidebar = !themeContext.sidebar || themeContext.layout === 'raw'
+
   return (
     <React.Fragment>
       <Head title={title} locale={locale} meta={meta} />
@@ -151,7 +157,7 @@ const Content: React.FC<LayoutProps> = ({
                   fullDirectories={directories}
                   headings={headings}
                   isRTL={isRTL}
-                  asPopover={activeType === 'page' || !themeContext.sidebar}
+                  asPopover={activeType === 'page' || hideSidebar}
                 />
                 <Body
                   themeContext={themeContext}
@@ -184,7 +190,7 @@ const Content: React.FC<LayoutProps> = ({
             </div>
           </ActiveAnchor>
           {themeContext.footer && config.footer ? (
-            <Footer menu={activeType === 'page' || !themeContext.sidebar} />
+            <Footer menu={activeType === 'page' || hideSidebar} />
           ) : null}
         </div>
       </MenuContext.Provider>

--- a/packages/nextra-theme-docs/src/misc/theme-context.tsx
+++ b/packages/nextra-theme-docs/src/misc/theme-context.tsx
@@ -4,6 +4,14 @@ export default {
   toc: true,
   pagination: true,
   footer: true,
-  full: false,
+  layout: 'default',
   breadcrumb: true
+} as {
+  navbar: Boolean
+  sidebar: Boolean
+  toc: Boolean
+  pagination: Boolean
+  footer: Boolean
+  layout: 'default' | 'full' | 'raw'
+  breadcrumb: Boolean
 }

--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -228,7 +228,7 @@ blockquote:not(:first-child),
 }
 
 /* Content Typography */
-article {
+article.nextra-body {
   min-height: calc(100vh - 64px);
   &.full {
     width: 100%;
@@ -583,13 +583,13 @@ table tr td {
   .nextra-sidebar a {
     @apply text-right;
   }
-  article blockquote {
+  article.nextra-body blockquote {
     @apply pr-6 border-r-2 pl-0 border-l-0;
   }
 }
 .nextra-container:not(.rtl):not(.page) article.nextra-body {
 }
-.nextra-container.rtl:not(.page) .nextra-body {
+.nextra-container.rtl:not(.page) article.nextra-body {
 }
 @screen md {
   .nextra-container:not(.page) article.nextra-body .bleed.full {
@@ -606,11 +606,11 @@ table tr td {
     margin-left: calc(50% - 50vw + 16rem);
     margin-right: calc(50% - 50vw);
   }
-  .nextra-container.rtl:not(.page) .nextra-body .bleed.full {
+  .nextra-container.rtl:not(.page) article.nextra-body .bleed.full {
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw + 16rem);
   }
-  .nextra-container.page .nextra-body .bleed.full {
+  .nextra-container.page article.nextra-body .bleed.full {
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
   }
@@ -622,8 +622,8 @@ table tr td {
   .anchor-icon {
     @apply ml-0 mr-2 inline-block;
   }
-  article ul,
-  article ol {
+  article.nextra-body ul,
+  article.nextra-body ol {
     @apply ml-0 mr-6;
   }
   .nextra-sidebar {


### PR DESCRIPTION
Breaking change:

```
"theme": {
  "full": true
}
```

will be:

```
"theme": {
  "layout": "full"
}
```

It will support three options: "default", "full" and "raw". "raw" will not be wrapped by `<MDXContent>` and `article`.

---

Also the `*` key will be used as the fallback configuration for all pages in the same level:

```
{
  "*": {
    "type": "page",
    "theme": {
      "sidebar": true
    }
  },
  "a": "A",
  "b": {
    "title": "B",
    "theme": {
      "sidebar": false
    }
  }
}
```