### PR TITLE
change(blog): add missing class names to override styles

### DIFF
--- a/.changeset/witty-tools-repair.md
+++ b/.changeset/witty-tools-repair.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-blog': patch
+---
+
+add missing class names to override styles

--- a/packages/nextra-theme-blog/src/mdx-theme.tsx
+++ b/packages/nextra-theme-blog/src/mdx-theme.tsx
@@ -42,7 +42,7 @@ const createHeaderLink =
     return (
       <Tag className={`subheading-${Tag}`} {...props}>
         <span className="subheading-anchor -mt-8" id={id} />
-        <a className="subheading-title" href={`#${id}`}>
+        <a href={`#${id}`}>
           {children}
         </a>
       </Tag>

--- a/packages/nextra-theme-blog/src/mdx-theme.tsx
+++ b/packages/nextra-theme-blog/src/mdx-theme.tsx
@@ -40,9 +40,9 @@ const createHeaderLink =
   (Tag: `h${2 | 3 | 4 | 5 | 6}`) =>
   ({ children, id, ...props }: ComponentProps<'h2'>): ReactElement => {
     return (
-      <Tag {...props}>
+      <Tag className={`subheading-${Tag}`} {...props}>
         <span className="subheading-anchor -mt-8" id={id} />
-        <a href={`#${id}`}>
+        <a className="subheading-title" href={`#${id}`}>
           {children}
         </a>
       </Tag>

--- a/packages/nextra-theme-blog/src/posts-layout.tsx
+++ b/packages/nextra-theme-blog/src/posts-layout.tsx
@@ -32,7 +32,7 @@ export const PostsLayout = ({ children }: { children: ReactNode }) => {
 
     return (
       <div key={post.route} className="post-item">
-        <h3 className="post-item-heading">
+        <h3>
           <Link href={post.route} passHref>
             <a className="post-item-title !no-underline">{postTitle}</a>
           </Link>

--- a/packages/nextra-theme-blog/src/posts-layout.tsx
+++ b/packages/nextra-theme-blog/src/posts-layout.tsx
@@ -49,7 +49,7 @@ export const PostsLayout = ({ children }: { children: ReactNode }) => {
         )}
         {date && (
           <time
-            className="post-item-date text-sm text-gray-300"
+            className="text-sm text-gray-300"
             dateTime={date.toISOString()}
           >
             {date.toDateString()}

--- a/packages/nextra-theme-blog/src/posts-layout.tsx
+++ b/packages/nextra-theme-blog/src/posts-layout.tsx
@@ -12,7 +12,9 @@ export const PostsLayout = ({ children }: { children: ReactNode }) => {
   const { config, opts } = useBlogContext()
   const { posts } = collectPostsAndNavs({ config, opts })
   const router = useRouter()
-  const { meta: { type } } = opts
+  const {
+    meta: { type }
+  } = opts
   const tagName = type === 'tag' ? router.query.tag : null
   const postList = posts.map(post => {
     if (tagName) {
@@ -29,24 +31,27 @@ export const PostsLayout = ({ children }: { children: ReactNode }) => {
     const description = post.frontMatter?.description
 
     return (
-      <div key={post.route}>
-        <h3>
+      <div key={post.route} className="post-item">
+        <h3 className="post-item-heading">
           <Link href={post.route} passHref>
-            <a className="!no-underline">{postTitle}</a>
+            <a className="post-item-title !no-underline">{postTitle}</a>
           </Link>
         </h3>
         {description && (
-          <p className="mb-2 text-gray-400">
+          <p className="post-item-description mb-2 text-gray-400">
             {description}
             {config.readMore && (
               <Link href={post.route} passHref>
-                <a className="ml-1">{config.readMore}</a>
+                <a className="post-item-more ml-2">{config.readMore}</a>
               </Link>
             )}
           </p>
         )}
         {date && (
-          <time className="text-sm text-gray-300" dateTime={date.toISOString()}>
+          <time
+            className="post-item-date text-sm text-gray-300"
+            dateTime={date.toISOString()}
+          >
             {date.toDateString()}
           </time>
         )}

--- a/packages/nextra-theme-blog/src/posts-layout.tsx
+++ b/packages/nextra-theme-blog/src/posts-layout.tsx
@@ -38,7 +38,7 @@ export const PostsLayout = ({ children }: { children: ReactNode }) => {
           </Link>
         </h3>
         {description && (
-          <p className="post-item-description mb-2 text-gray-400">
+          <p className="mb-2 text-gray-400">
             {description}
             {config.readMore && (
               <Link href={post.route} passHref>

--- a/packages/nextra-theme-blog/src/posts-layout.tsx
+++ b/packages/nextra-theme-blog/src/posts-layout.tsx
@@ -34,7 +34,7 @@ export const PostsLayout = ({ children }: { children: ReactNode }) => {
       <div key={post.route} className="post-item">
         <h3>
           <Link href={post.route} passHref>
-            <a className="post-item-title !no-underline">{postTitle}</a>
+            <a className="!no-underline">{postTitle}</a>
           </Link>
         </h3>
         {description && (


### PR DESCRIPTION
Even though these classes are not used within nextra for styling, these are still useful for users to be able to target these classes and override the styles.

cc @B2o5T 