### PR TITLE
feat: `menu` type

### DIFF
--- a/.changeset/modern-toys-admire.md
+++ b/.changeset/modern-toys-admire.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+New feature: menu type

--- a/examples/swr-site/pages/about/a-page.en-US.mdx
+++ b/examples/swr-site/pages/about/a-page.en-US.mdx
@@ -1,0 +1,1 @@
+# This Is A Page

--- a/examples/swr-site/pages/about/acknowledgement.en-US.mdx
+++ b/examples/swr-site/pages/about/acknowledgement.en-US.mdx
@@ -1,0 +1,2 @@
+# Acknowledgement
+

--- a/examples/swr-site/pages/about/meta.en-US.json
+++ b/examples/swr-site/pages/about/meta.en-US.json
@@ -1,4 +1,9 @@
 {
   "team": "👥 Team",
-  "acknowledgement": "🧩 Acknowledgement"
+  "acknowledgement": "🧩 Acknowledgement",
+  "a-page": {
+    "title": "A Page",
+    "type": "page",
+    "hidden": true
+  }
 }

--- a/examples/swr-site/pages/about/meta.en-US.json
+++ b/examples/swr-site/pages/about/meta.en-US.json
@@ -1,0 +1,4 @@
+{
+  "team": "👥 Team",
+  "acknowledgement": "🧩 Acknowledgement"
+}

--- a/examples/swr-site/pages/about/team.en-US.mdx
+++ b/examples/swr-site/pages/about/team.en-US.mdx
@@ -1,0 +1,3 @@
+# Team
+
+SWR is made by the team behind Next.js.

--- a/examples/swr-site/pages/meta.en-US.json
+++ b/examples/swr-site/pages/meta.en-US.json
@@ -18,13 +18,14 @@
     "items": {
       "contributors": {
         "title": "Contributors",
-        "href": "https://github.com/shuding/nextra",
+        "href": "https://github.com/vercel/swr/graphs/contributors",
         "newWindow": true
       },
       "team": {
-        "title": "Team",
-        "href": "https://github.com/shuding/nextra",
-        "newWindow": true
+        "title": "Team"
+      },
+      "acknowledgement": {
+        "title": "Acknowledgement"
       }
     }
   },

--- a/examples/swr-site/pages/meta.en-US.json
+++ b/examples/swr-site/pages/meta.en-US.json
@@ -26,6 +26,9 @@
       },
       "acknowledgement": {
         "title": "Acknowledgement"
+      },
+      "a-page": {
+        "title": "A Page"
       }
     }
   },

--- a/examples/swr-site/pages/meta.en-US.json
+++ b/examples/swr-site/pages/meta.en-US.json
@@ -12,6 +12,22 @@
       "toc": true
     }
   },
+  "about": {
+    "title": "About",
+    "type": "menu",
+    "items": {
+      "contributors": {
+        "title": "Contributors",
+        "href": "https://github.com/shuding/nextra",
+        "newWindow": true
+      },
+      "team": {
+        "title": "Team",
+        "href": "https://github.com/shuding/nextra",
+        "newWindow": true
+      }
+    }
+  },
   "examples": {
     "title": "Examples",
     "type": "page",

--- a/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
+++ b/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
@@ -1004,8 +1004,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
   ],
-  "pageDirectories": [],
-  "topLevelPageItems": [],
+  "topLevelNavbarItems": [],
 }
 `;
 
@@ -1827,8 +1826,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
   ],
-  "pageDirectories": [],
-  "topLevelPageItems": [],
+  "topLevelNavbarItems": [],
 }
 `;
 
@@ -2836,8 +2834,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
   ],
