### PR TITLE
Fix `sideEffects` in the docs theme

### DIFF
--- a/.changeset/chatty-gifts-dress.md
+++ b/.changeset/chatty-gifts-dress.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix sideEffects in package.json

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -9,7 +9,9 @@
     "dist",
     "style.css"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/polyfill.ts"
+  ],
   "typesVersions": {
     "*": {
       ".": [

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -9,6 +9,7 @@ import { SkipNavContent } from '@reach/skip-nav'
 import { ThemeProvider } from 'next-themes'
 import cn from 'classnames'
 
+import './polyfill'
 import {
   Head,
   Navbar,
@@ -27,7 +28,6 @@ import { getFSRoute } from './utils/get-fs-route'
 import { MenuContext } from './utils/menu-context'
 import normalizePages from './utils/normalize-pages'
 import { DocsThemeConfig, PageTheme } from './types'
-import './polyfill'
 import renderComponent from './utils/render-component'
 
 let resizeObserver: ResizeObserver


### PR DESCRIPTION
There's actually one import includes side effects, everything inside `dist` should be good.

<img width="1092" alt="CleanShot 2022-08-08 at 01 28 06@2x" src="https://user-images.githubusercontent.com/3676859/183315377-fc4f637e-79a8-4eec-b9d5-e0589b94eb1d.png">
