### PR TITLE
chore: remove redundant check for `MARKDOWN_EXTENSION_REGEX.test(filename)` in loader

### DIFF
--- a/.changeset/silent-games-nail.md
+++ b/.changeset/silent-games-nail.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+chore: remove redundant check for `MARKDOWN_EXTENSION_REGEX.test(filename)` in loader

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -11,11 +11,7 @@ import { parseFileName } from './utils'
 import { compileMdx } from './compile'
 import { getPageMap, findPagesDir } from './page-map'
 import { collectFiles, collectMdx } from './plugin'
-import {
-  MARKDOWN_EXTENSION_REGEX,
-  IS_PRODUCTION,
-  DEFAULT_LOCALE
-} from './constants'
+import { IS_PRODUCTION, DEFAULT_LOCALE } from './constants'
 
 // TODO: create this as a webpack plugin.
 const indexContentEmitted = new Set<string>()
@@ -133,8 +129,7 @@ async function loader(
   )
 
   if (unstable_flexsearch) {
-    // We only add .MD and .MDX contents
-    if (MARKDOWN_EXTENSION_REGEX.test(filename) && data.searchable !== false) {
+    if (data.searchable !== false) {
       addPage({
         fileLocale: fileLocale || DEFAULT_LOCALE,
         route,


### PR DESCRIPTION
because filename will be always `md`/`mdx` file
https://github.com/shuding/nextra/blob/417918abb9c87f6862a6f24115ee092e03d49f5b/packages/nextra/src/index.js#L44