-  "pageDirectories": [],
-  "topLevelPageItems": [],
+  "topLevelNavbarItems": [],
 }
 `;
 
@@ -3659,7 +3656,6 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
   ],
-  "pageDirectories": [],
-  "topLevelPageItems": [],
+  "topLevelNavbarItems": [],
 }
 `;

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -186,7 +186,6 @@ const Content: React.FC<PropsWithChildren<LayoutProps>> = ({
     activeIndex,
     activeThemeContext,
     activePath,
-    // pageDirectories,
     topLevelNavbarItems,
     docsDirectories,
     flatDirectories,
@@ -236,7 +235,7 @@ const Content: React.FC<PropsWithChildren<LayoutProps>> = ({
           <div className="mx-auto flex w-full max-w-[90rem] flex-1 items-stretch">
             <div className="flex w-full flex-1">
               <Sidebar
-                directories={docsDirectories}
+                docsDirectories={docsDirectories}
                 flatDirectories={flatDirectories}
                 fullDirectories={directories}
                 headings={headings}

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -187,7 +187,7 @@ const Content: React.FC<PropsWithChildren<LayoutProps>> = ({
     activeThemeContext,
     activePath,
     // pageDirectories,
-    topLevelPageItems,
+    topLevelNavbarItems,
     docsDirectories,
     flatDirectories,
     flatDocsDirectories,
@@ -229,7 +229,7 @@ const Content: React.FC<PropsWithChildren<LayoutProps>> = ({
           <Navbar
             isRTL={isRTL}
             flatDirectories={flatDirectories}
-            items={topLevelPageItems}
+            items={topLevelNavbarItems}
           />
         ) : null}
         <ActiveAnchor>

--- a/packages/nextra-theme-docs/src/navbar.tsx
+++ b/packages/nextra-theme-docs/src/navbar.tsx
@@ -166,9 +166,10 @@ export default function Navbar({ flatDirectories, items }: NavBarProps) {
                       <NavbarMenu
                         className={cn(
                           'nextra-nav-link',
-                          !isActive
-                            ? 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200'
-                            : 'active subpixel-antialiased text-current'
+                          isActive
+                            ? 'active subpixel-antialiased text-current'
+                            : 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200'
+                            
                         )}
                         menu={menu}
                       >

--- a/packages/nextra-theme-docs/src/navbar.tsx
+++ b/packages/nextra-theme-docs/src/navbar.tsx
@@ -63,9 +63,7 @@ function NavbarMenu({
         leaveTo="opacity-0"
       >
         <Menu.Items
-          className={
-            'menu absolute right-0 z-20 mt-1 max-h-64 min-w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-neutral-800 dark:ring-white dark:ring-opacity-20'
-          }
+          className="menu absolute right-0 z-20 mt-1 max-h-64 min-w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-neutral-800 dark:ring-white dark:ring-opacity-20"
         >
           {Object.entries(items || {}).map(([key, item]) => {
             const href =

--- a/packages/nextra-theme-docs/src/navbar.tsx
+++ b/packages/nextra-theme-docs/src/navbar.tsx
@@ -68,7 +68,8 @@ function NavbarMenu({
           }
         >
           {Object.entries(items || {}).map(([key, item]) => {
-            const href = item.href || routes[key]?.route || '#'
+            const href =
+              item.href || routes[key]?.route || menu.route + '/' + key
 
             return (
               <Menu.Item key={key}>

--- a/packages/nextra-theme-docs/src/navbar.tsx
+++ b/packages/nextra-theme-docs/src/navbar.tsx
@@ -73,9 +73,7 @@ function NavbarMenu({
               <Menu.Item key={key}>
                 <NavbarMenuLink
                   href={href}
-                  className={
-                    'hidden whitespace-nowrap no-underline md:inline-block text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 relative cursor-pointer select-none py-1.5 pl-3 pr-9 w-full'
-                  }
+                  className="hidden whitespace-nowrap no-underline md:inline-block text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 relative cursor-pointer select-none py-1.5 pl-3 pr-9 w-full"
                   {...(item.newWindow
                     ? {
                         target: '_blank',

--- a/packages/nextra-theme-docs/src/select.tsx
+++ b/packages/nextra-theme-docs/src/select.tsx
@@ -47,7 +47,6 @@ export default function Menu({ options, selected, onChange }: MenuProps) {
                   value={option}
                   className={({ active }) =>
                     cn(
-                      option.key === selected.key ? '' : '',
                       active
                         ? 'bg-primary-50 text-primary-500 dark:bg-primary-500 dark:bg-opacity-10'
                         : 'text-gray-800 dark:text-gray-100',

--- a/packages/nextra-theme-docs/src/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/sidebar.tsx
@@ -96,8 +96,13 @@ function FolderImpl({ item, anchors }: FolderProps) {
       (menu.children || []).map(route => [route.name, route])
     )
     const directories = Object.entries(menu.items || {}).map(([key, item]) => {
+      const route = routes[key] || {
+        name: key,
+        locale: menu.locale,
+        route: menu.route + '/' + key
+      }
       return {
-        ...routes[key],
+        ...route,
         ...item
       }
     })

--- a/packages/nextra-theme-docs/src/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/sidebar.tsx
@@ -13,7 +13,7 @@ import Search from './search'
 import Flexsearch from './flexsearch'
 import { useConfig } from './config'
 import getHeadingText from './utils/get-heading-text'
-import { Item, PageItem } from './utils/normalize-pages'
+import { Item, MenuItem, PageItem } from './utils/normalize-pages'
 import LocaleSwitch from './locale-switch'
 import ThemeSwitch from './theme-switch'
 import { ArrowRightIcon } from 'nextra/icons'
@@ -23,7 +23,7 @@ import renderComponent from './utils/render-component'
 const TreeState: Record<string, boolean> = {}
 
 interface FolderProps {
-  item: PageItem | Item
+  item: PageItem | MenuItem | Item
   anchors: string[]
 }
 
@@ -60,7 +60,7 @@ function FolderImpl({ item, anchors }: FolderProps) {
         if (clickedToggleIcon) {
           e.preventDefault()
         }
-        if (item.withIndexPage) {
+        if ((item as Item).withIndexPage) {
           // If it's focused, we toggle it. Otherwise always open it.
           if (active || clickedToggleIcon) {
             TreeState[item.route] = !open
@@ -90,18 +90,49 @@ function FolderImpl({ item, anchors }: FolderProps) {
     </a>
   )
 
+  if (item.type === 'menu') {
+    const menu = item as MenuItem
+    const routes = Object.fromEntries(
+      (menu.children || []).map(route => [route.name, route])
+    )
+    const directories = Object.entries(menu.items || {}).map(([key, item]) => {
+      return {
+        ...routes[key],
+        ...item
+      }
+    })
+
+    return (
+      <li className={cn({ open, active })}>
+        {link}
+        <Collapse open={open}>
+          <Menu
+            submenu
+            directories={directories}
+            base={item.route}
+            anchors={anchors}
+          />
+        </Collapse>
+      </li>
+    )
+  }
+
   return (
     <li className={cn({ open, active })}>
-      {item.withIndexPage ? <Link href={item.route}>{link}</Link> : link}
+      {(item as Item).withIndexPage ? (
+        <Link href={item.route}>{link}</Link>
+      ) : (
+        link
+      )}
       <Collapse open={open}>
-        {Array.isArray(item.children) && (
+        {Array.isArray(item.children) ? (
           <Menu
             submenu
             directories={item.children}
             base={item.route}
             anchors={anchors}
           />
-        )}
+        ) : null}
       </Collapse>
     </li>
   )
@@ -241,7 +272,10 @@ function Menu({ directories, anchors, submenu }: MenuProps) {
   return (
     <ul>
       {directories.map(item => {
-        if (item.children && (item.children.length || !item.withIndexPage)) {
+        if (
+          item.type === 'menu' ||
+          (item.children && (item.children.length || !item.withIndexPage))
+        ) {
           return <Folder key={item.name} item={item} anchors={anchors} />
         }
         return (
@@ -258,7 +292,7 @@ function Menu({ directories, anchors, submenu }: MenuProps) {
 }
 
 interface SideBarProps {
-  directories: PageItem[]
+  docsDirectories: PageItem[]
   flatDirectories: Item[]
   fullDirectories: Item[]
   asPopover?: boolean
@@ -269,7 +303,7 @@ interface SideBarProps {
 
 const emptyHeading: any[] = []
 export default function Sidebar({
-  directories,
+  docsDirectories,
   flatDirectories,
   fullDirectories,
   asPopover = false,
@@ -337,7 +371,8 @@ export default function Sidebar({
             </div>
             <div className="hidden md:block">
               <Menu
-                directories={directories}
+                // The sidebar menu, shows only the docs directories.
+                directories={docsDirectories}
                 anchors={
                   // When the viewport size is larger than `md`, hide the anchors in
                   // the sidebar when `floatTOC` is enabled.
@@ -347,6 +382,7 @@ export default function Sidebar({
             </div>
             <div className="md:hidden">
               <Menu
+                // The mobile dropdown menu, shows all the directories.
                 directories={fullDirectories}
                 anchors={
                   // Always show the anchor links on mobile (`md`).

--- a/packages/nextra-theme-docs/src/utils/normalize-pages.tsx
+++ b/packages/nextra-theme-docs/src/utils/normalize-pages.tsx
@@ -166,7 +166,7 @@ export default function normalizePages({
         metaKeyIndex = index
       }
 
-      const extendedItem = index !== -1 ? { ...meta[item.name], ...item } : item
+      const extendedItem = index === -1 ? item : { ...meta[item.name], ...item }
       items.push(extendedItem)
       return items
     })

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -7,6 +7,40 @@ exports[`Page Process > pageMap en-US 1`] = `
       "children": [
         {
           "locale": "en-US",
+          "name": "a-page",
+          "route": "/about/a-page",
+        },
+        {
+          "locale": "en-US",
+          "name": "acknowledgement",
+          "route": "/about/acknowledgement",
+        },
+        {
+          "locale": "en-US",
+          "meta": {
+            "a-page": {
+              "hidden": true,
+              "title": "A Page",
+              "type": "page",
+            },
+            "acknowledgement": "🧩 Acknowledgement",
+            "team": "👥 Team",
+          },
+          "name": "meta.json",
+        },
+        {
+          "locale": "en-US",
+          "name": "team",
+          "route": "/about/team",
+        },
+      ],
+      "name": "about",
+      "route": "/about",
+    },
+    {
+      "children": [
+        {
+          "locale": "en-US",
           "meta": {
             "swr-v1": {
               "theme": {
@@ -336,6 +370,26 @@ exports[`Page Process > pageMap en-US 1`] = `
     {
       "locale": "en-US",
       "meta": {
+        "about": {
+          "items": {
+            "a-page": {
+              "title": "A Page",
+            },
+            "acknowledgement": {
+              "title": "Acknowledgement",
+            },
+            "contributors": {
+              "href": "https://github.com/vercel/swr/graphs/contributors",
+              "newWindow": true,
+              "title": "Contributors",
+            },
+            "team": {
+              "title": "Team",
+            },
+          },
+          "title": "About",
+          "type": "menu",
+        },
         "blog": {
           "theme": {
             "breadcrumb": false,
@@ -385,6 +439,40 @@ exports[`Page Process > pageMap en-US 1`] = `
 exports[`Page Process > pageMap zh-CN 1`] = `
 [
   [
+    {
+      "children": [
+        {
+          "locale": "en-US",
+          "name": "a-page",
+          "route": "/about/a-page",
+        },
+        {
+          "locale": "en-US",
+          "name": "acknowledgement",
+          "route": "/about/acknowledgement",
+        },
+        {
+          "locale": "en-US",
+          "meta": {
+            "a-page": {
+              "hidden": true,
+              "title": "A Page",
+              "type": "page",
+            },
+            "acknowledgement": "🧩 Acknowledgement",
+            "team": "👥 Team",
+          },
+          "name": "meta.json",
+        },
+        {
+          "locale": "en-US",
+          "name": "team",
+          "route": "/about/team",
+        },
+      ],
+      "name": "about",
+      "route": "/about",
+    },
     {
       "children": [
         {


### PR DESCRIPTION
This is a new navbar item type that shows a dropdown menu:

<img width="357" alt="CleanShot 2022-07-28 at 00 36 47@2x" src="https://user-images.githubusercontent.com/3676859/181384459-15ed7afa-01ba-4b87-a5b8-ad408bd50cc3.png">

To-do:
- [x] ~Nested menu items~ We can do it in the future. This requires auto-positioning of popup menus.
- [x] Page menu items
- [x] Mobile style
- [x] A11y