### PR TITLE
fix(theme-switch): cannot use of ARIA attribute without `role` attribute

### DIFF
--- a/packages/nextra-theme-blog/src/theme-switch.tsx
+++ b/packages/nextra-theme-blog/src/theme-switch.tsx
@@ -14,6 +14,7 @@ export default function ThemeSwitch() {
 
   return (
     <span
+      role="button"
       aria-label="Toggle Dark Mode"
       className="text-current p-2 cursor-pointer ml-3"
       tabIndex={0}


### PR DESCRIPTION
Fixes the following lighthouse error around accessibility

> Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes.

And also fixes a warning in Chromium

> Elements must only use allowed ARIA attributes: aria-label attribute cannot be used on a span with no valid role attribute.