### PR TITLE
Fix flexsearch option being overridden

### DIFF
--- a/.changeset/lemon-bags-check.md
+++ b/.changeset/lemon-bags-check.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+Fix flexsearch option being overridden

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -282,8 +282,7 @@ const Content = ({
 const createLayout = (opts: PageOpts, config: DocsThemeConfig) => {
   const extendedConfig = {
     ...defaultConfig,
-    ...config,
-    unstable_flexsearch: opts.unstable_flexsearch
+    ...config
   }
   const nextThemes = extendedConfig.nextThemes || {}
   const Page = ({ children }: { children: ReactNode }): ReactNode => children

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -282,7 +282,8 @@ const Content = ({
 const createLayout = (opts: PageOpts, config: DocsThemeConfig) => {
   const extendedConfig = {
     ...defaultConfig,
-    ...config
+    ...config,
+    unstable_flexsearch: opts.unstable_flexsearch
   }
   const nextThemes = extendedConfig.nextThemes || {}
   const Page = ({ children }: { children: ReactNode }): ReactNode => children

--- a/packages/nextra/src/index.js
+++ b/packages/nextra/src/index.js
@@ -7,7 +7,7 @@ const MARKDOWN_EXTENSIONS = ['md', 'mdx']
 const nextra = (...config) =>
   function withNextra(nextConfig = {}) {
     const nextraConfig =
-      typeof config[0] === "string"
+      typeof config[0] === 'string'
         ? {
             theme: config[0],
             themeConfig: config[1]

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -100,10 +100,6 @@ async function loader(
   // Extract frontMatter information if it exists
   const { data: meta, content } = grayMatter(source)
 
-  if (IS_PRODUCTION && indexContentEmitted.has(filename)) {
-    unstable_flexsearch = false
-  }
-
   const { result, headings, structurizedData, hasJsxInH1 } = await compileMdx(
     content,
     mdxOptions,
@@ -120,7 +116,9 @@ async function loader(
     defaultLocale
   )
 
-  if (unstable_flexsearch) {
+  const skipFlexsearchIndexing =
+    IS_PRODUCTION && indexContentEmitted.has(filename)
+  if (unstable_flexsearch && !skipFlexsearchIndexing) {
     if (meta.searchable !== false) {
       addPage({
         fileLocale: fileLocale || DEFAULT_LOCALE,
@@ -130,7 +128,6 @@ async function loader(
         structurizedData
       })
     }
-
     indexContentEmitted.add(filename)
   }
 


### PR DESCRIPTION
Closes #594. I noticed that the flexsearch option being overridden here:

<img width="809" alt="CleanShot 2022-08-01 at 14 37 33@2x" src="https://user-images.githubusercontent.com/3676859/182149380-4b2ff10f-97fb-458e-9dbc-a63688360968.png">

Which is not needed, we should just remove it.