### PR TITLE
`"layout": "raw"` should render `all` unstyled elements, except `<a />`

### DIFF
--- a/.changeset/long-pants-obey.md
+++ b/.changeset/long-pants-obey.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+`"layout": "raw"` should render `all` unstyled elements, except `<a />`

--- a/examples/swr-site/pages/docs/meta.en-US.json
+++ b/examples/swr-site/pages/docs/meta.en-US.json
@@ -41,5 +41,11 @@
     "newWindow": true
   },
   "scroll-with-dynamic-height": "Scroll With Dynamic Height",
-  "404-500": "404/500 Custom Error Pages"
+  "404-500": "404/500 Custom Error Pages",
+  "raw-layout": {
+    "title": "Raw Layout",
+    "theme": {
+      "layout": "raw"
+    }
+  }
 }

--- a/examples/swr-site/pages/docs/raw-layout.en-US.mdx
+++ b/examples/swr-site/pages/docs/raw-layout.en-US.mdx
@@ -1,0 +1,76 @@
+# Raw Layout
+
+| Version   | Changes                                                             |
+| ----------| ------------------------------------------------------------------- |
+| `v10.0.0` | `locale`, `locales`, `defaultLocale`, and `notFound` options added. |
+| `v9.3.0`  | `getServerSideProps` introduced.                                    |
+
+| Version   | Changes                                                             |
+| ---------: | :-------------------------------------------------------------------: |
+| `v10.0.0` | `locale`, `locales`, `defaultLocale`, and `notFound` options added. |
+| `v9.3.0`  | `getServerSideProps` introduced.
+
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+##### Heading 5
+
+# Ul
+
+- one
+- two
+- three
+
+# Ol
+
+1. one
+1. two
+1. three
+
+> Blockquoute
+
+[link](/docs)
+
+# Hr
+
+---
+
+# With tags
+
+<a href="/docs">docs</a>
+
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h3>
+<h4>Heading 4</h4>
+<h5>Heading 5</h5>
+<h6>Heading 6</h6>
+
+<table>
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Changes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`v10.0.0`</td>
+      <td>`locale`, `locales`, `defaultLocale`, and `notFound` options added.</td>
+    </tr>
+    <tr>
+      <td>`v9.3.0`</td>
+      <td>`getServerSideProps` introduced.</td>
+    </tr>
+  </tbody>
+</table>
+
+<details>
+  <summary>Details</summary>
+  <p>Something small enough to escape casual notice.</p>
+</details>

