### PR TITLE
Support for Custom Header IDs

### DIFF
--- a/packages/nextra-theme-docs/src/toc.tsx
+++ b/packages/nextra-theme-docs/src/toc.tsx
@@ -211,7 +211,7 @@ export default function ToC({
             <p className="font-semibold tracking-tight mb-4">On This Page</p>
             {headings.map(heading => {
               const text = getHeadingText(heading)
-              const slug = slugger.slug(text)
+              const slug = heading?.data?.id || slugger.slug(text)
 
               return (
                 <Item


### PR DESCRIPTION
Sometimes it's helpful to be able to specify a slug for a header in the Markdown source, e.g., to shorten it, to avoid collisions in a way that is robust to re-ordering, or to avoid having Unicode characters in URLs:

```
# This is a really long title for a long section [#long-section]
```

If a Nextra user installs a plugin to accommodate this syntax, it almost works perfectly, except in one place: the table of contents. The table of contents has access to the `heading.data.id` value that is used to create the links in the page (cf. [here](https://github.com/shuding/nextra/blob/e162f839a4967ce66345a57e9b43c30651fffb93/packages/nextra-theme-docs/src/toc.tsx#L220)), but it instead re-slugs the headers. This can lead to an inconsistency if such a plugin is used. 

To my understanding, this is a simple issue that can be addressed with the one-line change suggested in the PR.

In case it's helpful, [here's](https://github.com/newrelic/docs-website/pull/465) an example of a PR that implements such a plugin.

FWIW, I'm with RelationalAI; copying @robbear on this PR.