### PR TITLE
change(theme-blog)!: make `footer` a react component

### DIFF
--- a/.changeset/purple-actors-roll.md
+++ b/.changeset/purple-actors-roll.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-blog': major
+---
+
+change(blog)!: make `footer` config a component

--- a/examples/blog/theme.config.jsx
+++ b/examples/blog/theme.config.jsx
@@ -1,5 +1,8 @@
+/**
+ * @type {import('nextra-theme-blog').NextraBlogTheme}
+ */
 export default {
-  footer: (
+  footer: (/* { title, meta } */) => (
     <small style={{ display: 'block', marginTop: '8rem' }}>
       <abbr
         title="This site and all its content are licensed under a Creative Commons Attribution-NonCommercial 4.0 International License."

--- a/packages/nextra-theme-blog/src/index.tsx
+++ b/packages/nextra-theme-blog/src/index.tsx
@@ -172,7 +172,7 @@ const BlogLayout = ({
           {type === 'post' && comments}
         </MDXTheme>
         {postList}
-        {config.footer}
+        {config.footer?.({ title, meta: opts.meta })}
       </HeadingContext.Provider>
     </article>
   )

--- a/packages/nextra-theme-blog/src/types.ts
+++ b/packages/nextra-theme-blog/src/types.ts
@@ -1,15 +1,14 @@
+interface Props {
+  title: string,
+  meta: Record<string, unknown>
+}
+
 export interface NextraBlogTheme {
   readMore?: string
-  footer?: React.ReactNode
+  footer?: (props: Props) => React.ReactNode
   titleSuffix?: string
   postFooter?: string
-  head?: ({
-    title,
-    meta
-  }: {
-    title: string
-    meta: Record<string, any>
-  }) => React.ReactNode
+  head?: (props: Props) => React.ReactNode
   cusdis?: {
     appId: string
     host?: string


### PR DESCRIPTION
I think making `footer` config a component allows greater customizability and some use cases (ref: #577). And also makes it consistent with `head` config. Therefore, I am putting this up for discussion. Let me know what you all think. 

### Backwards Compatibility
Nextra v2 is going to be a major release so I guess we can have a breaking change.

---

Closes #577 