### PR TITLE
[nextra-theme-docs]: use new opacity modifier syntax for tailwindcss

### DIFF
--- a/.changeset/quick-cobras-end.md
+++ b/.changeset/quick-cobras-end.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+[nextra-theme-docs]: use new opacity modifier syntax for tailwindcss

--- a/packages/nextra-theme-docs/src/callout.tsx
+++ b/packages/nextra-theme-docs/src/callout.tsx
@@ -2,12 +2,12 @@ import React, { PropsWithChildren } from 'react'
 
 const themes = {
   default:
-    'bg-orange-50 border border-orange-100 text-orange-800 dark:text-orange-300 dark:bg-orange-400 dark:border-orange-400 dark:bg-opacity-20 dark:border-opacity-30',
+    'bg-orange-50 border border-orange-100 text-orange-800 dark:text-orange-300 dark:bg-orange-400/20 dark:border-orange-400/30',
   error:
-    'bg-red-100 border border-red-200 text-red-900 dark:text-red-200 dark:bg-red-900 dark:bg-opacity-30 dark:border-opacity-30',
-  info: 'bg-blue-100 border border-blue-200 text-blue-900 dark:text-blue-200 dark:bg-blue-900 dark:bg-opacity-30 dark:border-opacity-30',
+    'bg-red-100 border border-red-200 text-red-900 dark:text-red-200 dark:bg-red-900/30 dark:border-red-200/30',
+  info: 'bg-blue-100 border border-blue-200 text-blue-900 dark:text-blue-200 dark:bg-blue-900/30 dark:border-blue-200/30',
   warning:
-    'bg-yellow-50 border border-yellow-100 text-yellow-900 dark:text-yellow-200 dark:bg-yellow-700 dark:bg-opacity-30'
+    'bg-yellow-50 border border-yellow-100 text-yellow-900 dark:text-yellow-200 dark:bg-yellow-700/30'
 }
 
 interface CalloutProps {

--- a/packages/nextra-theme-docs/src/css/styles.css
+++ b/packages/nextra-theme-docs/src/css/styles.css
@@ -86,7 +86,7 @@ blockquote:not(:first-child),
     .nextra-menu-icon {
       @apply select-none rounded outline-none;
       &:active {
-        @apply bg-gray-400 bg-opacity-20;
+        @apply bg-gray-400/20;
       }
     }
     .nextra-menu-icon svg {
@@ -156,7 +156,7 @@ blockquote:not(:first-child),
       li.active > a,
       li.active > a:hover {
         @apply bg-primary-50 font-bold text-primary-500;
-        @apply dark:bg-primary-500 dark:bg-opacity-10 dark:text-primary-500;
+        @apply dark:bg-primary-500/10 dark:text-primary-500;
       }
       @media (prefers-contrast: more) {
         li.active > a {
@@ -172,7 +172,7 @@ blockquote:not(:first-child),
         -webkit-touch-callout: none;
         &:hover {
           @apply bg-gray-100 text-gray-900;
-          @apply dark:bg-primary-100 dark:bg-opacity-5 dark:text-gray-50;
+          @apply dark:bg-primary-100/5 dark:text-gray-50;
         }
         @media (prefers-contrast: more) {
           & {
@@ -350,7 +350,7 @@ blockquote:not(:first-child),
     }
   }
   article pre {
-    @apply border border-primary-900 border-opacity-20 contrast-150 dark:border-primary-100 dark:border-opacity-40;
+    @apply border border-primary-900/20 contrast-150 dark:border-primary-100/40;
   }
   .nextra-callout {
     @apply border-current dark:!border-current;
@@ -417,7 +417,7 @@ article {
     @apply mt-10 text-3xl font-semibold tracking-tight;
     @apply border-b pb-1;
     .dark & {
-      @apply border-primary-100 border-opacity-10;
+      @apply border-primary-100/10;
     }
   }
   h3 {
@@ -452,7 +452,7 @@ article {
     @apply no-underline;
   }
   a {
-    @apply ring-primary-500 ring-opacity-30 focus:outline-none focus-visible:ring;
+    @apply ring-primary-500/30 focus:outline-none focus-visible:ring;
   }
   hr {
     @apply my-8;
@@ -575,8 +575,8 @@ article {
 /* Search */
 .nextra-search {
   input {
-    @apply bg-black bg-opacity-[.03] text-sm text-gray-900;
-    @apply dark:bg-gray-50 dark:bg-opacity-10 dark:text-gray-300;
+    @apply bg-black/[.03] text-sm text-gray-900;
+    @apply dark:bg-gray-50/10 dark:text-gray-300;
     @apply dark:border-gray-800;
   }
   input::placeholder {
@@ -597,7 +597,7 @@ article {
     }
 
     /* Using bg-white as background-color when the browser didn't support backdrop-filter */
-    @apply bg-white text-gray-100 ring-1 ring-black ring-opacity-5;
+    @apply bg-white text-gray-100 ring-1 ring-black/5;
     li {
       @apply mx-2.5 break-words rounded-md px-2.5 py-2 text-gray-800;
       .highlight {
@@ -606,19 +606,19 @@ article {
     }
     li.active,
     a:focus li {
-      @apply bg-primary-400 bg-opacity-[.1] text-primary-500;
+      @apply bg-primary-400/10 text-primary-500;
     }
     .nextra-search-section {
-      @apply border-b border-black border-opacity-10;
+      @apply border-b border-black/10;
       .dark & {
-        @apply border-b border-white border-opacity-20;
+        @apply border-b border-white/20;
       }
     }
   }
   .dark & {
     /* Using bg-white as background-color when the browser didn't support backdrop-filter */
     ul {
-      @apply bg-neutral-900 text-gray-100 ring-white ring-opacity-10;
+      @apply bg-neutral-900 text-gray-100 ring-white/10;
       li {
         @apply text-gray-300;
         .highlight {
@@ -627,7 +627,7 @@ article {
       }
       li.active,
       a:focus li {
-        @apply bg-primary-500 bg-opacity-[.1] text-primary-500;
+        @apply bg-primary-500/10 text-primary-500;
       }
     }
   }
@@ -636,11 +636,11 @@ article {
   ) {
     ul {
       backdrop-filter: blur(16px);
-      @apply bg-opacity-[.7];
+      @apply bg-opacity-70;
     }
     .dark & {
       ul {
-        @apply bg-opacity-[.8];
+        @apply bg-opacity-80;
       }
     }
   }
@@ -713,7 +713,7 @@ table tr {
 }
 table tr:nth-child(2n) {
   @apply bg-gray-100;
-  @apply dark:bg-gray-600 dark:bg-opacity-20;
+  @apply dark:bg-gray-600/20;
 }
 table tr th {
   @apply font-semibold;

--- a/packages/nextra-theme-docs/src/flexsearch.jsx
+++ b/packages/nextra-theme-docs/src/flexsearch.jsx
@@ -380,7 +380,7 @@ export default function Search() {
             setSearch(e.target.value)
             setShow(true)
           }}
-          className="block w-full appearance-none rounded-lg px-3 py-2 leading-tight transition-colors hover:bg-opacity-5 focus:bg-white focus:outline-none focus:ring-1 focus:ring-gray-200 dark:focus:bg-dark dark:focus:ring-gray-100 dark:focus:ring-opacity-20"
+          className="block w-full appearance-none rounded-lg px-3 py-2 leading-tight transition-colors focus:bg-white focus:outline-none focus:ring-1 focus:ring-gray-200 dark:focus:bg-dark dark:focus:ring-gray-100/20"
           type="search"
           placeholder={renderComponent(
             config.searchPlaceholder,
@@ -399,7 +399,7 @@ export default function Search() {
         />
         {!renderList && (
           <div className="pointer-events-none absolute inset-y-0 right-0 hidden select-none py-1.5 pr-1.5 sm:flex">
-            <kbd className="inline-flex items-center rounded border bg-white px-1.5 font-mono text-sm font-medium text-gray-400 dark:border-gray-100 dark:border-opacity-20 dark:bg-dark dark:bg-opacity-50 dark:text-gray-500">
+            <kbd className="inline-flex items-center rounded border bg-white px-1.5 font-mono text-sm font-medium text-gray-400 dark:border-gray-100/20 dark:bg-dark/50 dark:text-gray-500">
               /
             </kbd>
           </div>

--- a/packages/nextra-theme-docs/src/search.tsx
+++ b/packages/nextra-theme-docs/src/search.tsx
@@ -147,7 +147,7 @@ const Search = ({ directories = [] }: SearchProps) => {
             setSearch(e.target.value)
             setShow(true)
           }}
-          className="block w-full appearance-none rounded-lg bg-black bg-opacity-[.03] px-3 py-2 leading-tight transition-colors hover:bg-opacity-5 focus:outline-none focus:ring"
+          className="block w-full appearance-none rounded-lg bg-black/[.03] px-3 py-2 leading-tight transition-colors hover:bg-black/5 focus:outline-none focus:ring"
           type="search"
           placeholder={placeholder}
           onKeyDown={handleKeyDown}

--- a/packages/nextra-theme-docs/src/select.tsx
+++ b/packages/nextra-theme-docs/src/select.tsx
@@ -23,8 +23,8 @@ export default function Menu({ options, selected, onChange }: MenuProps) {
             className={cn(
               'h-7 w-full cursor-pointer rounded-md px-2 text-left text-xs font-medium text-gray-600 transition-colors focus:outline-none dark:text-gray-400',
               open
-                ? 'bg-gray-200 text-gray-900 dark:bg-primary-100 dark:bg-opacity-10 dark:text-gray-50'
-                : 'hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-primary-100 dark:hover:bg-opacity-5 dark:hover:text-gray-50'
+                ? 'bg-gray-200 text-gray-900 dark:bg-primary-100/10 dark:text-gray-50'
+                : 'hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-primary-100/5 dark:hover:text-gray-50'
             )}
           >
             {selected.name}
@@ -38,7 +38,7 @@ export default function Menu({ options, selected, onChange }: MenuProps) {
           >
             <Listbox.Options
               className={
-                'menu absolute bottom-[130%] z-20 mt-1 max-h-64 min-w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-neutral-800 dark:ring-white dark:ring-opacity-20'
+                'menu absolute bottom-[130%] z-20 mt-1 max-h-64 min-w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-neutral-800 dark:ring-white/20'
               }
             >
               {options.map(option => (
@@ -49,7 +49,7 @@ export default function Menu({ options, selected, onChange }: MenuProps) {
                     cn(
                       option.key === selected.key ? '' : '',
                       active
-                        ? 'bg-primary-50 text-primary-500 dark:bg-primary-500 dark:bg-opacity-10'
+                        ? 'bg-primary-50 text-primary-500 dark:bg-primary-500/10'
                         : 'text-gray-800 dark:text-gray-100',
                       'relative cursor-pointer select-none whitespace-nowrap py-1.5 pl-3 pr-9'
                     )

--- a/packages/nextra-theme-docs/src/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/sidebar.tsx
@@ -81,7 +81,7 @@ function FolderImpl({ item, anchors }: FolderProps) {
         <ArrowRightIcon
           height="1em"
           className={cn(
-            'ml-2 h-[18px] min-w-[18px] rounded-sm p-[2px] hover:bg-gray-800 hover:bg-opacity-5 dark:hover:bg-gray-100 dark:hover:bg-opacity-5',
+            'ml-2 h-[18px] min-w-[18px] rounded-sm p-[2px] hover:bg-gray-800/5 dark:hover:bg-gray-100/5',
             '[&>path]:origin-center [&>path]:transition-transform',
             open && '[&>path]:rotate-90'
           )}
@@ -131,7 +131,7 @@ function Separator({ title, topLevel }: SeparatorProps) {
             : title}
         </div>
       ) : (
-        <hr className="mx-2 border-t border-gray-200 dark:border-primary-100 dark:border-opacity-10" />
+        <hr className="mx-2 border-t border-gray-200 dark:border-primary-100/10" />
       )}
     </li>
   )


### PR DESCRIPTION
Tailwind recommends using new opacity modifier syntax https://tailwindcss.com/docs/upgrade-guide#new-opacity-modifier-syntax

<img width="784" alt="image" src="https://user-images.githubusercontent.com/7361780/181901870-fbb80d62-0756-4608-97c2-bc76b0d92a19.png">
