### PR TITLE
feat(nextra): export `compile.tsx`

### DIFF
--- a/packages/nextra/context.js
+++ b/packages/nextra/context.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/context')

--- a/packages/nextra/data.js
+++ b/packages/nextra/data.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/ssg')

--- a/packages/nextra/index.js
+++ b/packages/nextra/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/index')

--- a/packages/nextra/locales.js
+++ b/packages/nextra/locales.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/locales')

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -5,13 +5,17 @@
   "main": "index.js",
   "files": [
     "dist/*",
-    "index.js",
-    "ssg.js",
-    "data.js",
-    "loader.js",
-    "locales.js",
-    "context.js"
+    "loader.js"
   ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./compile": "./dist/compile.mjs",
+    "./context": "./dist/context.js",
+    "./data": "./dist/ssg.js",
+    "./loader": "./loader.js",
+    "./locales": "./dist/locales.js",
+    "./ssg": "./dist/ssg.js"
+  },
   "types": "./dist/types.d.ts",
   "repository": "https://github.com/shuding/nextra",
   "license": "MIT",

--- a/packages/nextra/scripts/build.js
+++ b/packages/nextra/scripts/build.js
@@ -1,38 +1,46 @@
 const esbuild = require('esbuild')
-const package = require('../package.json')
+const packageJson = require('../package.json')
+
+const BUILD_OPTIONS = {
+  platform: 'node',
+  bundle: true,
+  color: true,
+  target: 'es2016'
+}
+
+const externalDeps = [
+  ...Object.keys(packageJson.dependencies),
+  ...Object.keys(packageJson.peerDependencies || {})
+]
 
 // Build CJS entrypoints
 esbuild.buildSync({
+  ...BUILD_OPTIONS,
   entryPoints: [
     'src/index.js',
     'src/ssg.ts',
     'src/locales.ts',
     'src/context.ts'
   ],
-  platform: 'node',
-  bundle: true,
   format: 'cjs',
   outdir: 'dist',
-  color: true,
-  target: 'es2016',
-  external: [
-    'next/server',
-    ...Object.keys(package.dependencies),
-    ...Object.keys(package.peerDependencies || {})
-  ]
+  external: ['next/server', ...externalDeps]
 })
 
 // Build the loader as ESM
 esbuild.buildSync({
+  ...BUILD_OPTIONS,
   entryPoints: ['src/loader.ts'],
   format: 'esm',
-  bundle: true,
-  platform: 'node',
   outfile: 'dist/loader.mjs',
-  color: true,
-  target: 'es2016',
-  external: [
-    ...Object.keys(package.dependencies),
-    ...Object.keys(package.peerDependencies || {})
-  ].filter(d => d !== 'shiki')
+  external: externalDeps.filter(d => d !== 'shiki')
+})
+
+// Build compile as ESM
+esbuild.buildSync({
+  ...BUILD_OPTIONS,
+  entryPoints: ['src/compile.ts'],
+  format: 'esm',
+  outfile: 'dist/compile.mjs',
+  external: externalDeps
 })

--- a/packages/nextra/scripts/dev.js
+++ b/packages/nextra/scripts/dev.js
@@ -1,52 +1,57 @@
 const esbuild = require('esbuild')
-const package = require('../package.json')
+const packageJson = require('../package.json')
 
 console.log('Watching...')
 
