### PR TITLE
docs(configuration): fix `footerEditLink` type

### DIFF
--- a/pages/themes/docs/configuration.mdx
+++ b/pages/themes/docs/configuration.mdx
@@ -119,7 +119,7 @@ export default {
 
 The text that should be shown on the link that leads to the editable page on the repository.
 
-**Type:** `boolean`\
+**Type:** `ReactNode`\
 **Default:** `Edit this page`
 
 **Example:** `Edit this page on GitHub`


### PR DESCRIPTION
Update `Type` value for `footerEditLink` property (as it not supposed to be a `boolean`).

See: https://github.com/shuding/nextra/blob/237faa9d606cfce005b0fee69338768b54499163/packages/nextra-theme-docs/src/types.ts#L25