### PR TITLE
change(blog): improve tags styling

### DIFF
--- a/.changeset/friendly-singers-provide.md
+++ b/.changeset/friendly-singers-provide.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-blog': patch
+---
+
+improve tags styling

--- a/packages/nextra-theme-blog/src/meta.tsx
+++ b/packages/nextra-theme-blog/src/meta.tsx
@@ -23,7 +23,7 @@ export default function Meta({
 
   return (
     <div className="mb-8 flex items-center gap-3">
-      <div className="flex flex-1 flex-wrap items-center gap-1 text-gray-400">
+      <div className="flex flex-1 flex-wrap items-center gap-1 text-gray-400 not-prose">
         {author}
         {author && date && ','}
         {date && (
@@ -39,17 +39,16 @@ export default function Meta({
                 select-none
                 rounded-md
                 px-1
+                transition-colors
                 text-sm
-                !no-underline
+                text-gray-400
+                hover:text-gray-500
+                dark:text-gray-300
+                dark:hover:text-gray-200
                 bg-gray-200
-                !text-gray-400
-                hover:!bg-gray-300
-                hover:!text-gray-500
-                active:bg-gray-400
+                hover:bg-gray-300
                 dark:bg-gray-600
-                dark:!text-gray-300
-                dark:hover:!bg-gray-700
-                dark:hover:!text-gray-200
+                dark:hover:bg-gray-700
               "
             >
               {t}

--- a/packages/nextra-theme-blog/src/meta.tsx
+++ b/packages/nextra-theme-blog/src/meta.tsx
@@ -38,16 +38,18 @@ export default function Meta({
               className="
                 select-none
                 rounded-md
-                bg-gray-200
                 px-1
                 text-sm
-                !text-gray-400
                 !no-underline
-                hover:!text-gray-800
+                bg-gray-200
+                !text-gray-400
+                hover:!bg-gray-300
+                hover:!text-gray-500
                 active:bg-gray-400
-                dark:bg-gray-400
-                dark:!text-gray-100
-                dark:hover:!text-gray-800
+                dark:bg-gray-600
+                dark:!text-gray-300
+                dark:hover:!bg-gray-700
+                dark:hover:!text-gray-200
               "
             >
               {t}


### PR DESCRIPTION
I tried to improve tags' styling; specially in dark-mode where the contrast was very low. Let me know what do you all think :)

### Before

https://user-images.githubusercontent.com/24727447/183091115-7a188744-d1b4-42e3-a752-9e3563bbdc89.mp4

### After

https://user-images.githubusercontent.com/24727447/183091149-dea48d27-2289-4cce-bf73-ec687907ce62.mp4

---

Supersedes #504
