### PR TITLE
Use 'main' as GitLab default branch

### DIFF
--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -21,7 +21,7 @@ const getEditUrl = (filepath?: string): string => {
       }/${repo.subdir || 'pages'}${filepath}`
     case 'gitlab':
       return `https://gitlab.com/${repo.owner}/${repo.name}/-/blob/${
-        repo.branch || 'master'
+        repo.branch || 'main'
       }/${repo.subdir || 'pages'}${filepath}`
   }
 


### PR DESCRIPTION
Use 'main' as the default branch for GitLab, just like GitHub. It is the default starting ~April to June 2021

https://about.gitlab.com/blog/2021/03/10/new-git-default-branch-name/