### PR TITLE
Fix body overflow under `layout: raw`

### DIFF
--- a/.changeset/seven-bobcats-battle.md
+++ b/.changeset/seven-bobcats-battle.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix body overflow

--- a/examples/swr-site/pages/about/meta.en-US.json
+++ b/examples/swr-site/pages/about/meta.en-US.json
@@ -4,6 +4,9 @@
   "a-page": {
     "title": "A Page",
     "type": "page",
-    "hidden": true
+    "hidden": true,
+    "theme": {
+      "layout": "raw"
+    }
   }
 }

--- a/examples/swr-site/pages/meta.en-US.json
+++ b/examples/swr-site/pages/meta.en-US.json
@@ -2,8 +2,7 @@
   "index": {
     "title": "Introduction",
     "type": "page",
-    "hidden": true,
-    "theme": {}
+    "hidden": true
   },
   "docs": {
     "title": "Docs",

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -119,7 +119,7 @@ const Body = ({
           {navLinks}
         </article>
       ) : themeContext.layout === 'raw' ? (
-        <div className="nextra-body full expand relative overflow-x-hidden">
+        <div className="nextra-body full relative overflow-x-hidden">
           {children}
         </div>
       ) : (
@@ -225,7 +225,12 @@ const InnerLayout = ({
           />
         ) : null}
         <ActiveAnchor>
-          <div className="mx-auto flex w-full max-w-[90rem] flex-1 items-stretch">
+          <div
+            className={cn(
+              'mx-auto flex w-full flex-1 items-stretch',
+              themeContext.layout === 'raw' ? '' : 'max-w-[90rem]'
+            )}
+          >
             <div className="flex w-full flex-1">
               <Sidebar
                 docsDirectories={docsDirectories}

--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -402,10 +402,6 @@ blockquote:not(:first-child),
 .nextra-body {
   &.full {
     width: 100%;
-    &.expand {
-      width: 100vw;
-      margin: 0 calc(50% - 50vw);
-    }
   }
 }
 article {

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -20,6 +20,9 @@ exports[`Page Process > pageMap en-US 1`] = `
           "meta": {
             "a-page": {
               "hidden": true,
+              "theme": {
+                "layout": "raw",
+              },
               "title": "A Page",
               "type": "page",
             },
@@ -417,7 +420,6 @@ exports[`Page Process > pageMap en-US 1`] = `
         },
         "index": {
           "hidden": true,
-          "theme": {},
           "title": "Introduction",
           "type": "page",
         },
@@ -456,6 +458,9 @@ exports[`Page Process > pageMap zh-CN 1`] = `
           "meta": {
             "a-page": {
               "hidden": true,
+              "theme": {
+                "layout": "raw",
+              },
               "title": "A Page",
               "type": "page",
             },


### PR DESCRIPTION
When having the scrollbar always shown, `100vw` behaves weirdly and causes overflow when `layout: "raw"` is set. This can be reproduced on [turborepo.org](https://turborepo.org/):

![CleanShot 2022-08-08 at 15 15 11@2x](https://user-images.githubusercontent.com/3676859/183426680-32d16d3e-57ea-448e-b514-c8e84ae3d2a3.png)

Here we just remove the `max-w-[90rem]` constraint when using the raw layout.