### PR TITLE
fix(theme-blog): remove extra padding from post-item list

### DIFF
--- a/packages/nextra-theme-blog/src/index.tsx
+++ b/packages/nextra-theme-blog/src/index.tsx
@@ -126,7 +126,7 @@ const BlogLayout = ({
   const meta = opts.meta
 
   const postList = posts.length > 0 ? (
-    <ul>
+    <div>
       {posts.map(post => {
         if (tagName) {
           const tags = getTags(post)
@@ -168,7 +168,7 @@ const BlogLayout = ({
           </div>
         )
       })}
-    </ul>
+    </div>
   ) : null
   const ref = React.useRef<HTMLHeadingElement>(null)
 


### PR DESCRIPTION
Using `<ul>` adds unnecessary left padding to the post item list and changing it to `<div>` removes the padding.

### Before

![image](https://user-images.githubusercontent.com/24727447/177555112-37dee7f6-9bae-4ec2-acd1-a2ffc0b0a12e.png)

### After

![image](https://user-images.githubusercontent.com/24727447/177555188-c30a4614-c328-4f78-95ce-c84b36ac8c35.png)
