### PR TITLE
chore(nextra-theme-docs): refactor `theme-context.ts`

### DIFF
--- a/.changeset/nasty-radios-joke.md
+++ b/.changeset/nasty-radios-joke.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+chore(nextra-theme-docs): refactor `theme-context.ts`

--- a/packages/nextra-theme-docs/src/misc/theme-context.ts
+++ b/packages/nextra-theme-docs/src/misc/theme-context.ts
@@ -1,4 +1,4 @@
-export default {
+export default <PageTheme>{
   navbar: true,
   sidebar: true,
   toc: true,
@@ -7,15 +7,15 @@ export default {
   layout: 'default',
   typesetting: 'default',
   breadcrumb: true
-} as PageTheme
+}
 
 export type PageTheme = {
-  navbar: Boolean
-  sidebar: Boolean
-  toc: Boolean
-  pagination: Boolean
-  footer: Boolean
+  navbar: boolean
+  sidebar: boolean
+  toc: boolean
+  pagination: boolean
+  footer: boolean
   layout: 'default' | 'full' | 'raw'
   typesetting: 'default' | 'article'
-  breadcrumb: Boolean
+  breadcrumb: boolean
 }


### PR DESCRIPTION
I renamed the extension to `ts` since there is no `jsx` content in this function