### PR TITLE
reuse Flexsearch result styles on match-sorter search

### DIFF
--- a/.changeset/breezy-news-talk.md
+++ b/.changeset/breezy-news-talk.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+reuse Flexsearch result styles on match-sorter search

--- a/.changeset/nervous-otters-design.md
+++ b/.changeset/nervous-otters-design.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+typescripify `<Flexsearch />`

--- a/.changeset/sharp-carpets-care.md
+++ b/.changeset/sharp-carpets-care.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+match-sorter search should highlight every match like flexsearch

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -50,7 +50,7 @@
     "focus-visible": "^5.2.0",
     "github-slugger": "^1.4.0",
     "intersection-observer": "^0.12.2",
-    "match-sorter": "^4.2.0",
+    "match-sorter": "^6.3.1",
     "next-themes": "^0.2.0-beta.2",
     "parse-git-url": "^1.0.1",
     "scroll-into-view-if-needed": "^2.2.29",

--- a/packages/nextra-theme-docs/src/components/flexsearch.jsx
+++ b/packages/nextra-theme-docs/src/components/flexsearch.jsx
@@ -26,8 +26,7 @@ const MemoedStringWithMatchHighlights = memo(
       )
       index = regexp.lastIndex
     }
-
-    res.push(<Fragment key={id++}>{content}</Fragment>)
+    res.push(<Fragment key={id++}>{splittedText.join('')}</Fragment>)
 
     return res
   }

--- a/packages/nextra-theme-docs/src/components/flexsearch.tsx
+++ b/packages/nextra-theme-docs/src/components/flexsearch.tsx
@@ -1,38 +1,11 @@
-import React, { memo, useState, useEffect, Fragment, ReactElement } from 'react'
+import React, { useState, useEffect, ReactElement, ReactNode } from 'react'
 import { useRouter } from 'next/router'
 import FlexSearch from 'flexsearch'
 import cn from 'clsx'
 import { Search } from './search'
+import { HighlightMatches } from './highlight-matches'
 import { DEFAULT_LOCALE } from '../constants'