+const BUILD_OPTIONS = {
+  platform: 'node',
+  bundle: true,
+  color: true,
+  target: 'es2016',
+  watch: {
+    onRebuild(error) {
+      if (error) {
+        console.error('Watch build failed:', error)
+      } else {
+        console.log('Watch build succeeded.')
+      }
+    }
+  }
+}
+
+const externalDeps = [
+  ...Object.keys(packageJson.dependencies),
+  ...Object.keys(packageJson.peerDependencies || {})
+]
+
 // Build CJS entrypoints
 esbuild.build({
+  ...BUILD_OPTIONS,
   entryPoints: [
     'src/index.js',
     'src/ssg.ts',
     'src/locales.ts',
     'src/context.ts'
   ],
-  platform: 'node',
-  bundle: true,
   format: 'cjs',
   outdir: 'dist',
-  color: true,
-  target: 'es2016',
-  watch: {
-    onRebuild(error) {
-      if (error) console.error('Watch build failed:', error)
-      else console.log('Watch build succeeded.')
-    }
-  },
-  external: [
-    'next/server',
-    ...Object.keys(package.dependencies),
-    ...Object.keys(package.peerDependencies || {})
-  ]
+  external: ['next/server', ...externalDeps]
 })
 
 // Build the loader as ESM
 esbuild.build({
+  ...BUILD_OPTIONS,
   entryPoints: ['src/loader.ts'],
   format: 'esm',
-  platform: 'node',
-  bundle: true,
   outfile: 'dist/loader.mjs',
-  color: true,
-  target: 'es2016',
-  watch: {
-    onRebuild(error) {
-      if (error) console.error('Watch build failed:', error)
-      else console.log('Watch build succeeded.')
-    }
-  },
-  external: [
-    ...Object.keys(package.dependencies),
-    ...Object.keys(package.peerDependencies || {})
-  ].filter(d => d !== 'shiki')
+  external: externalDeps.filter(d => d !== 'shiki')
+})
+
+// Build compile as ESM
+esbuild.build({
+  ...BUILD_OPTIONS,
+  entryPoints: ['src/compile.ts'],
+  format: 'esm',
+  outfile: 'dist/compile.mjs',
+  external: externalDeps
 })

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -60,7 +60,8 @@ export async function compileMdx(
 ) {
   let structurizedData = {}
   const compiler = createCompiler({
-    jsx: true,
+    jsx: mdxOptions.jsx ?? true,
+    outputFormat: mdxOptions.outputFormat,
     providerImportSource: '@mdx-js/react',
     remarkPlugins: [
       ...(mdxOptions.remarkPlugins || []),

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -44,7 +44,8 @@ const rehypePrettyCodeOptions = {
 
 export async function compileMdx(
   source: string,
-  mdxOptions: LoaderOptions['mdxOptions'] = {},
+  mdxOptions: LoaderOptions['mdxOptions'] &
+    Pick<ProcessorOptions, 'jsx' | 'outputFormat'> = {},
   nextraOptions: {
     unstable_staticImage: boolean
     unstable_flexsearch:

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -1,6 +1,7 @@
 import { Heading as MDASTHeading } from 'mdast'
 import { ProcessorOptions } from '@mdx-js/mdx'
 import { PageMapCache } from './plugin'
+
 export interface LoaderOptions {
   theme: Theme
   themeConfig: string
@@ -8,7 +9,10 @@ export interface LoaderOptions {
   defaultLocale: string
   unstable_staticImage: boolean
   unstable_flexsearch: boolean
-  mdxOptions: Pick<ProcessorOptions, 'rehypePlugins' | 'remarkPlugins'>
+  mdxOptions: Pick<
+    ProcessorOptions,
+    'rehypePlugins' | 'remarkPlugins' | 'jsx' | 'outputFormat'
+  >
   pageMapCache: PageMapCache
 }
 
@@ -26,6 +30,7 @@ export interface PageMapItem {
 export type Heading = MDASTHeading & {
   value: string
 }
+
 export interface PageOpt {
   filename: string
   route: string

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -9,10 +9,7 @@ export interface LoaderOptions {
   defaultLocale: string
   unstable_staticImage: boolean
   unstable_flexsearch: boolean
-  mdxOptions: Pick<
-    ProcessorOptions,
-    'rehypePlugins' | 'remarkPlugins' | 'jsx' | 'outputFormat'
-  >
+  mdxOptions: Pick<ProcessorOptions, 'rehypePlugins' | 'remarkPlugins'>
   pageMapCache: PageMapCache
 }
 

--- a/packages/nextra/ssg.js
+++ b/packages/nextra/ssg.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/ssg')


### PR DESCRIPTION
`compileMdx` is a pretty useful function for me, but unfortunately, it is not exported by Nextra, and I use this function with [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote)

P.S. also I found a way to remove dummy `context.js`, `data.js`, `index.js`, `locales.js` and `ssg.js` files by configuring the `exports` field in `package.json`