### PR TITLE
Fix release workflow

### DIFF
--- a/.changeset/stale-masks-change.md
+++ b/.changeset/stale-masks-change.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+Fix release CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - uses: pnpm/action-setup@v2.2.2
         with:

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "trailingComma": "none",
     "arrowParens": "avoid"
   },
-  "packageManager": "pnpm@7.3.0"
+  "packageManager": "pnpm@7.3.0",
+  "workspaces": [
+    "packages/*"
+  ]
 }


### PR DESCRIPTION
It seems there's a bug in the Changeset package resolution process where private packages are included too. One workaround is to limit the workspace to only include the ones inside `packages/`.