### PR TITLE
simpify `tocEl` ternary

### DIFF
--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -180,11 +180,10 @@ const InnerLayout = ({
 
   const themeContext = { ...activeThemeContext, ...meta }
   const hideSidebar = !themeContext.sidebar || themeContext.layout === 'raw'
-  const hideToc = !themeContext.toc || themeContext.layout === 'raw'
   const asPopover = activeType === 'page' || hideSidebar
 
   const tocEl =
-    activeType === 'page' || hideToc || themeContext.layout !== 'default' ? (
+    activeType === 'page' || !themeContext.toc || themeContext.layout !== 'default' ? (
       themeContext.layout === 'full' || themeContext.layout === 'raw' ? null : (
         <div className="nextra-toc order-last hidden w-64 flex-shrink-0 px-4 text-sm xl:block" />
       )


### PR DESCRIPTION
The current ternary is hard to read
<img width="643" alt="image" src="https://user-images.githubusercontent.com/7361780/184334081-e39df5a7-8645-4dfc-9a8b-7416839d90fa.png">

1. If we remove `hideToc` variable, and move his value inside ternary we'll see duplicated  `themeContext.layout === 'raw'` check

<img width="806" alt="image" src="https://user-images.githubusercontent.com/7361780/184334342-6dcf218c-b74c-4abc-94e5-89bc553e53fc.png">

2. We can safely remove the first one check
<img width="643" alt="image" src="https://user-images.githubusercontent.com/7361780/184334571-045b8d01-d87f-4c18-b4d7-e771447ca879.png">