-
-const MemoizedStringWithMatchHighlights = memo<{
-  content: string
-  search: string
-  // @ts-expect-error -- Is totally valid return array of ReactElement's from component
-}>(function StringWithMatchHighlights({ content, search }) {
-  const splittedText = content.split('')
-  const escapedSearch = search.trim().replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
-  const regexp = RegExp('(' + escapedSearch.replaceAll(' ', '|') + ')', 'ig')
-  let match
-  let id = 0
-  let index = 0
-  const res = []
-
-  while ((match = regexp.exec(content)) !== null) {
-    res.push(
-      <Fragment key={id++}>
-        {splittedText.splice(0, match.index - index).join('')}
-        <span className="highlight">
-          {splittedText.splice(0, regexp.lastIndex - match.index).join('')}
-        </span>
-      </Fragment>
-    )
-    index = regexp.lastIndex
-  }
-  res.push(<Fragment key={id++}>{splittedText.join('')}</Fragment>)
-
-  return res
-})
+import { SearchResult } from '../types'
 
 type SectionIndex = FlexSearch.Document<
   {
@@ -58,11 +31,9 @@ type PageIndex = FlexSearch.Document<
 type Result = {
   _page_rk: number
   _section_rk: number
-  first: boolean
   route: string
-  page: string
-  title: ReactElement
-  excerpt: ReactElement | null
+  prefix: ReactNode
+  children: ReactNode
 }
 
 type NextraData = {
@@ -73,14 +44,16 @@ type NextraData = {
 }
 
 // This can be global for better caching.
-const indexes: Record<string, [PageIndex, SectionIndex]> = {}
+const indexes: {
+  [locale: string]: [PageIndex, SectionIndex]
+} = {}
 
-export function Flexsearch() {
+export function Flexsearch(): ReactElement {
   const router = useRouter()
   const { locale = DEFAULT_LOCALE } = router
   const [loading, setLoading] = useState(false)
   const [search, setSearch] = useState('')
-  const [results, setResults] = useState<Result[]>([])
+  const [results, setResults] = useState<SearchResult[]>([])
 
   useEffect(() => {
     if (!search) return
@@ -111,146 +84,161 @@ export function Flexsearch() {
           tag: 'page_' + result.id
         })[0]?.result || []
 
-      let firstItemOfPage = true
+      let isFirstItemOfPage = true
       const occurred: Record<string, boolean> = {}
 
       for (let j = 0; j < sectionResults.length; j++) {
         const { doc } = sectionResults[j]
         const isMatchingTitle = doc.display !== undefined
-        const content = doc.display || doc.content
-        const { url, title } = doc
         if (isMatchingTitle) {
           pageTitleMatches[i]++
         }
-
+        const { url, title } = doc
+        const content = doc.display || doc.content
         if (occurred[url + '@' + content]) continue
         occurred[url + '@' + content] = true
 
         results.push({
           _page_rk: i,
           _section_rk: j,
-          first: firstItemOfPage,
           route: url,
-          page: result.doc.title,
-          title: (
-            <MemoizedStringWithMatchHighlights
-              content={title}
-              search={search}
-            />
+          prefix: isFirstItemOfPage && (
+            <div
+              className={cn(
+                'border-b border-black/10 dark:border-white/20 mx-2.5 mb-2 mt-6 select-none px-2.5 pb-1.5 text-xs font-semibold uppercase text-gray-500 first:mt-0 dark:text-gray-300',
+                'contrast-more:border-gray-600 contrast-more:text-gray-900 contrast-more:dark:border-gray-50 contrast-more:dark:text-gray-50'
+              )}
+            >
+              {result.doc.title}
+            </div>
           ),
-          excerpt: (
-            <MemoizedStringWithMatchHighlights
-              content={content}
-              search={search}
-            />
+          children: (
+            <>
+              <div className="font-semibold leading-5 text-base">
+                <HighlightMatches match={search} value={title} />
+              </div>
+              {content && (
+                <div className="excerpt mt-1 text-sm leading-[1.35rem] text-gray-600 dark:text-gray-400">
+                  <HighlightMatches match={search} value={content} />
+                </div>
+              )}
+            </>
           )
         })
 
-        firstItemOfPage = false
+        isFirstItemOfPage = false
       }
     }
 
     setResults(
-      results.sort((a, b) => {
-        // Sort by number of matches in the title.
-        if (a._page_rk === b._page_rk) {
-          return a._section_rk - b._section_rk
-        }
-        if (pageTitleMatches[a._page_rk] !== pageTitleMatches[b._page_rk]) {
-          return pageTitleMatches[b._page_rk] - pageTitleMatches[a._page_rk]
-        }
-        return a._page_rk - b._page_rk
-      })
+      results
+        .sort((a, b) => {
+          // Sort by number of matches in the title.
+          if (a._page_rk === b._page_rk) {
+            return a._section_rk - b._section_rk
+          }
+          if (pageTitleMatches[a._page_rk] !== pageTitleMatches[b._page_rk]) {
+            return pageTitleMatches[b._page_rk] - pageTitleMatches[a._page_rk]
+          }
+          return a._page_rk - b._page_rk
+        })
+        .map(res => ({
+          id: `${res._page_rk}_${res._section_rk}`,
+          route: res.route,
+          prefix: res.prefix,
+          children: res.children
+        }))
     )
   }, [search])
 
   const load = async () => {
-    if (!indexes[locale] && !loading) {
-      setLoading(true)
-      const response = await fetch(
-        `${router.basePath}/_next/static/chunks/nextra-data-${locale}.json`
-      )
-      const data = (await response.json()) as NextraData
+    if (indexes[locale] || loading) {
+      return
+    }
+    setLoading(true)
+    const response = await fetch(
+      `${router.basePath}/_next/static/chunks/nextra-data-${locale}.json`
+    )
+    const data = (await response.json()) as NextraData
 
-      const pageIndex: PageIndex = new FlexSearch.Document({
-        cache: 100,
-        tokenize: 'full',
-        document: {
-          id: 'id',
-          index: 'content',
-          store: ['title']
-        },
-        context: {
-          resolution: 9,
-          depth: 2,
-          bidirectional: true
-        }
-      })
+    const pageIndex: PageIndex = new FlexSearch.Document({
+      cache: 100,
+      tokenize: 'full',
+      document: {
+        id: 'id',
+        index: 'content',
+        store: ['title']
+      },
+      context: {
+        resolution: 9,
+        depth: 2,
+        bidirectional: true
+      }
+    })
 
-      const sectionIndex: SectionIndex = new FlexSearch.Document({
-        cache: 100,
-        tokenize: 'full',
-        document: {
-          id: 'id',
-          index: 'content',
-          tag: 'pageId',
-          store: ['title', 'content', 'url', 'display']
-        },
-        context: {
-          resolution: 9,
-          depth: 2,
-          bidirectional: true
-        }
-      })
+    const sectionIndex: SectionIndex = new FlexSearch.Document({
+      cache: 100,
+      tokenize: 'full',
+      document: {
+        id: 'id',
+        index: 'content',
+        tag: 'pageId',
+        store: ['title', 'content', 'url', 'display']
+      },
+      context: {
+        resolution: 9,
+        depth: 2,
+        bidirectional: true
+      }
+    })
 
-      let pageId = 0
-      for (const route in data) {
-        let pageContent = ''
-        ++pageId
+    let pageId = 0
+    for (const route in data) {
+      let pageContent = ''
+      ++pageId
 
-        for (const heading in data[route].data) {
-          const [hash, text] = heading.split('#')
-          const url = route + (hash ? '#' + hash : '')
-          const title = text || data[route].title
+      for (const heading in data[route].data) {
+        const [hash, text] = heading.split('#')
+        const url = route + (hash ? '#' + hash : '')
+        const title = text || data[route].title
 
-          const content = data[route].data[heading] || ''
-          const paragraphs = content.split('\n').filter(Boolean)
+        const content = data[route].data[heading] || ''
+        const paragraphs = content.split('\n').filter(Boolean)
 
+        sectionIndex.add({
+          id: url,
+          url,
+          title,
+          pageId: `page_${pageId}`,
+          content: title,
+          ...(paragraphs[0] && { display: paragraphs[0] })
+        })
+
+        for (let i = 0; i < paragraphs.length; i++) {
           sectionIndex.add({
-            id: url,
+            id: url + '_' + i,
             url,
             title,
             pageId: `page_${pageId}`,
-            content: title,
-            ...(paragraphs[0] && { display: paragraphs[0] })
+            content: paragraphs[i]
           })
-
-          for (let i = 0; i < paragraphs.length; i++) {
-            sectionIndex.add({
-              id: url + '_' + i,
-              url,
-              title,
-              pageId: `page_${pageId}`,
-              content: paragraphs[i]
-            })
-          }
-
-          // Add the page itself.
-          pageContent += ' ' + title + ' ' + content
         }
 
-        pageIndex.add({
-          id: pageId,
-          title: data[route].title,
-          content: pageContent
-        })
+        // Add the page itself.
+        pageContent += ' ' + title + ' ' + content
       }
 
-      indexes[locale] = [pageIndex, sectionIndex]
-
-      setLoading(false)
-      setSearch(s => (s ? s + ' ' : s)) // Trigger the effect
+      pageIndex.add({
+        id: pageId,
+        title: data[route].title,
+        content: pageContent
+      })
     }
+
+    indexes[locale] = [pageIndex, sectionIndex]
+
+    setLoading(false)
+    setSearch(s => (s ? s + ' ' : s)) // Trigger the effect
   }
 
   return (
@@ -259,34 +247,8 @@ export function Flexsearch() {
       loading={loading}
       value={search}
       onChange={setSearch}
-      className="w-screen max-w-[min(calc(100vw-2rem),calc(100%+20rem))]"
-      results={results.map(res => ({
-        route: res.route,
-        prefix: (
-          <>
-            {res.first ? (
-              <div
-                className={cn(
-                  'border-b border-black/10 dark:border-white/20 mx-2.5 mb-2 mt-6 select-none px-2.5 pb-1.5 text-xs font-semibold uppercase text-gray-500 first:mt-0 dark:text-gray-300',
-                  'contrast-more:border-gray-600 contrast-more:text-gray-900 contrast-more:dark:border-gray-50 contrast-more:dark:text-gray-50'
-                )}
-              >
-                {res.page}
-              </div>
-            ) : null}
-          </>
-        ),
-        children: (
-          <>
-            <div className="font-semibold leading-5 text-base">{res.title}</div>
-            {res.excerpt ? (
-              <div className="excerpt mt-1 text-sm leading-[1.35rem] text-gray-600 dark:text-gray-400">
-                {res.excerpt}
-              </div>
-            ) : null}
-          </>
-        )
-      }))}
+      className="w-screen min-h-[100px] max-w-[min(calc(100vw-2rem),calc(100%+20rem))]"
+      results={results}
     />
   )
 }

--- a/packages/nextra-theme-docs/src/components/highlight-matches.tsx
+++ b/packages/nextra-theme-docs/src/components/highlight-matches.tsx
@@ -1,0 +1,33 @@
+import React, { Fragment, memo } from 'react'
+
+export const HighlightMatches = memo<{
+  value: string
+  match: string
+}>(function HighlightMatches({ value, match }) {
+  const splittedText = value.split('')
+  const escapedSearch = match.trim().replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+  const regexp = RegExp('(' + escapedSearch.replaceAll(' ', '|') + ')', 'ig')
+  let result
+  let id = 0
+  let index = 0
+  const res = []
+
+  while ((result = regexp.exec(value)) !== null) {
+    res.push(
+      <Fragment key={id++}>
+        {splittedText.splice(0, result.index - index).join('')}
+        <span className="text-primary-500 underline decoration-primary-400">
+          {splittedText.splice(0, regexp.lastIndex - result.index).join('')}
+        </span>
+      </Fragment>
+    )
+    index = regexp.lastIndex
+  }
+
+  return (
+    <>
+      {res}
+      {splittedText.join('')}
+    </>
+  )
+})

--- a/packages/nextra-theme-docs/src/components/input.tsx
+++ b/packages/nextra-theme-docs/src/components/input.tsx
@@ -5,32 +5,34 @@ type InputProps = ComponentProps<'input'> & { show?: boolean }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, show, ...props }, forwardedRef) => (
-    <div className="relative flex items-center">
+    <div className="relative flex items-center text-gray-900 dark:text-gray-300 contrast-more:text-gray-800 contrast-more:dark:text-gray-300">
       <input
         ref={forwardedRef}
         spellCheck={false}
         className={cn(
           className,
-          'block w-full appearance-none rounded-lg px-3 py-2 leading-tight transition-colors',
+          'block w-full appearance-none rounded-lg px-3 py-2 transition-colors',
+          'md:text-sm text-base leading-tight',
+          'bg-black/[.03] dark:bg-gray-50/10',
           'focus:bg-white focus:outline-none focus:ring-1 focus:ring-gray-200',
           'dark:focus:bg-dark dark:focus:ring-gray-100/20',
-          'bg-black/[.03] text-gray-900 md:text-sm text-base',
-          'dark:bg-gray-50/10 dark:text-gray-300 dark:border-gray-800',
-          'placeholder:text-gray-400 dark:placeholder:text-gray-500'
+          'placeholder:text-gray-400 dark:placeholder:text-gray-500',
+          'contrast-more:border contrast-more:border-current'
         )}
         {...props}
       />
       {!show && (
-        <div className="pointer-events-none absolute inset-y-0 ltr:right-0 rtl:left-0 hidden select-none p-1.5 sm:flex">
-          <kbd
-            className={cn(
-              'inline-flex items-center rounded border bg-white px-1.5 font-mono text-sm font-medium text-gray-400',
-              'dark:border-gray-100/20 dark:bg-dark/50 dark:text-gray-500'
-            )}
-          >
-            /
-          </kbd>
-        </div>
+        <kbd
+          className={cn(
+            'pointer-events-none absolute ltr:right-1.5 rtl:left-1.5 my-1.5 hidden select-none sm:flex',
+            'rounded bg-white px-1.5 font-mono text-sm font-medium',
+            'text-gray-500',
+            'border dark:bg-dark/50 dark:border-gray-100/20',
+            'contrast-more:border-current contrast-more:text-current contrast-more:dark:border-current'
+          )}
+        >
+          /
+        </kbd>
       )}
     </div>
   )

--- a/packages/nextra-theme-docs/src/components/input.tsx
+++ b/packages/nextra-theme-docs/src/components/input.tsx
@@ -1,10 +1,10 @@
-import React, { ComponentProps, forwardRef } from 'react'
+import React, { ComponentProps, forwardRef, ReactNode } from 'react'
 import cn from 'clsx'
 
-type InputProps = ComponentProps<'input'> & { show?: boolean }
+type InputProps = ComponentProps<'input'> & { suffix?: ReactNode }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, show, ...props }, forwardedRef) => (
+  ({ className, suffix, ...props }, forwardedRef) => (
     <div className="relative flex items-center text-gray-900 dark:text-gray-300 contrast-more:text-gray-800 contrast-more:dark:text-gray-300">
       <input
         ref={forwardedRef}
@@ -21,19 +21,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         {...props}
       />
-      {!show && (
-        <kbd
-          className={cn(
-            'pointer-events-none absolute ltr:right-1.5 rtl:left-1.5 my-1.5 hidden select-none sm:flex',
-            'rounded bg-white px-1.5 font-mono text-sm font-medium',
-            'text-gray-500',
-            'border dark:bg-dark/50 dark:border-gray-100/20',
-            'contrast-more:border-current contrast-more:text-current contrast-more:dark:border-current'
-          )}
-        >
-          /
-        </kbd>
-      )}
+      {suffix}
     </div>
   )
 )

--- a/packages/nextra-theme-docs/src/components/match-sorter-search.tsx
+++ b/packages/nextra-theme-docs/src/components/match-sorter-search.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo, useState, ReactElement } from 'react'
-import matchSorter from 'match-sorter'
+import { matchSorter } from 'match-sorter'
 import { Item as NormalItem } from '../utils'
 import { Search } from './search'
+import { HighlightMatches } from './highlight-matches'
+import { SearchResult } from '../types'
 
 export function MatchSorterSearch({
   directories = []
@@ -9,36 +11,29 @@ export function MatchSorterSearch({
   directories: NormalItem[]
 }): ReactElement {
   const [search, setSearch] = useState('')
-  const results = useMemo<{ route: string; title: string }[]>(
+  const results = useMemo<SearchResult[]>(
     () =>
       // Will need to scrape all the headers from each page and search through them here
       // (similar to what we already do to render the hash links in sidebar)
       // We could also try to search the entire string text from each page
-      search ? matchSorter(directories, search, { keys: ['title'] }) : [],
+      search
+        ? matchSorter(directories, search, { keys: ['title'] }).map(
+            ({ route, title }) => ({
+              id: route + title,
+              route,
+              children: <HighlightMatches value={title} match={search} />
+            })
+          )
+        : [],
     [search]
   )
 
   return (
     <Search
-      loading={false}
       value={search}
       onChange={setSearch}
       className="w-full"
-      results={results.map(({ route, title }, i) => {
-        const highlight = title.toLowerCase().indexOf(search.toLowerCase())
-        return {
-          route,
-          children: (
-            <>
-              {title.substring(0, highlight)}
-              <span className="highlight">
-                {title.substring(highlight, highlight + search.length)}
-              </span>
-              {title.substring(highlight + search.length)}
-            </>
-          )
-        }
-      })}
+      results={results}
     />
   )
 }

--- a/packages/nextra-theme-docs/src/components/match-sorter-search.tsx
+++ b/packages/nextra-theme-docs/src/components/match-sorter-search.tsx
@@ -1,0 +1,44 @@
+import React, { useMemo, useState, ReactElement } from 'react'
+import matchSorter from 'match-sorter'
+import { Item as NormalItem } from '../utils'
+import { Search } from './search'
+
+export function MatchSorterSearch({
+  directories = []
+}: {
+  directories: NormalItem[]
+}): ReactElement {
+  const [search, setSearch] = useState('')
+  const results = useMemo<{ route: string; title: string }[]>(
+    () =>
+      // Will need to scrape all the headers from each page and search through them here
+      // (similar to what we already do to render the hash links in sidebar)
+      // We could also try to search the entire string text from each page
+      search ? matchSorter(directories, search, { keys: ['title'] }) : [],
+    [search]
+  )
+
+  return (
+    <Search
+      loading={false}
+      value={search}
+      onChange={setSearch}
+      className="w-full"
+      results={results.map(({ route, title }, i) => {
+        const highlight = title.toLowerCase().indexOf(search.toLowerCase())
+        return {
+          route,
+          children: (
+            <>
+              {title.substring(0, highlight)}
+              <span className="highlight">
+                {title.substring(highlight, highlight + search.length)}
+              </span>
+              {title.substring(highlight + search.length)}
+            </>
+          )
+        }
+      })}
+    />
+  )
+}

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -5,7 +5,7 @@ import { Menu, Transition } from '@headlessui/react'
 import { ArrowRightIcon } from 'nextra/icons'
 
 import { useConfig, useMenu } from '../contexts'
-import { Search } from './search'
+import { MatchSorterSearch } from './match-sorter-search'
 import { Flexsearch } from './flexsearch'
 import { GitHubIcon, DiscordIcon, MenuIcon } from 'nextra/icons'
 import { Item, PageItem, MenuItem, renderComponent, getFSRoute } from '../utils'
@@ -161,7 +161,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
               config.unstable_flexsearch ? (
                 <Flexsearch />
               ) : (
-                <Search directories={flatDirectories} />
+                <MatchSorterSearch directories={flatDirectories} />
               )
             ) : null)}
         </div>

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -5,8 +5,7 @@ import React, {
   useCallback,
   useState,
   useEffect,
-  useRef,
-  ReactNode
+  useRef
 } from 'react'
 import cn from 'clsx'
 import { Transition } from '@headlessui/react'
@@ -16,14 +15,15 @@ import { Anchor } from './anchor'
 import { renderComponent, renderString } from '../utils'
 import { useConfig, useMenu } from '../contexts'
 import { useRouter } from 'next/router'
+import { SearchResult } from '../types'
 
 type SearchProps = {
   className?: string
   value: string
   onChange: (newValue: string) => void
   load?: () => Promise<void>
-  loading: boolean
-  results: { route: string; prefix?: ReactNode; children: ReactNode }[]
+  loading?: boolean
+  results: SearchResult[]
 }
 
 export function Search({
@@ -147,7 +147,21 @@ export function Search({
           load?.()
           setShow(true)
         }}
-        show={renderList}
+        suffix={
+          !renderList && (
+            <kbd
+              className={cn(
+                'pointer-events-none absolute ltr:right-1.5 rtl:left-1.5 my-1.5 hidden select-none sm:flex',
+                'rounded bg-white px-1.5 font-mono text-sm font-medium',
+                'text-gray-500',
+                'border dark:bg-dark/50 dark:border-gray-100/20',
+                'contrast-more:border-current contrast-more:text-current contrast-more:dark:border-current'
+              )}
+            >
+              /
+            </kbd>
+          )
+        }
       />
 
       <Transition
@@ -163,7 +177,7 @@ export function Search({
               // Using bg-white as background-color when the browser didn't support backdrop-filter
               'bg-white text-gray-100 ring-1 ring-black/5',
               'dark:bg-neutral-900 dark:ring-white/10',
-              'absolute top-full z-20 mt-2 overscroll-contain rounded-xl py-2.5 shadow-xl overflow-auto min-h-[100px]',
+              'absolute top-full z-20 mt-2 overscroll-contain rounded-xl py-2.5 shadow-xl overflow-auto',
               'right-0 left-0 ltr:md:left-auto rtl:md:right-auto',
               'contrast-more:border contrast-more:border-gray-900 contrast-more:dark:border-gray-50',
               className
@@ -175,8 +189,8 @@ export function Search({
                 Loading...
               </span>
             ) : results.length > 0 ? (
-              results.map(({ route, prefix, children }, i) => (
-                <Fragment key={`search-item-${i}`}>
+              results.map(({ route, prefix, children, id }, i) => (
+                <Fragment key={id}>
                   {prefix}
                   <li
                     className={cn(
@@ -188,7 +202,7 @@ export function Search({
                     )}
                   >
                     <Anchor
-                      className="block no-underline !text-current hover:!bg-transparent !p-0"
+                      className="block no-underline scroll-m-12 !text-current hover:!bg-transparent !p-0"
                       href={router.basePath + route}
                       onMouseMove={() => setActive(i)}
                       onClick={finishSearch}

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -1,135 +1,65 @@
 import React, {
-  useMemo,
+  ComponentProps,
+  ReactElement,
+  Fragment,
   useCallback,
-  useRef,
   useState,
   useEffect,
-  MouseEventHandler,
-  ReactElement
+  useRef,
+  ReactNode
 } from 'react'
-import matchSorter from 'match-sorter'
 import cn from 'clsx'
-import { useRouter } from 'next/router'
-import { Anchor } from './anchor'
+import { Transition } from '@headlessui/react'
+import { SpinnerIcon } from 'nextra/icons'
 import { Input } from './input'
-import { useConfig } from '../contexts'
-import { renderString, Item as NormalItem } from '../utils'
+import { Anchor } from './anchor'
+import { renderComponent, renderString } from '../utils'
+import { useConfig, useMenu } from '../contexts'
+import { useRouter } from 'next/router'
 
-interface ItemProps {
-  title: string
-  active: boolean
-  href: string
-  search: string
-  onMouseOver: MouseEventHandler
+type SearchProps = {
+  className?: string
+  value: string
+  onChange: (newValue: string) => void
+  load?: () => Promise<void>
+  loading: boolean
+  results: { route: string; prefix?: ReactNode; children: ReactNode }[]
 }
 
-const Item = ({
-  title,
-  active,
-  href,
-  onMouseOver,
-  search
-}: ItemProps): ReactElement => {
-  const highlight = title.toLowerCase().indexOf(search.toLowerCase())
-  return (
-    <li className={cn('p-2', { active })}>
-      <Anchor
-        href={href}
-        className="block no-underline"
-        onMouseOver={onMouseOver}
-      >
-        {title.substring(0, highlight)}
-        <span className="highlight">
-          {title.substring(highlight, highlight + search.length)}
-        </span>
-        {title.substring(highlight + search.length)}
-      </Anchor>
-    </li>
-  )
-}
-
-const UP = true
-const DOWN = false
-
-interface SearchProps {
-  directories: NormalItem[]
-}
-
-export function Search({ directories = [] }: SearchProps): ReactElement {
-  const router = useRouter()
-  const config = useConfig()
+export function Search({
+  className,
+  value,
+  onChange,
+  load,
+  loading,
+  results
+}: SearchProps): ReactElement {
   const [show, setShow] = useState(false)
-  const [search, setSearch] = useState('')
-  const [active, setActive] = useState<number | null>(null)
-  const input = useRef<HTMLInputElement | null>(null)
-  const results = useMemo<{ route: string; title: string }[]>(() => {
-    if (!search) return []
-
-    // Will need to scrape all the headers from each page and search through them here
-    // (similar to what we already do to render the hash links in sidebar)
-    // We could also try to search the entire string text from each page
-    return matchSorter(directories, search, { keys: ['title'] })
-  }, [search])
-
-  const moveActiveItem = (up: boolean) => {
-    const position = active !== null ? active + (up ? -1 : 1) : 0
-    const { length } = results
-
-    // Modulo instead of remainder,
-    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder
-    const next = (position + length) % length
-    setActive(next)
-  }
-
-  const handleKeyDown = useCallback<
-    React.KeyboardEventHandler<HTMLInputElement>
-  >(
-    e => {
-      const { key, ctrlKey } = e
-
-      if ((ctrlKey && key === 'n') || key === 'ArrowDown') {
-        e.preventDefault()
-        moveActiveItem(DOWN)
-      }
-
-      if ((ctrlKey && key === 'p') || key === 'ArrowUp') {
-        e.preventDefault()
-        moveActiveItem(UP)
-      }
-
-      if (active !== null && key === 'Enter' && results[active]) {
-        router.push(results[active].route)
-      }
-    },
-    [active, results, router]
-  )
-
-  const handleOnBlur = useCallback<React.FocusEventHandler<HTMLInputElement>>(
-    e => {
-      if (active === null) {
-        setShow(false)
-      }
-    },
-    [active]
-  )
+  const config = useConfig()
+  const [active, setActive] = useState(0)
+  const router = useRouter()
+  const { setMenu } = useMenu()
+  const input = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    setActive(null)
-  }, [search])
+    setActive(0)
+  }, [value])
 
   useEffect(() => {
     const inputs = ['input', 'select', 'button', 'textarea']
 
-    const down = (e: KeyboardEvent): void => {
+    const down = (e: KeyboardEvent) => {
       if (
+        input.current &&
         document.activeElement &&
         inputs.indexOf(document.activeElement.tagName.toLowerCase()) === -1
       ) {
-        if (e.key === '/') {
+        if (e.key === '/' || (e.key === 'k' && e.metaKey)) {
           e.preventDefault()
-          input.current?.focus()
+          input.current.focus()
         } else if (e.key === 'Escape') {
           setShow(false)
+          input.current.blur()
         }
       }
     }
@@ -138,42 +68,142 @@ export function Search({ directories = [] }: SearchProps): ReactElement {
     return () => window.removeEventListener('keydown', down)
   }, [])
 
-  const renderList = show && results.length > 0
+  const handleKeyDown = useCallback<
+    NonNullable<ComponentProps<'input'>['onKeyDown']>
+  >(
+    e => {
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault()
+          if (active + 1 < results.length) {
+            setActive(active + 1)
+            const activeElement = document.querySelector(
+              `.nextra-search li:nth-of-type(${active + 2}) > a`
+            )
+            activeElement?.scrollIntoView({
+              behavior: 'smooth',
+              block: 'nearest'
+            })
+          }
+          break
+        }
+        case 'ArrowUp': {
+          e.preventDefault()
+          if (active - 1 >= 0) {
+            setActive(active - 1)
+            const activeElement = document.querySelector(
+              `.nextra-search li:nth-of-type(${active}) > a`
+            )
+            activeElement?.scrollIntoView({
+              behavior: 'smooth',
+              block: 'nearest'
+            })
+          }
+          break
+        }
+        case 'Enter': {
+          router.push(results[active].route)
+          finishSearch()
+          break
+        }
+        case 'Escape': {
+          setShow(false)
+          input.current?.blur()
+          break
+        }
+      }
+    },
+    [active, results, router]
+  )
+
+  const finishSearch = () => {
+    if (input.current) {
+      input.current.value = ''
+      input.current.blur()
+    }
+    onChange('')
+    setShow(false)
+    setMenu(false)
+  }
+
+  const renderList = show && !!value
 
   return (
-    <div className="nextra-search relative w-full md:w-64">
+    <div className="nextra-search relative md:w-64">
       {renderList && (
         <div className="fixed inset-0 z-10" onClick={() => setShow(false)} />
       )}
 
       <Input
-        show={show}
+        ref={input}
         onChange={e => {
-          setSearch(e.target.value)
+          onChange(e.target.value)
           setShow(true)
         }}
         type="search"
         placeholder={renderString(config.searchPlaceholder)}
         onKeyDown={handleKeyDown}
-        onFocus={() => setShow(true)}
-        onBlur={handleOnBlur}
-        ref={input}
+        onFocus={() => {
+          load?.()
+          setShow(true)
+        }}
+        show={renderList}
       />
 
-      {renderList && (
-        <ul className="top-100 absolute left-0 z-20 m-0 mt-1 w-full list-none divide-y rounded border p-0 py-2.5 shadow-md md:right-0 md:w-auto">
-          {results.map((res, i) => (
-            <Item
-              key={`search-item-${i}`}
-              title={res.title}
-              href={res.route}
-              active={i === active}
-              search={search}
-              onMouseOver={() => setActive(i)}
-            />
-          ))}
-        </ul>
-      )}
+      <Transition
+        show={renderList}
+        as={Fragment}
+        leave="transition duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <Transition.Child>
+          <ul
+            className={cn(
+              // Using bg-white as background-color when the browser didn't support backdrop-filter
+              'bg-white text-gray-100 ring-1 ring-black/5',
+              'dark:bg-neutral-900 dark:ring-white/10',
+              'absolute top-full z-20 mt-2 overscroll-contain rounded-xl py-2.5 shadow-xl overflow-auto min-h-[100px]',
+              'right-0 left-0 ltr:md:left-auto rtl:md:right-auto',
+              'contrast-more:border contrast-more:border-gray-900 contrast-more:dark:border-gray-50',
+              className
+            )}
+          >
+            {loading ? (
+              <span className="flex select-none justify-center p-8 text-center text-sm text-gray-400 gap-2">
+                <SpinnerIcon className="h-5 w-5 animate-spin" />
+                Loading...
+              </span>
+            ) : results.length > 0 ? (
+              results.map(({ route, prefix, children }, i) => (
+                <Fragment key={`search-item-${i}`}>
+                  {prefix}
+                  <li
+                    className={cn(
+                      'mx-2.5 px-2.5 py-2 rounded-md break-words',
+                      'contrast-more:border',
+                      i === active
+                        ? 'bg-primary-500/10 text-primary-500 contrast-more:border-primary-500'
+                        : 'text-gray-800 dark:text-gray-300 contrast-more:border-transparent'
+                    )}
+                  >
+                    <Anchor
+                      className="block no-underline !text-current hover:!bg-transparent !p-0"
+                      href={router.basePath + route}
+                      onMouseMove={() => setActive(i)}
+                      onClick={finishSearch}
+                    >
+                      {children}
+                    </Anchor>
+                  </li>
+                </Fragment>
+              ))
+            ) : (
+              renderComponent(config.unstable_searchResultEmpty)
+            )}
+          </ul>
+        </Transition.Child>
+      </Transition>
     </div>
   )
 }

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router'
 import { Heading } from 'nextra'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
-import { Search } from './search'
+import { MatchSorterSearch } from './match-sorter-search'
 import { Flexsearch } from './flexsearch'
 import { useConfig, useMenu, useActiveAnchor } from '../contexts'
 import {
@@ -334,7 +334,7 @@ export function Sidebar({
                   config.unstable_flexsearch ? (
                     <Flexsearch />
                   ) : (
-                    <Search directories={flatDirectories} />
+                    <MatchSorterSearch directories={flatDirectories} />
                   )
                 ) : null)}
             </div>

--- a/packages/nextra-theme-docs/src/env.d.ts
+++ b/packages/nextra-theme-docs/src/env.d.ts
@@ -1,5 +1,3 @@
-declare module 'match-sorter'
-
 declare module 'title' {
   export default function title(
     title: string,

--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -134,16 +134,6 @@ p {
       button:focus-visible {
         @apply ring ring-primary-200;
       }
-      li.active > a,
-      li.active > a:hover {
-        @apply bg-primary-50 font-bold text-primary-500;
-        @apply dark:bg-primary-500/10 dark:text-primary-500;
-      }
-      @media (prefers-contrast: more) {
-        li.active > a {
-          @apply border border-primary-500 dark:border-primary-500;
-        }
-      }
       button,
       summary,
       li a {
@@ -313,22 +303,8 @@ p {
   .nextra-callout {
     @apply border-current dark:!border-current;
   }
-  .nextra-search {
-    ul {
-      @apply border border-gray-900 dark:border-gray-50;
-      div.nextra-search-section {
-        @apply border-gray-600 text-gray-900 dark:border-gray-50 dark:text-gray-50;
-      }
-      li {
-        @apply border border-transparent;
-        .excerpt {
-          @apply dark:text-gray-50;
-        }
-      }
-      li.active {
-        @apply border border-primary-500;
-      }
-    }
+  .nextra-search ul li .excerpt {
+    @apply dark:text-gray-50;
   }
   .nextra-navigation-links {
     border-color: #999 !important;
@@ -409,63 +385,21 @@ article {
 }
 
 /* Search */
-.nextra-search {
-  &.nextra-flexsearch ul {
-    max-height: min(calc(100vh - 5rem - env(safe-area-inset-bottom)), 400px);
-    max-width: min(calc(100vw - 2rem), calc(100% + 20rem));
-    transition: max-height 0.2s ease;
-  }
-  ul {
-    a {
-      scroll-margin: 50px;
-    }
-
-    /* Using bg-white as background-color when the browser didn't support backdrop-filter */
-    @apply bg-white text-gray-100 ring-1 ring-black/5;
-    li {
-      @apply mx-2.5 break-words rounded-md px-2.5 py-2 text-gray-800;
-      .highlight {
-        @apply text-primary-500 underline decoration-primary-400;
-      }
-    }
-    li.active,
-    a:focus li {
-      @apply bg-primary-400/10 text-primary-500;
-    }
-    .nextra-search-section {
-      @apply border-b border-black/10;
-      .dark & {
-        @apply border-b border-white/20;
-      }
-    }
-  }
-  .dark & {
-    /* Using bg-white as background-color when the browser didn't support backdrop-filter */
-    ul {
-      @apply bg-neutral-900 text-gray-100 ring-white/10;
-      li {
-        @apply text-gray-300;
-        .highlight {
-          @apply text-primary-500 underline decoration-primary-400;
-        }
-      }
-      li.active,
-      a:focus li {
-        @apply bg-primary-500/10 text-primary-500;
-      }
+.nextra-search ul {
+  max-height: min(calc(100vh - 5rem - env(safe-area-inset-bottom)), 400px);
+  transition: max-height 0.2s ease;
+  a {
+    scroll-margin: 50px;
+    .highlight {
+      @apply text-primary-500 underline decoration-primary-400;
     }
   }
   @supports (
     (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
   ) {
-    ul {
+    & {
       backdrop-filter: blur(16px);
-      @apply bg-opacity-70;
-    }
-    .dark & {
-      ul {
-        @apply bg-opacity-80;
-      }
+      @apply bg-opacity-70 dark:bg-opacity-80;
     }
   }
 }
@@ -479,7 +413,7 @@ article {
     line-clamp: 1;
     -webkit-box-orient: vertical;
   }
-  .nextra-search.nextra-flexsearch ul {
+  .nextra-search ul {
     max-height: min(calc(50vh - 11rem - env(safe-area-inset-bottom)), 400px);
   }
 }

--- a/packages/nextra-theme-docs/src/styles.css
+++ b/packages/nextra-theme-docs/src/styles.css
@@ -388,12 +388,6 @@ article {
 .nextra-search ul {
   max-height: min(calc(100vh - 5rem - env(safe-area-inset-bottom)), 400px);
   transition: max-height 0.2s ease;
-  a {
-    scroll-margin: 50px;
-    .highlight {
-      @apply text-primary-500 underline decoration-primary-400;
-    }
-  }
   @supports (
     (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
   ) {
@@ -405,16 +399,18 @@ article {
 }
 
 @media screen and (max-width: 767px) {
-  .nextra-search .excerpt {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    line-clamp: 1;
-    -webkit-box-orient: vertical;
-  }
-  .nextra-search ul {
-    max-height: min(calc(50vh - 11rem - env(safe-area-inset-bottom)), 400px);
+  .nextra-search {
+    .excerpt {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      line-clamp: 1;
+      -webkit-box-orient: vertical;
+    }
+    ul {
+      max-height: min(calc(50vh - 11rem - env(safe-area-inset-bottom)), 400px);
+    }
   }
 }
 

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -65,3 +65,10 @@ export type Context = {
   pageOpts: PageOpts
   themeConfig: DocsThemeConfig
 }
+
+export type SearchResult = {
+  id: string
+  route: string
+  prefix?: ReactNode
+  children: ReactNode
+}

--- a/packages/nextra-theme-docs/tailwind.config.js
+++ b/packages/nextra-theme-docs/tailwind.config.js
@@ -10,7 +10,7 @@ const makePrimaryColor =
   }
 
 module.exports = {
-  content: ['./src/**/*.{jsx,tsx}'],
+  content: ['./src/**/*.{jsx,tsx}', '../nextra/src/icons/*.tsx'],
   theme: {
     screens: {
       sm: '640px',

--- a/packages/nextra-theme-docs/tailwind.config.js
+++ b/packages/nextra-theme-docs/tailwind.config.js
@@ -10,7 +10,7 @@ const makePrimaryColor =
   }
 
 module.exports = {
-  content: ['./src/**/*.{jsx,tsx}', '../nextra/src/icons/*.tsx'],
+  content: ['./src/**/*.tsx', '../nextra/src/icons/*.tsx'],
   theme: {
     screens: {
       sm: '640px',

--- a/packages/nextra-theme-docs/tsconfig.json
+++ b/packages/nextra-theme-docs/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "allowJs": true,
     "jsx": "react",
-    "moduleResolution": "Node",
+    "moduleResolution": "node",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["vitest/globals"],
     "resolveJsonModule": true
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,7 +236,7 @@ importers:
       focus-visible: ^5.2.0
       github-slugger: ^1.4.0
       intersection-observer: ^0.12.2
-      match-sorter: ^4.2.0
+      match-sorter: ^6.3.1
       next: ^12.2.4
       next-themes: ^0.2.0-beta.2
       nextra: workspace:*
@@ -260,7 +260,7 @@ importers:
       focus-visible: 5.2.0
       github-slugger: 1.4.0
       intersection-observer: 0.12.2
-      match-sorter: 4.2.1
+      match-sorter: 6.3.1
       next-themes: 0.2.0_vyccxgqxcnj5vudpssiumaxlme
       parse-git-url: 1.0.1
       scroll-into-view-if-needed: 2.2.29
@@ -3457,8 +3457,8 @@ packages:
       unquote: 1.1.1
     dev: false
 
-  /match-sorter/4.2.1:
-    resolution: {integrity: sha512-s+3h9TiZU9U1pWhIERHf8/f4LmBN6IXaRgo2CI17+XGByGS1GvG5VvXK9pcGyCjGe3WM3mSYRC3ipGrd5UEVgw==}
+  /match-sorter/6.3.1:
+    resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
     dependencies:
       '@babel/runtime': 7.18.6
       remove-accents: 0.4.2
@@ -6462,7 +6462,7 @@ packages:
     resolution: {directory: packages/nextra-theme-blog, type: directory}
     id: file:packages/nextra-theme-blog
     name: nextra-theme-blog
-    version: 2.0.0-beta.16
+    version: 2.0.0-beta.17
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6483,7 +6483,7 @@ packages:
     resolution: {directory: packages/nextra-theme-docs, type: directory}
     id: file:packages/nextra-theme-docs
     name: nextra-theme-docs
-    version: 2.0.0-beta.16
+    version: 2.0.0-beta.17
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6498,7 +6498,7 @@ packages:
       focus-visible: 5.2.0
       github-slugger: 1.4.0
       intersection-observer: 0.12.2
-      match-sorter: 4.2.1
+      match-sorter: 6.3.1
       next: 12.2.4_biqbaboplfbrettd7655fr4n2y
       next-themes: 0.2.0_vyccxgqxcnj5vudpssiumaxlme
       parse-git-url: 1.0.1
@@ -6512,7 +6512,7 @@ packages:
     resolution: {directory: packages/nextra, type: directory}
     id: file:packages/nextra
     name: nextra
-    version: 2.0.0-beta.16
+    version: 2.0.0-beta.17
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'


### PR DESCRIPTION
`<Flexsearch />` component is much more beautiful and contains smarter keyboard handlers that can be extracted to `<Search />` component and reused in both searches (flexsearch and match-sorter)
fixes https://github.com/shuding/nextra/issues/694

Previous 
![image](https://user-images.githubusercontent.com/7361780/184511368-e12aa6ff-8d00-46c9-842a-2156202a264f.png)

## Now (match-sorter):


https://user-images.githubusercontent.com/7361780/184511575-47abb663-c3f7-44a4-a3c7-40d211e9a422.mov


https://user-images.githubusercontent.com/7361780/184511578-763c390b-bad6-4b01-b6b1-e5a7d67e4ae2.mov



## flexsearch (styles like previous)

https://user-images.githubusercontent.com/7361780/184511517-9c1fc4bb-5448-4897-990d-159ae89d1aed.mov


https://user-images.githubusercontent.com/7361780/184511555-4b9afe20-e7fe-4a42-8033-8757164e6103.mov


https://user-images.githubusercontent.com/7361780/184511557-8b563b99-8088-4558-b784-d2d118867b71.mov