--- a/packages/nextra-theme-docs/src/components/collapse.tsx
+++ b/packages/nextra-theme-docs/src/components/collapse.tsx
@@ -70,7 +70,7 @@ export function Collapse({
     >
       <div
         ref={innerRef}
-        className="nextra-collapse-content transform-gpu overflow-hidden transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
+        className="p-2 transform-gpu overflow-hidden transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
         style={{
           opacity: initialState.current ? 1 : 0
         }}

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -125,7 +125,15 @@ const Body = ({
   }
 
   return (
-    <article className="nextra-body relative flex w-full min-w-0 max-w-full justify-center pb-8 pr-[calc(env(safe-area-inset-right)-1.5rem)]">
+    <article
+      className={cn(
+        'nextra-body relative flex w-full min-w-0 max-w-full justify-center pb-8 pr-[calc(env(safe-area-inset-right)-1.5rem)]',
+        {
+          default: '',
+          article: 'nextra-body-typesetting-article'
+        }[themeContext.typesetting]
+      )}
+    >
       <main
         className="z-10 w-full min-w-0 max-w-4xl px-6 pt-4 md:px-8"
         ref={mainElement}

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -89,8 +89,8 @@ const Body = ({
 
   if (themeContext.layout === 'raw') {
     return (
-      <div className="nextra-body full relative overflow-x-hidden">
-        {children}
+      <div className="nextra-body w-full relative overflow-x-hidden">
+        <MDXTheme isRaw>{children}</MDXTheme>
       </div>
     )
   }
@@ -116,7 +116,7 @@ const Body = ({
 
   if (themeContext.layout === 'full') {
     return (
-      <article className="nextra-body full relative justify-center overflow-x-hidden pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
+      <article className="nextra-body w-full relative justify-center overflow-x-hidden pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
         <MDXTheme>{children}</MDXTheme>
         {gitTimestampEl}
         {navLinks}
@@ -125,13 +125,7 @@ const Body = ({
   }
 
   return (
-    <article
-      className={cn(
-        'nextra-body relative flex w-full min-w-0 max-w-full justify-center pb-8 pr-[calc(env(safe-area-inset-right)-1.5rem)]',
-        themeContext.typesetting &&
-          `nextra-body-typesetting-${themeContext.typesetting}`
-      )}
-    >
+    <article className="nextra-body relative flex w-full min-w-0 max-w-full justify-center pb-8 pr-[calc(env(safe-area-inset-right)-1.5rem)]">
       <main
         className="z-10 w-full min-w-0 max-w-4xl px-6 pt-4 md:px-8"
         ref={mainElement}

--- a/packages/nextra-theme-docs/src/mdx-theme.tsx
+++ b/packages/nextra-theme-docs/src/mdx-theme.tsx
@@ -5,13 +5,15 @@ import React, {
   cloneElement,
   Children,
   ReactNode,
-  ReactElement
+  ReactElement,
+  ComponentProps
 } from 'react'
 import 'intersection-observer'
 import { useSetActiveAnchor, DetailsProvider, useDetails } from './contexts'
 import { MDXProvider } from '@mdx-js/react'
 import { Collapse, Anchor } from './components'
 import { IS_BROWSER } from './constants'
+import cn from 'clsx'
 
 let observer: IntersectionObserver
 let setActiveAnchor: ReturnType<typeof useSetActiveAnchor>
@@ -80,11 +82,7 @@ const createHeaderLink = (
     children,
     id,
     ...props
-  }: {
-    tag: any
-    children: ReactNode
-    id: string
-  }): ReactElement {
+  }: ComponentProps<'h2'> & { id: string }): ReactElement {
     setActiveAnchor = useSetActiveAnchor()
     const obRef = useRef<HTMLSpanElement>(null)
 
@@ -106,20 +104,24 @@ const createHeaderLink = (
     }, [])
 
     return (
-      <Tag {...props}>
+      <Tag
+        className={cn(
+          'font-semibold tracking-tight',
+          {
+            h2: 'mt-10 text-3xl border-b pb-1 dark:border-primary-100/10',
+            h3: 'mt-8 text-2xl',
+            h4: 'mt-8 text-xl',
+            h5: 'mt-8 text-lg',
+            h6: 'mt-8 text-base'
+          }[Tag]
+        )}
+        {...props}
+      >
         <span className="subheading-anchor -mt-20" id={id} ref={obRef} />
         <a href={`#${id}`}>{children}</a>
       </Tag>
     )
   }
-
-const Table = ({ children }: { children: ReactNode }) => {
-  return (
-    <div className="table-container">
-      <table>{children}</table>
-    </div>
-  )
-}
 
 const findSummary = (children: ReactNode) => {
   let summary: ReactNode = null
@@ -167,8 +169,16 @@ const Details = ({
   const [summary, restChildren] = findSummary(children)
 
   return (
-    <details {...props} ref={ref} open {...(openState && { 'data-open': '' })}>
-      <DetailsProvider value={setOpen}>{summary}</DetailsProvider>
+    <details
+      className="my-4 rounded border border-gray-200 bg-white p-2 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 first:mt-0 last:mb-0"
+      {...props}
+      ref={ref}
+      open
+      {...(openState && { 'data-open': '' })}
+    >
+      <DetailsProvider value={setOpen}>
+        {summary}
+      </DetailsProvider>
       <Collapse open={openState}>{restChildren}</Collapse>
     </details>
   )
@@ -183,6 +193,11 @@ const Summary = ({
   const setOpen = useDetails()
   return (
     <summary
+      className={cn(
+        'list-none cursor-pointer rounded p-1 outline-none transition-colors hover:bg-gray-100 dark:hover:bg-neutral-800',
+        "before:content-[''] before:inline-block before:transition-transform dark:before:invert",
+        '[[data-open]>&]:before:rotate-90'
+      )}
       {...props}
       onClick={e => {
         e.preventDefault()
@@ -194,29 +209,123 @@ const Summary = ({
   )
 }
 
+const A = ({ href = '', ...props }) => (
+  <Anchor
+    href={href}
+    newWindow={href.startsWith('https://')}
+    className="ring-primary-500/30 focus:outline-none focus-visible:ring"
+    {...props}
+  />
+)
+
 export const getComponents = () => {
   const context = { index: 0 }
   return {
+    h1: ({ children, ...props }: ComponentProps<'h1'>) => (
+      <h1 className="mt-2 text-4xl font-bold tracking-tight" {...props}>
+        {children}
+      </h1>
+    ),
     h2: createHeaderLink('h2', context),
     h3: createHeaderLink('h3', context),
     h4: createHeaderLink('h4', context),
     h5: createHeaderLink('h5', context),
     h6: createHeaderLink('h6', context),
-    a: ({ href = '', ...props }): ReactElement => (
-      <Anchor href={href} newWindow={href.startsWith('https://')} {...props} />
+    ul: ({ children, ...props }: ComponentProps<'ul'>) => (
+      <ul className="ml-6 mt-6 list-disc first:mt-0" {...props}>
+        {children}
+      </ul>
     ),
-    table: Table,
+    ol: ({ children, ...props }: ComponentProps<'ol'>) => (
+      <ol className="ml-6 mt-6 list-decimal" {...props}>
+        {children}
+      </ol>
+    ),
+    li: ({ children, ...props }: ComponentProps<'li'>) => (
+      <li className="my-2" {...props}>
+        {children}
+      </li>
+    ),
+    blockquote: ({ children, ...props }: ComponentProps<'blockquote'>) => (
+      <blockquote
+        className="mt-6 first:mt-0 border-l-2 border-gray-300 pl-6 italic text-gray-700 dark:border-gray-700 dark:text-gray-400"
+        {...props}
+      >
+        {children}
+      </blockquote>
+    ),
+    hr: ({ children, ...props }: ComponentProps<'hr'>) => (
+      <hr className="my-8 dark:border-gray-900" {...props}>
+        {children}
+      </hr>
+    ),
+    a: A,
+    table: ({ children, ...props }: ComponentProps<'table'>) => (
+      <table className="mt-6 first:mt-0 p-0" {...props}>
+        {children}
+      </table>
+    ),
+    p: ({ children, ...props }: ComponentProps<'p'>) => (
+      <p className="mt-6 first:mt-0" {...props}>
+        {children}
+      </p>
+    ),
+    tr: ({ children, ...props }: ComponentProps<'tr'>) => (
+      <tr
+        className={cn(
+          'm-0 border-t border-gray-300 p-0 dark:border-gray-600',
+          'even:bg-gray-100 even:dark:bg-gray-600/20'
+        )}
+        {...props}
+      >
+        {children}
+      </tr>
+    ),
+    th: ({ children, align, ...props }: ComponentProps<'th'>) => (
+      <th
+        className={cn(
+          'text-left m-0 border border-gray-300 px-4 py-2 dark:border-gray-600 font-semibold',
+          {
+            center: 'text-center',
+            right: 'text-right'
+          }[align as 'center' | 'right']
+        )}
+        align={align}
+        {...props}
+      >
+        {children}
+      </th>
+    ),
+    td: ({ children, align, ...props }: ComponentProps<'td'>) => (
+      <td
+        className={cn(
+          'text-left m-0 border border-gray-300 px-4 py-2 dark:border-gray-600',
+          {
+            center: 'text-center',
+            right: 'text-right'
+          }[align as 'center' | 'right']
+        )}
+        align={align}
+        {...props}
+      >
+        {children}
+      </td>
+    ),
     details: Details,
     summary: Summary
   }
 }
 
 export const MDXTheme = ({
-  children
+  children,
+  isRaw
 }: {
   children: ReactNode
+  isRaw?: boolean
 }): ReactElement => {
   return (
-    <MDXProvider components={getComponents() as any}>{children}</MDXProvider>
+    <MDXProvider components={isRaw ? { a: A } : (getComponents() as any)}>
+      {children}
+    </MDXProvider>
   )
 }

--- a/packages/nextra-theme-docs/src/mdx-theme.tsx
+++ b/packages/nextra-theme-docs/src/mdx-theme.tsx
@@ -176,9 +176,7 @@ const Details = ({
       open
       {...(openState && { 'data-open': '' })}
     >
-      <DetailsProvider value={setOpen}>
-        {summary}
-      </DetailsProvider>
+      <DetailsProvider value={setOpen}>{summary}</DetailsProvider>
       <Collapse open={openState}>{restChildren}</Collapse>
     </details>
   )
@@ -221,81 +219,57 @@ const A = ({ href = '', ...props }) => (
 export const getComponents = () => {
   const context = { index: 0 }
   return {
-    h1: ({ children, ...props }: ComponentProps<'h1'>) => (
-      <h1 className="mt-2 text-4xl font-bold tracking-tight" {...props}>
-        {children}
-      </h1>
+    h1: (props: ComponentProps<'h1'>) => (
+      <h1 className="mt-2 text-4xl font-bold tracking-tight" {...props} />
     ),
     h2: createHeaderLink('h2', context),
     h3: createHeaderLink('h3', context),
     h4: createHeaderLink('h4', context),
     h5: createHeaderLink('h5', context),
     h6: createHeaderLink('h6', context),
-    ul: ({ children, ...props }: ComponentProps<'ul'>) => (
-      <ul className="ml-6 mt-6 list-disc first:mt-0" {...props}>
-        {children}
-      </ul>
+    ul: (props: ComponentProps<'ul'>) => (
+      <ul className="ml-6 mt-6 list-disc first:mt-0" {...props} />
     ),
-    ol: ({ children, ...props }: ComponentProps<'ol'>) => (
-      <ol className="ml-6 mt-6 list-decimal" {...props}>
-        {children}
-      </ol>
+    ol: (props: ComponentProps<'ol'>) => (
+      <ol className="ml-6 mt-6 list-decimal" {...props} />
     ),
-    li: ({ children, ...props }: ComponentProps<'li'>) => (
-      <li className="my-2" {...props}>
-        {children}
-      </li>
-    ),
-    blockquote: ({ children, ...props }: ComponentProps<'blockquote'>) => (
+    li: (props: ComponentProps<'li'>) => <li className="my-2" {...props} />,
+    blockquote: (props: ComponentProps<'blockquote'>) => (
       <blockquote
         className="mt-6 first:mt-0 border-l-2 border-gray-300 pl-6 italic text-gray-700 dark:border-gray-700 dark:text-gray-400"
         {...props}
-      >
-        {children}
-      </blockquote>
+      />
     ),
-    hr: ({ children, ...props }: ComponentProps<'hr'>) => (
-      <hr className="my-8 dark:border-gray-900" {...props}>
-        {children}
-      </hr>
+    hr: (props: ComponentProps<'hr'>) => (
+      <hr className="my-8 dark:border-gray-900" {...props} />
     ),
     a: A,
-    table: ({ children, ...props }: ComponentProps<'table'>) => (
-      <table className="mt-6 first:mt-0 p-0" {...props}>
-        {children}
-      </table>
+    table: (props: ComponentProps<'table'>) => (
+      <table className="mt-6 first:mt-0 p-0" {...props} />
     ),
-    p: ({ children, ...props }: ComponentProps<'p'>) => (
-      <p className="mt-6 first:mt-0" {...props}>
-        {children}
-      </p>
+    p: (props: ComponentProps<'p'>) => (
+      <p className="mt-6 first:mt-0" {...props} />
     ),
-    tr: ({ children, ...props }: ComponentProps<'tr'>) => (
+    tr: (props: ComponentProps<'tr'>) => (
       <tr
         className={cn(
           'm-0 border-t border-gray-300 p-0 dark:border-gray-600',
           'even:bg-gray-100 even:dark:bg-gray-600/20'
         )}
         {...props}
-      >
-        {children}
-      </tr>
+      />
     ),
-    th: ({ children, ...props }: ComponentProps<'th'>) => (
+    th: (props: ComponentProps<'th'>) => (
       <th
         className="m-0 border border-gray-300 px-4 py-2 dark:border-gray-600 font-semibold"
         {...props}
-      >
-        {children}
-      </th>
+      />
     ),
-    td: ({ children, ...props }: ComponentProps<'td'>) => (
+    td: (props: ComponentProps<'td'>) => (
       <td
         className="m-0 border border-gray-300 px-4 py-2 dark:border-gray-600"
         {...props}
-      >
-        {children}
-      </td>
+      />
     ),
     details: Details,
     summary: Summary

--- a/packages/nextra-theme-docs/src/mdx-theme.tsx
+++ b/packages/nextra-theme-docs/src/mdx-theme.tsx
@@ -281,31 +281,17 @@ export const getComponents = () => {
         {children}
       </tr>
     ),
-    th: ({ children, align, ...props }: ComponentProps<'th'>) => (
+    th: ({ children, ...props }: ComponentProps<'th'>) => (
       <th
-        className={cn(
-          'text-left m-0 border border-gray-300 px-4 py-2 dark:border-gray-600 font-semibold',
-          {
-            center: 'text-center',
-            right: 'text-right'
-          }[align as 'center' | 'right']
-        )}
-        align={align}
+        className="m-0 border border-gray-300 px-4 py-2 dark:border-gray-600 font-semibold"
         {...props}
       >
         {children}
       </th>
     ),
-    td: ({ children, align, ...props }: ComponentProps<'td'>) => (
+    td: ({ children, ...props }: ComponentProps<'td'>) => (
       <td
-        className={cn(
-          'text-left m-0 border border-gray-300 px-4 py-2 dark:border-gray-600',
-          {
-            center: 'text-center',
-            right: 'text-right'
-          }[align as 'center' | 'right']
-        )}
-        align={align}
+        className="m-0 border border-gray-300 px-4 py-2 dark:border-gray-600"
         {...props}
       >
         {children}

--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -13,16 +13,12 @@
 }
 
 html {
-  @apply antialiased;
-  font-size: 16px;
+  @apply antialiased text-base;
   font-feature-settings: 'rlig' 1, 'calt' 1, 'ss01' 1, 'ss06' 1;
   -webkit-tap-highlight-color: transparent;
 }
 body {
-  @apply w-full bg-white;
-}
-.dark body {
-  @apply bg-dark text-gray-100;
+  @apply w-full bg-white dark:bg-dark dark:text-gray-100;
 }
 
 a {
@@ -32,15 +28,6 @@ a {
 }
 p {
   @apply leading-7;
-}
-p:not(:first-child),
-blockquote:not(:first-child),
-.table-container:not(:first-child) {
-  @apply mt-6;
-}
-
-.main-container {
-  min-height: 100vh;
 }
 
 .nextra-container {
@@ -386,109 +373,18 @@ blockquote:not(:first-child),
 }
 
 /* Content Typography */
-.nextra-body {
-  &.full {
-    width: 100%;
-  }
-}
 article {
   min-height: calc(100vh - 64px);
-  h1 {
-    @apply mt-2 text-4xl font-bold tracking-tight;
-  }
-  h2 {
-    @apply mt-10 text-3xl font-semibold tracking-tight;
-    @apply border-b pb-1;
-    .dark & {
-      @apply border-primary-100/10;
-    }
-  }
-  h3 {
-    @apply mt-8 text-2xl font-semibold tracking-tight;
-  }
-  h4 {
-    @apply mt-8 text-xl font-semibold tracking-tight;
-  }
-  h5 {
-    @apply mt-8 text-lg font-semibold tracking-tight;
-  }
-  h6 {
-    @apply mt-8 text-base font-semibold tracking-tight;
-  }
-  ul {
-    @apply ml-6 mt-6 list-disc;
-    &:first-child {
-      @apply mt-0;
-    }
-  }
-  li {
-    @apply my-2;
-  }
-  ol {
-    @apply ml-6 mt-6 list-decimal;
-  }
-  blockquote {
-    @apply border-l-2 border-gray-300 pl-6 italic text-gray-700;
-    @apply dark:border-gray-700 dark:text-gray-400;
-  }
-  h2 a {
-    @apply no-underline;
-  }
-  a {
-    @apply ring-primary-500/30 focus:outline-none focus-visible:ring;
-  }
-  hr {
-    @apply my-8;
-    .dark & {
-      @apply border-gray-900;
-    }
-  }
-  details {
-    @apply my-4 rounded border border-gray-200 bg-white p-2 shadow-sm;
-    .dark & {
-      @apply border-neutral-800 bg-neutral-900;
-    }
-    &:first-child {
-      @apply mt-0;
-    }
-    &:last-child {
-      @apply mb-0;
-    }
-    .nextra-collapse-content {
-      @apply p-2;
-    }
-  }
-  summary {
-    @apply cursor-pointer rounded p-1 outline-none transition-colors;
-    &:hover {
-      @apply bg-gray-100;
-    }
-    .dark &:hover {
-      @apply bg-neutral-800;
-    }
-    &::-webkit-details-marker {
-      display: none;
-    }
-  }
   details > summary {
-    list-style-type: none;
+    &::-webkit-details-marker {
+      @apply hidden;
+    }
     &::before {
-      content: '';
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z' clip-rule='evenodd' /%3E%3C/svg%3E");
       height: 1.2em;
       width: 1.2em;
       margin-right: 0.125em;
       vertical-align: -4px;
-      @apply inline-block transition-transform;
-    }
-    .dark &::before {
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='white'%3E%3Cpath fill-rule='evenodd' d='M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z' clip-rule='evenodd' /%3E%3C/svg%3E");
-    }
-  }
-  details[data-open] > summary {
-    list-style-type: none;
-    &::before {
-      @apply rotate-90;
     }
   }
 
@@ -652,42 +548,6 @@ input[type='search']::-webkit-search-results-decoration {
 .locale-switch .locale-dropdown {
   position: absolute;
   z-index: 11;
-}
-
-/* Table */
-table {
-  @apply mt-2 p-0;
-  &:first-child {
-    @apply mt-0;
-  }
-}
-table tr {
-  @apply m-0 border-t border-gray-300 p-0;
-  @apply dark:border-gray-600;
-}
-table tr:nth-child(2n) {
-  @apply bg-gray-100;
-  @apply dark:bg-gray-600/20;
-}
-table tr th {
-  @apply font-semibold;
-}
-table tr th[align='center'],
-table tr td[align='center'] {
-  @apply text-center;
-}
-table tr th[align='right'],
-table tr td[align='right'] {
-  @apply text-right;
-}
-table tr th,
-table tr td {
-  @apply text-left;
-  @apply m-0 border border-gray-300 px-4 py-2;
-  @apply dark:border-gray-600;
-}
-.table-container {
-  overflow: auto;
 }
 
 .contains-task-list {

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -242,6 +242,12 @@ exports[`Page Process > pageMap en-US 1`] = `
             "options": "Options",
             "pagination": "Pagination",
             "prefetching": "Prefetching",
+            "raw-layout": {
+              "theme": {
+                "layout": "raw",
+              },
+              "title": "Raw Layout",
+            },
             "revalidation": "Auto Revalidation",
             "scroll-with-dynamic-height": "Scroll With Dynamic Height",
             "suspense": "Suspense",
@@ -274,6 +280,11 @@ exports[`Page Process > pageMap en-US 1`] = `
           "locale": "en-US",
           "name": "prefetching",
           "route": "/docs/prefetching",
+        },
+        {
+          "locale": "en-US",
+          "name": "raw-layout",
+          "route": "/docs/raw-layout",
         },
         {
           "locale": "en-US",
@@ -701,6 +712,11 @@ exports[`Page Process > pageMap zh-CN 1`] = `
           "locale": "en-US",
           "name": "advanced",
           "route": "/docs/advanced",
+        },
+        {
+          "locale": "en-US",
+          "name": "raw-layout",
+          "route": "/docs/raw-layout",
         },
         {
           "locale": "en-US",


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/620
closes https://github.com/shuding/nextra/pull/628

## before (table should be unstyled, not needed margin-top for `p`/`blockquote`/`table`)
<img width="1612" alt="image" src="https://user-images.githubusercontent.com/7361780/183853526-bd77cf4c-0d69-4432-8b6a-4ddbcaae3cf4.png">

## after
![image](https://user-images.githubusercontent.com/7361780/183854109-e02896b0-24e7-47ce-bad2-62c722aa6e3d.png)
