### PR TITLE
feat(nextra): allow define custom languages for shiki with `mdxOptions.rehypePrettyCodeOptions` option

### DIFF
--- a/.changeset/pretty-tips-invite.md
+++ b/.changeset/pretty-tips-invite.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+feat(nextra): allow define custom languages for shiki with `mdxOptions.rehypePrettyCodeOptions` option

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -46,17 +46,10 @@ export async function compileMdx(
   source: string,
   mdxOptions: LoaderOptions['mdxOptions'] &
     Pick<ProcessorOptions, 'jsx' | 'outputFormat'> = {},
-  nextraOptions: {
-    unstable_staticImage: boolean
-    unstable_flexsearch:
-      | boolean
-      | {
-          codeblocks: boolean
-        }
-  } = {
-    unstable_staticImage: false,
-    unstable_flexsearch: false
-  },
+  nextraOptions: Pick<
+    LoaderOptions,
+    'unstable_staticImage' | 'unstable_flexsearch'
+  > = {},
   resourcePath: string
 ) {
   let structurizedData = {}
@@ -77,7 +70,10 @@ export async function compileMdx(
     rehypePlugins: [
       ...(mdxOptions.rehypePlugins || []),
       parseMeta,
-      [rehypePrettyCode, rehypePrettyCodeOptions],
+      [
+        rehypePrettyCode,
+        { ...rehypePrettyCodeOptions, ...mdxOptions.rehypePrettyCodeOptions }
+      ],
       attachMeta
     ].filter(Boolean)
   })

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -1,15 +1,11 @@
 import { Heading as MDASTHeading } from 'mdast'
 import { ProcessorOptions } from '@mdx-js/mdx'
+import { Options as RehypePrettyCodeOptions } from 'rehype-pretty-code'
 import { PageMapCache } from './plugin'
 
-export interface LoaderOptions {
-  theme: Theme
-  themeConfig: string
+export interface LoaderOptions extends NextraConfig {
   locales: string[]
   defaultLocale: string
-  unstable_staticImage: boolean
-  unstable_flexsearch: boolean
-  mdxOptions: Pick<ProcessorOptions, 'rehypePlugins' | 'remarkPlugins'>
   pageMapCache: PageMapCache
 }
 
@@ -49,8 +45,11 @@ type Theme = string
 export type NextraConfig = {
   theme: Theme
   themeConfig: string
-  unstable_flexsearch: boolean
+  unstable_flexsearch?: boolean | { codeblocks: boolean }
   unstable_staticImage?: boolean
+  mdxOptions?: Pick<ProcessorOptions, 'rehypePlugins' | 'remarkPlugins'> & {
+    rehypePrettyCodeOptions?: Partial<RehypePrettyCodeOptions>
+  }
 }
 
 export type withNextra = (


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/555