### PR TITLE
[nextra-theme-docs]: fix `Warning: A title element received an array` and possible `[object Object]` in title

### DIFF
--- a/.changeset/olive-frogs-greet.md
+++ b/.changeset/olive-frogs-greet.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+[nextra-theme-docs]: fix `Warning: A title element received an array` and possible `[object Object]` in title

--- a/examples/swr-site/theme.config.js
+++ b/examples/swr-site/theme.config.js
@@ -32,7 +32,9 @@ const TITLE_WITH_TRANSLATIONS = {
 export default {
   github: "https://github.com/vercel/swr",
   docsRepositoryBase: "https://github.com/vercel/swr-site/blob/master/pages",
-  titleSuffix: " – SWR",
+  titleSuffix({ locale }) {
+    return ` – SWR (${locale})`
+  },
   search: true,
   unstable_flexsearch: true,
   floatTOC: true,

--- a/packages/nextra-theme-docs/src/head.tsx
+++ b/packages/nextra-theme-docs/src/head.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import NextHead from 'next/head'
 import { useTheme } from 'next-themes'
 
@@ -16,23 +16,32 @@ export default function Head({ title, locale, meta }: HeadProps) {
   const config = useConfig()
   const { theme, systemTheme } = useTheme()
   const renderedTheme = theme === 'system' ? systemTheme : theme
-  const [mounted, setMounted] = React.useState(false)
-  React.useEffect(() => setMounted(true), [])
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+
+  const suffix = renderComponent(
+    // @ts-expect-error -- Type 'string' is not assignable to type 'ReactElement<any, any>'
+    config.titleSuffix,
+    { locale, config, title, meta },
+    true
+  )
 
   return (
     <NextHead>
-      <title>
-        {title}
-        {renderComponent(config.titleSuffix, { locale, config, title, meta })}
-      </title>
-      {renderComponent(config.head, { locale, config, title, meta }, true)}
+      <title>{title + (suffix || '')}</title>
+      {renderComponent(config.head, { locale, config, title, meta })}
       {config.unstable_faviconGlyph ? (
         <link
           rel="icon"
           href={`data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text x='50' y='.9em' font-size='90' text-anchor='middle'>${config.unstable_faviconGlyph}</text><style>text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";fill:black}@media(prefers-color-scheme:dark){text{fill:white}}</style></svg>`}
         />
       ) : null}
-      {!mounted ? (
+      {mounted ? (
+        <meta
+          name="theme-color"
+          content={renderedTheme === 'dark' ? '#111' : '#fff'}
+        />
+      ) : (
         <>
           <meta
             name="theme-color"
@@ -45,11 +54,6 @@ export default function Head({ title, locale, meta }: HeadProps) {
             media="(prefers-color-scheme: dark)"
           />
         </>
-      ) : (
-        <meta
-          name="theme-color"
-          content={renderedTheme === 'dark' ? '#111111' : '#ffffff'}
-        />
       )}
       <meta
         name="viewport"

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -9,15 +9,14 @@ export interface DocsThemeConfig {
     | React.FC<PropsWithChildren<{ locale: string }>>
   docsRepositoryBase?: string
   titleSuffix?:
-    | React.ReactNode
-    | React.FC<
-        PropsWithChildren<{
-          locale: string
-          config: DocsThemeConfig
-          title: string
-          meta: Meta
-        }>
-      >
+    | string
+    // Can't be React component, otherwise will get Warning: A title element received an array with more than 1 element as children.
+    | ((props: {
+        locale: string
+        config: DocsThemeConfig
+        title: string
+        meta: Meta
+      }) => string)
   nextLinks?: boolean
   prevLinks?: boolean
   search?: boolean
@@ -73,6 +72,7 @@ export interface DocsThemeConfig {
       >
   feedbackLabels?: string
   customSearch?: React.ReactNode | false
+  // Can't be React component
   searchPlaceholder?: string | ((props: { locale: string }) => string)
   projectChatLink?: string
   projectChatLinkIcon?: React.FC<PropsWithChildren<{ locale: string }>>

--- a/packages/nextra-theme-docs/src/utils/render-component.tsx
+++ b/packages/nextra-theme-docs/src/utils/render-component.tsx
@@ -1,16 +1,14 @@
-import React, { PropsWithChildren } from 'react'
+import React, { FC, PropsWithChildren, ReactNode } from 'react'
 
-const renderComponent = <T,>(
-  ComponentOrNode: React.FC<PropsWithChildren<T>> | React.ReactNode,
+function renderComponent<T>(
+  ComponentOrNode: FC<PropsWithChildren<T>> | ReactNode,
   props: PropsWithChildren<T>,
-  functionOnly?: boolean
-) => {
+  functionOnly = false
+) {
   if (!ComponentOrNode) return null
-  if (typeof ComponentOrNode === 'function') {
-    if (functionOnly) return ComponentOrNode(props)
-    return <ComponentOrNode {...props} />
-  }
-  return ComponentOrNode
+  if (typeof ComponentOrNode !== 'function') return ComponentOrNode
+  if (functionOnly) return ComponentOrNode(props)
+  return <ComponentOrNode {...props} />
 }
 
 export default renderComponent


### PR DESCRIPTION
fixes console warning
![image](https://user-images.githubusercontent.com/7361780/181811582-a135c20a-927e-448e-a764-703243c95da3.png)
and possible issue when declaring `titleSuffix` as function
![image](https://user-images.githubusercontent.com/7361780/181811612-c952459b-7853-4274-8d5b-c1ca88b1a9cc.png)
