### PR TITLE
chore: Add `strict-peer-dependencies=false`

### DIFF
--- a/.changeset/large-ligers-doubt.md
+++ b/.changeset/large-ligers-doubt.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+chore: Add strict-peer-dependencies=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-peer-dependencies=false


### PR DESCRIPTION
Fixes the `ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies` error in dev deployments.