### PR TITLE
[docs] ❗️BREAKING ❗️ various theme config options was renamed

### DIFF
--- a/.changeset/curvy-tomatoes-worry.md
+++ b/.changeset/curvy-tomatoes-worry.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+BREAKING! various theme config options was renamed, take a look of renamed options [here](https://github.com/shuding/nextra/blob/core/packages/nextra-theme-docs/src/constants.tsx)

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,7 @@ module.exports = {
     {
       // TODO: enable for `nextra-theme-blog` also
       files: 'packages/nextra-theme-docs/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+      plugins: ['typescript-sort-keys'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/examples/blog/theme.config.jsx
+++ b/examples/blog/theme.config.jsx
@@ -1,4 +1,6 @@
+/* eslint sort-keys: error */
 export default {
+  darkMode: true,
   footer: (
     <small style={{ display: 'block', marginTop: '8rem' }}>
       <abbr
@@ -22,5 +24,4 @@ export default {
       `}</style>
     </small>
   ),
-  darkMode: true
 }

--- a/examples/docs/src/pages/themes/docs/bleed.mdx
+++ b/examples/docs/src/pages/themes/docs/bleed.mdx
@@ -27,10 +27,9 @@ For example you can put text, image, video or any component inside:
   <iframe
     width="100%"
     height="430"
-    src="https://www.youtube.com/embed/3hccXiXI0u8"
-    frameBorder="0"
+    src="https://youtube.com/embed/3hccXiXI0u8"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullscreen
+    allowFullScreen
   />
 </Bleed>
 

--- a/examples/docs/src/theme.config.js
+++ b/examples/docs/src/theme.config.js
@@ -1,19 +1,14 @@
+/* eslint sort-keys: error */
 /**
  * @type {import('nextra-theme-docs').DocsThemeConfig}
  */
 export default {
-  projectLink: 'https://github.com/shuding/nextra',
+  banner: {
+    key: 'Nextra 2',
+    text: 'Nextra 2 Alpha',
+  },
   docsRepositoryBase: 'https://github.com/shuding/nextra/blob/core/examples/docs',
-  projectChatLink: 'https://discord.gg/hEM84NMkRv', // Next.js discord server,
-  titleSuffix: ' – Nextra',
-  logo: (
-    <>
-      <span className="mr-2 font-extrabold hidden md:inline">Nextra</span>
-      <span className="text-gray-600 font-normal hidden md:inline">
-        The Next.js Static Site Generator
-      </span>
-    </>
-  ),
+  editLink: 'Edit this page on GitHub',
   head: () => (
     <>
       <meta name="msapplication-TileColor" content="#ffffff" />
@@ -61,14 +56,8 @@ export default {
       <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
     </>
   ),
-  search: true,
+  projectChat: {
+    link: 'https://discord.gg/hEM84NMkRv', // Next.js discord server,
+  },
   unstable_faviconGlyph: '✦',
-  prevLinks: true,
-  nextLinks: true,
-  footer: true,
-  footerEditLink: 'Edit this page on GitHub',
-  footerText: `MIT ${new Date().getFullYear()} © Nextra.`,
-  darkMode: true,
-  bannerKey: 'Nextra 2',
-  banner: 'Nextra 2 Alpha'
 }

--- a/examples/docs/src/theme.config.js
+++ b/examples/docs/src/theme.config.js
@@ -8,7 +8,7 @@ export default {
     text: 'Nextra 2 Alpha',
   },
   docsRepositoryBase: 'https://github.com/shuding/nextra/blob/core/examples/docs',
-  editLink: 'Edit this page on GitHub',
+  editLinkText: 'Edit this page on GitHub',
   head: () => (
     <>
       <meta name="msapplication-TileColor" content="#ffffff" />

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -1,5 +1,5 @@
+/* eslint sort-keys: error */
 import { useRouter } from "next/router";
-import NextHead from "next/head";
 import { DocsThemeConfig, useConfig } from "nextra-theme-docs";
 
 const Logo = ({ height }) => (
@@ -20,56 +20,117 @@ const Vercel = () => (
   </svg>
 );
 
-const TITLE_WITH_TRANSLATIONS = {
+const TITLE = {
   "en-US": "React Hooks for Data Fetching",
-  "zh-CN": "用于数据请求的 React Hooks 库",
   "es-ES": "Biblioteca React Hooks para la obtención de datos",
   ja: "データ取得のための React Hooks ライブラリ",
   ko: "데이터 가져오기를 위한 React Hooks",
   ru: "React хуки для выборки данных",
+  "zh-CN": "用于数据请求的 React Hooks 库",
 };
 
-const EDIT_LINK_WITH_TRANSLATIONS = {
-  "zh-CN": "在 GitHub 上编辑本页",
+const EDIT_TEXT = {
+  "en-US": "Edit this page on GitHub →",
   "es-ES": "Edite esta página en GitHub",
   ja: "Github で編集する",
   ko: "Github에서 이 페이지 편집하기",
   ru: "Редактировать на GitHub",
+  "zh-CN": "在 GitHub 上编辑本页",
+};
+
+const FOOTER_LINK = {
+  "en-US": "https://vercel.com/?utm_source=swr",
+  "es-ES": "https://vercel.com/?utm_source=swr_es-es",
+  ja: "https://vercel.com/?utm_source=swr_ja",
+  ko: "https://vercel.com/?utm_source=swr_ko",
+  ru: "https://vercel.com/?utm_source=swr_ru",
+  "zh-CN": "https://vercel.com/?utm_source=swr_zh-cn",
 };
 
 const config: DocsThemeConfig = {
-  github: "https://github.com/vercel/swr",
-  docsRepositoryBase: "https://github.com/shuding/nextra/blob/core/examples/swr-site",
-  titleSuffix() {
-    const { locale } = useRouter();
-    return ` – SWR (${locale})`;
+  banner: {
+    key: "swr-2",
+    text: "SWR 2.0 is out! Read more →",
   },
-  search: true,
-  floatTOC: true,
-  darkMode: true,
-  defaultMenuCollapsed: true,
-  nextThemes: {
-    defaultTheme: "dark",
-  },
-  feedbackLink: "Question? Give us feedback →",
-  feedbackLabels: "feedback",
-  bannerKey: "swr-2",
-  banner: "SWR 2.0 is out! Read more →",
-  tocExtraContent: <img src="https://placekitten.com/g/300/200" />,
-  logo() {
-    const { locale } = useRouter();
+  bodyExtraContent() {
+    const router = useRouter();
     return (
-      <>
-        <Logo height={12} />
-        <span
-          className="ltr:ml-2 rtl:mr-2 font-extrabold hidden md:inline select-none"
-          title={"SWR: " + (TITLE_WITH_TRANSLATIONS[locale] || "")}
-        >
-          SWR
-        </span>
-      </>
+      router.route.startsWith("/docs") && (
+        <>💪 content from `config.bodyExtraContent`</>
+      )
     );
   },
+  darkMode: true,
+  docsRepositoryBase:
+    "https://github.com/shuding/nextra/blob/core/examples/swr-site",
+  editLink() {
+    const { locale } = useRouter();
+    return EDIT_TEXT[locale] || EDIT_TEXT["en-US"];
+  },
+  feedback: {
+    labels: "feedback",
+    link: "Question? Give us feedback →",
+  },
+  footer: {
+    text() {
+      const { locale } = useRouter();
+
+      const linkProps = {
+        className: "inline-flex items-center font-semibold gap-2",
+        href: FOOTER_LINK[locale],
+        rel: "noopener",
+        target: "_blank",
+      };
+
+      switch (locale) {
+        case "zh-CN":
+          return (
+            <a {...linkProps}>
+              由
+              <Vercel />
+              驱动
+            </a>
+          );
+        case "es-ES":
+          return (
+            <a {...linkProps}>
+              Desarrollado por
+              <Vercel />
+            </a>
+          );
+        case "ja":
+          return (
+            <a {...linkProps}>
+              提供
+              <Vercel />
+            </a>
+          );
+        case "ko":
+          return (
+            <a {...linkProps}>
+              Powered by
+              <Vercel />
+            </a>
+          );
+        case "ru":
+          return (
+            <a {...linkProps}>
+              Работает на
+              <Vercel />
+            </a>
+          );
+        default:
+          return (
+            <a {...linkProps}>
+              Powered by
+              <Vercel />
+            </a>
+          );
+      }
+    },
+  },
+  gitTimestamp: "Last updated on",
+  github: "https://github.com/vercel/swr",
   head() {
     const config = useConfig();
     const description =
@@ -117,95 +178,47 @@ const config: DocsThemeConfig = {
       </>
     );
   },
-  sidebarSubtitle: ({ title }) => (
-    <div className="flex items-center gap-2">
-      <Logo height={6} />
-      {title}
-    </div>
-  ),
-  footerEditLink() {
-    const { locale } = useRouter();
-    return EDIT_LINK_WITH_TRANSLATIONS[locale] || "Edit this page on GitHub →";
-  },
-  footerText() {
-    const { locale } = useRouter();
-
-    const linkProps = {
-      target: "_blank",
-      rel: "noopener",
-      className: "inline-flex items-center font-semibold gap-2",
-      href:
-        {
-          "zh-CN": "https://vercel.com/?utm_source=swr_zh-cn",
-          "es-ES": "https://vercel.com/?utm_source=swr_es-es",
-          ja: "https://vercel.com/?utm_source=swr_ja",
-          ko: "https://vercel.com/?utm_source=swr_ko",
-          ru: "https://vercel.com/?utm_source=swr_ru",
-        }[locale] || "https://vercel.com/?utm_source=swr",
-    };
-
-    switch (locale) {
-      case "zh-CN":
-        return (
-          <a {...linkProps}>
-            由
-            <Vercel />
-            驱动
-          </a>
-        );
-      case "es-ES":
-        return (
-          <a {...linkProps}>
-            Desarrollado por
-            <Vercel />
-          </a>
-        );
-      case "ja":
-        return (
-          <a {...linkProps}>
-            提供
-            <Vercel />
-          </a>
-        );
-      case "ko":
-        return (
-          <a {...linkProps}>
-            Powered by
-            <Vercel />
-          </a>
-        );
-      case "ru":
-        return (
-          <a {...linkProps}>
-            Работает на
-            <Vercel />
-          </a>
-        );
-      default:
-        return (
-          <a {...linkProps}>
-            Powered by
-            <Vercel />
-          </a>
-        );
-    }
-  },
   i18n: [
     { locale: "en-US", text: "English" },
-    { locale: "es-ES", text: "Español RTL", direction: "rtl" },
+    { direction: "rtl", locale: "es-ES", text: "Español RTL" },
     { locale: "zh-CN", text: "简体中文" },
     { locale: "ja", text: "日本語" },
     { locale: "ko", text: "한국어" },
     { locale: "ru", text: "Русский" },
   ],
-  gitTimestamp: "Last updated on",
-  bodyExtraContent() {
-    const router = useRouter();
+  logo() {
+    const { locale } = useRouter();
     return (
-      router.route.startsWith("/docs") && (
-        <>💪 content from `config.bodyExtraContent`</>
-      )
+      <>
+        <Logo height={12} />
+        <span
+          className="ltr:ml-2 rtl:mr-2 font-extrabold hidden md:inline select-none"
+          title={"SWR: " + (TITLE[locale] || "")}
+        >
+          SWR
+        </span>
+      </>
     );
+  },
+  nextThemes: {
+    defaultTheme: "dark",
+  },
+  sidebar: {
+    defaultMenuCollapsed: true,
+    subtitle: ({ title }) => (
+      <div className="flex items-center gap-2">
+        <Logo height={6} />
+        {title}
+      </div>
+    ),
+  },
+  titleSuffix() {
+    const { locale } = useRouter();
+    return ` – SWR (${locale})`;
+  },
+  toc: {
+    extraContent: <img src="https://placekitten.com/g/300/200" />,
+    float: true,
   },
 };
 

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -47,6 +47,46 @@ const FOOTER_LINK = {
   "zh-CN": "https://vercel.com/?utm_source=swr_zh-cn",
 };
 
+const FOOTER_LINK_TEXT = {
+  "en-US": (
+    <>
+      Powered by
+      <Vercel />
+    </>
+  ),
+  "es-ES": (
+    <>
+      Desarrollado por
+      <Vercel />
+    </>
+  ),
+  ja: (
+    <>
+      提供
+      <Vercel />
+    </>
+  ),
+  ko: (
+    <>
+      Powered by
+      <Vercel />
+    </>
+  ),
+  ru: (
+    <>
+      Работает на
+      <Vercel />
+    </>
+  ),
+  "zh-CN": (
+    <>
+      由
+      <Vercel />
+      驱动
+    </>
+  ),
+};
+
 const config: DocsThemeConfig = {
   banner: {
     key: "swr-2",
@@ -63,9 +103,9 @@ const config: DocsThemeConfig = {
   darkMode: true,
   docsRepositoryBase:
     "https://github.com/shuding/nextra/blob/core/examples/swr-site",
-  editLink() {
+  editLinkText() {
     const { locale } = useRouter();
-    return EDIT_TEXT[locale] || EDIT_TEXT["en-US"];
+    return EDIT_TEXT[locale];
   },
   feedback: {
     labels: "feedback",
@@ -74,59 +114,16 @@ const config: DocsThemeConfig = {
   footer: {
     text() {
       const { locale } = useRouter();
-
-      const linkProps = {
-        className: "inline-flex items-center font-semibold gap-2",
-        href: FOOTER_LINK[locale],
-        rel: "noopener",
-        target: "_blank",
-      };
-
-      switch (locale) {
-        case "zh-CN":
-          return (
-            <a {...linkProps}>
-              由
-              <Vercel />
-              驱动
-            </a>
-          );
-        case "es-ES":
-          return (
-            <a {...linkProps}>
-              Desarrollado por
-              <Vercel />
-            </a>
-          );
-        case "ja":
-          return (
-            <a {...linkProps}>
-              提供
-              <Vercel />
-            </a>
-          );
-        case "ko":
-          return (
-            <a {...linkProps}>
-              Powered by
-              <Vercel />
-            </a>
-          );
-        case "ru":
-          return (
-            <a {...linkProps}>
-              Работает на
-              <Vercel />
-            </a>
-          );
-        default:
-          return (
-            <a {...linkProps}>
-              Powered by
-              <Vercel />
-            </a>
-          );
-      }
+      return (
+        <a
+          rel="noopener"
+          target="_blank"
+          className="inline-flex items-center font-semibold gap-2"
+          href={FOOTER_LINK[locale]}
+        >
+          {FOOTER_LINK_TEXT[locale]}
+        </a>
+      );
     },
   },
   gitTimestamp: "Last updated on",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@edge-runtime/vm": "1.1.0-beta.23",
     "@typescript-eslint/parser": "^5.32.0",
     "eslint": "^8.21.0",
+    "eslint-plugin-typescript-sort-keys": "^2.1.0",
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/packages/nextra-theme-blog/src/constants.tsx
+++ b/packages/nextra-theme-blog/src/constants.tsx
@@ -1,11 +1,12 @@
+/* eslint sort-keys: error */
 import React from 'react'
 import { NextraBlogTheme } from './types'
 
 export const DEFAULT_THEME: NextraBlogTheme = {
-  readMore: 'Read More →',
   footer: (
     <small className="block mt-32">
       CC BY-NC 4.0 {new Date().getFullYear()} © Shu Ding.
     </small>
-  )
+  ),
+  readMore: 'Read More →',
 }

--- a/packages/nextra-theme-blog/src/types.ts
+++ b/packages/nextra-theme-blog/src/types.ts
@@ -1,29 +1,30 @@
+/* eslint typescript-sort-keys/interface: error */
 import { PageOpts } from 'nextra'
-import React from 'react'
+import { ReactNode } from 'react'
 
 export interface NextraBlogTheme {
-  readMore?: string
-  footer?: React.ReactNode
-  titleSuffix?: string
-  postFooter?: string
-  head?: ({
-    title,
-    meta
-  }: {
-    title: string
-    meta: Record<string, any>
-  }) => React.ReactNode
+  comments?: ReactNode
   cusdis?: {
     appId: string
     host?: string
     lang: string
   }
   darkMode?: boolean
+  footer?: ReactNode
+  head?: ({
+    meta,
+    title,
+  }: {
+    meta: Record<string, any>
+    title: string
+  }) => ReactNode
   navs?: {
-    url: string
     name: string
+    url: string
   }[]
-  comments?: React.ReactNode
+  postFooter?: string
+  readMore?: string
+  titleSuffix?: string
 }
 
 export interface BlogPageOpts extends PageOpts {
@@ -31,13 +32,13 @@ export interface BlogPageOpts extends PageOpts {
 }
 
 type Meta = {
-  title?: string
-  type?: 'post' | 'page' | 'posts' | 'tag'
-  tag?: string | string[]
+  author?: string
   back?: string
   date?: string
   description?: string
-  author?: string
+  tag?: string | string[]
+  title?: string
+  type?: 'post' | 'page' | 'posts' | 'tag'
 }
 
 export interface LayoutProps {

--- a/packages/nextra-theme-docs/src/components/banner.tsx
+++ b/packages/nextra-theme-docs/src/components/banner.tsx
@@ -3,36 +3,36 @@ import { XIcon } from 'nextra/icons'
 import { useConfig } from '../contexts'
 import { renderComponent } from '../utils'
 
-export function Banner(): ReactElement {
-  const { bannerKey, banner } = useConfig()
-
+export function Banner(): ReactElement | null {
+  const { banner } = useConfig()
+  if (!banner.text) {
+    return null
+  }
   return (
     <>
       <script
         dangerouslySetInnerHTML={{
           __html: `try{if(localStorage.getItem(${JSON.stringify(
-            bannerKey
+            banner.key
           )})==='0'){document.body.classList.add('nextra-banner-hidden')}}catch(e){}`
         }}
       />
-      {banner && bannerKey ? (
-        <div className="nextra-banner-container sticky top-0 z-20 flex h-10 items-center bg-neutral-900 pl-10 text-sm text-slate-50  dark:bg-[linear-gradient(1deg,#383838,#212121)] dark:text-white md:relative">
-          <div className="mx-auto w-full max-w-[90rem] truncate whitespace-nowrap py-1 pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)] text-center font-medium">
-            {renderComponent(banner)}
-          </div>
-          <button
-            className="mr-2 w-8 opacity-80 hover:opacity-100"
-            onClick={() => {
-              try {
-                localStorage.setItem(bannerKey, '0')
-              } catch {}
-              document.body.classList.add('nextra-banner-hidden')
-            }}
-          >
-            <XIcon className="h4 mx-auto w-4" />
-          </button>
+      <div className="nextra-banner-container sticky top-0 z-20 flex h-10 items-center bg-neutral-900 pl-10 text-sm text-slate-50  dark:bg-[linear-gradient(1deg,#383838,#212121)] dark:text-white md:relative">
+        <div className="mx-auto w-full max-w-[90rem] truncate whitespace-nowrap py-1 pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)] text-center font-medium">
+          {renderComponent(banner.text)}
         </div>
-      ) : null}
+        <button
+          className="mr-2 w-8 opacity-80 hover:opacity-100"
+          onClick={() => {
+            try {
+              localStorage.setItem(banner.key, '0')
+            } catch {}
+            document.body.classList.add('nextra-banner-hidden')
+          }}
+        >
+          <XIcon className="h4 mx-auto w-4" />
+        </button>
+      </div>
     </>
   )
 }

--- a/packages/nextra-theme-docs/src/components/footer.tsx
+++ b/packages/nextra-theme-docs/src/components/footer.tsx
@@ -5,7 +5,7 @@ import { LocaleSwitch } from './locale-switch'
 import { ThemeSwitch } from './theme-switch'
 import { renderComponent } from '../utils'
 
-export function Footer({ menu }: { menu?: boolean }): ReactElement | null {
+export function Footer({ menu }: { menu?: boolean }): ReactElement {
   const config = useConfig()
   return (
     <footer className="bg-gray-100 pb-[env(safe-area-inset-bottom)] dark:bg-neutral-900">

--- a/packages/nextra-theme-docs/src/components/footer.tsx
+++ b/packages/nextra-theme-docs/src/components/footer.tsx
@@ -5,9 +5,8 @@ import { LocaleSwitch } from './locale-switch'
 import { ThemeSwitch } from './theme-switch'
 import { renderComponent } from '../utils'
 
-export function Footer({ menu }: { menu?: boolean }): ReactElement {
+export function Footer({ menu }: { menu?: boolean }): ReactElement | null {
   const config = useConfig()
-
   return (
     <footer className="bg-gray-100 pb-[env(safe-area-inset-bottom)] dark:bg-neutral-900">
       <div
@@ -18,11 +17,11 @@ export function Footer({ menu }: { menu?: boolean }): ReactElement {
       >
         <div className="mx-auto max-w-[90rem]">
           <div className="inline-flex px-4">
-            {config.i18n ? (
+            {config.i18n.length > 0 && (
               <div className="relative flex-1">
                 <LocaleSwitch options={config.i18n} />
               </div>
-            ) : null}
+            )}
             {config.darkMode ? (
               <div className="relative grow-0">
                 <ThemeSwitch lite={false} />
@@ -34,7 +33,7 @@ export function Footer({ menu }: { menu?: boolean }): ReactElement {
       <div className="mx-auto max-w-[90rem] py-12 pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
         <div className="flex flex-col-reverse items-center justify-between md:flex-row md:items-end">
           <span className="text-gray-600 dark:text-gray-400">
-            {renderComponent(config.footerText)}
+            {renderComponent(config.footer.text)}
           </span>
           <div className="mt-6" />
         </div>

--- a/packages/nextra-theme-docs/src/components/locale-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/locale-switch.tsx
@@ -3,16 +3,14 @@ import { useRouter } from 'next/router'
 import { Select } from './select'
 import { DocsThemeConfig } from '../types'
 import { GlobeIcon } from 'nextra/icons'
-import { DEFAULT_LOCALE } from '../constants'
 
 interface LocaleSwitchProps {
   options: NonNullable<DocsThemeConfig['i18n']>
 }
 
 export function LocaleSwitch({ options }: LocaleSwitchProps): ReactElement {
-  const { locale = DEFAULT_LOCALE, asPath } = useRouter()
-  const selected = options.find(l => locale === l.locale)!
-
+  const { locale, asPath } = useRouter()
+  const selected = options.find(l => locale === l.locale)
   return (
     <Select
       onChange={option => {
@@ -23,11 +21,11 @@ export function LocaleSwitch({ options }: LocaleSwitchProps): ReactElement {
         location.href = asPath
       }}
       selected={{
-        key: selected.locale,
+        key: selected?.locale || '',
         name: (
           <div className="flex items-center gap-2">
             <GlobeIcon />
-            <span>{selected.text}</span>
+            <span>{selected?.text}</span>
           </div>
         )
       }}

--- a/packages/nextra-theme-docs/src/components/nav-links.tsx
+++ b/packages/nextra-theme-docs/src/components/nav-links.tsx
@@ -15,8 +15,8 @@ export const NavLinks = ({
   currentIndex
 }: NavLinkProps): ReactElement | null => {
   const config = useConfig()
-  const prev = config.prevLinks ? flatDirectories[currentIndex - 1] : null
-  const next = config.nextLinks ? flatDirectories[currentIndex + 1] : null
+  const prev = config.navigation.prev ? flatDirectories[currentIndex - 1] : null
+  const next = config.navigation.next ? flatDirectories[currentIndex + 1] : null
 
   if (!prev && !next) return null
 

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -5,9 +5,7 @@ import { Menu, Transition } from '@headlessui/react'
 import { ArrowRightIcon } from 'nextra/icons'
 
 import { useConfig, useMenu } from '../contexts'
-import { MatchSorterSearch } from './match-sorter-search'
-import { Flexsearch } from './flexsearch'
-import { GitHubIcon, DiscordIcon, MenuIcon } from 'nextra/icons'
+import { MenuIcon } from 'nextra/icons'
 import { Item, PageItem, MenuItem, renderComponent, getFSRoute } from '../utils'
 import { Anchor } from './anchor'
 import { DEFAULT_LOCALE } from '../constants'
@@ -156,47 +154,28 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         })}
 
         <div className="hidden md:inline-block min-w-[200px]">
-          {config.customSearch ||
-            (config.search ? (
-              config.unstable_flexsearch ? (
-                <Flexsearch />
-              ) : (
-                <MatchSorterSearch directories={flatDirectories} />
-              )
-            ) : null)}
+          {renderComponent(config.search.component, {
+            directories: flatDirectories
+          })}
         </div>
 
-        {config.projectLink || config.github ? (
+        {config.project.link || config.github ? (
           <Anchor
             className="p-2 text-current"
-            href={config.projectLink || config.github}
+            href={config.project.link || config.github}
             newWindow
           >
-            {config.projectLinkIcon ? (
-              renderComponent(config.projectLinkIcon)
-            ) : (
-              <>
-                <GitHubIcon />
-                <span className="sr-only">GitHub</span>
-              </>
-            )}
+            {renderComponent(config.project.icon)}
           </Anchor>
         ) : null}
 
-        {config.projectChatLink ? (
+        {config.projectChat.link ? (
           <Anchor
             className="p-2 text-current"
-            href={config.projectChatLink}
+            href={config.projectChat.link}
             newWindow
           >
-            {config.projectChatLinkIcon ? (
-              renderComponent(config.projectChatLinkIcon)
-            ) : (
-              <>
-                <DiscordIcon />
-                <span className="sr-only">Discord</span>
-              </>
-            )}
+            {renderComponent(config.projectChat.icon)}
           </Anchor>
         ) : null}
 

--- a/packages/nextra-theme-docs/src/components/not-found.tsx
+++ b/packages/nextra-theme-docs/src/components/not-found.tsx
@@ -1,14 +1,15 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import { useConfig } from '../contexts'
 import { renderComponent, useMounted, getGitIssueUrl } from '../utils'
 import { useRouter } from 'next/router'
 import { Anchor } from './anchor'
 
-export function NotFoundPage() {
+export function NotFoundPage(): ReactElement | null {
   const config = useConfig()
   const mounted = useMounted()
   const { asPath } = useRouter()
-  if (!config.notFoundLink) {
+  const { link, labels } = config.notFound
+  if (!link) {
     return null
   }
 
@@ -18,12 +19,12 @@ export function NotFoundPage() {
         href={getGitIssueUrl({
           repository: config.docsRepositoryBase,
           title: `Found broken \`${mounted ? asPath : ''}\` link. Please fix!`,
-          labels: config.notFoundLabels
+          labels
         })}
         newWindow
         className="ring-primary-500/30 focus:outline-none focus-visible:ring text-primary-500 underline decoration-from-font [text-underline-position:under]"
       >
-        {renderComponent(config.notFoundLink)}
+        {renderComponent(link)}
       </Anchor>
     </p>
   )

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -194,7 +194,7 @@ export function Search({
           setShow(true)
         }}
         type="search"
-        placeholder={renderString(config.searchPlaceholder)}
+        placeholder={renderString(config.search.placeholder)}
         onKeyDown={handleKeyDown}
         onFocus={handleFocusAndBlur}
         onBlur={handleFocusAndBlur}
@@ -258,7 +258,7 @@ export function Search({
                 </Fragment>
               ))
             ) : (
-              renderComponent(config.unstable_searchResultEmpty)
+              renderComponent(config.search.emptyResult)
             )}
           </ul>
         </Transition.Child>

--- a/packages/nextra-theme-docs/src/components/server-side-error.tsx
+++ b/packages/nextra-theme-docs/src/components/server-side-error.tsx
@@ -1,14 +1,15 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import { useConfig } from '../contexts'
 import { renderComponent, useMounted, getGitIssueUrl } from '../utils'
 import { useRouter } from 'next/router'
 import { Anchor } from './anchor'
 
-export function ServerSideErrorPage() {
+export function ServerSideErrorPage(): ReactElement | null {
   const config = useConfig()
   const mounted = useMounted()
   const { asPath } = useRouter()
-  if (!config.serverSideErrorLink) {
+  const { link, labels } = config.serverSideError
+  if (!link) {
     return null
   }
 
@@ -20,12 +21,12 @@ export function ServerSideErrorPage() {
           title: `Got server-side error in \`${
             mounted ? asPath : ''
           }\` url. Please fix!`,
-          labels: config.serverSideErrorLabels
+          labels
         })}
         newWindow
         className="ring-primary-500/30 focus:outline-none focus-visible:ring text-primary-500 underline decoration-from-font [text-underline-position:under]"
       >
-        {renderComponent(config.serverSideErrorLink)}
+        {renderComponent(link)}
       </Anchor>
     </p>
   )

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -5,8 +5,6 @@ import { useRouter } from 'next/router'
 import { Heading } from 'nextra'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
-import { MatchSorterSearch } from './match-sorter-search'
-import { Flexsearch } from './flexsearch'
 import { useConfig, useMenu, useActiveAnchor } from '../contexts'
 import {
   Item,
@@ -39,11 +37,12 @@ function FolderImpl({ item, anchors }: FolderProps) {
   const active = [route, route + '/'].includes(item.route + '/')
   const activeRouteInside = active || route.startsWith(item.route + '/')
 
-  const { defaultMenuCollapsed, setMenu } = useMenu()
+  const { setMenu } = useMenu()
+  const config = useConfig()
   const open =
     TreeState[item.route] !== undefined
       ? TreeState[item.route]
-      : active || activeRouteInside || !defaultMenuCollapsed
+      : active || activeRouteInside || !config.sidebar.defaultMenuCollapsed
 
   const rerender = useState({})[1]
 
@@ -149,7 +148,7 @@ interface SeparatorProps {
 function Separator({ title, topLevel }: SeparatorProps): ReactElement {
   // since title can be empty string ''
   const hasTitle = title !== undefined
-  const { sidebarSubtitle } = useConfig()
+  const config = useConfig()
   return (
     <li
       className={cn(
@@ -160,9 +159,7 @@ function Separator({ title, topLevel }: SeparatorProps): ReactElement {
     >
       {hasTitle ? (
         <div className="mx-2 py-1.5 text-sm font-semibold text-gray-900 dark:text-gray-100">
-          {sidebarSubtitle
-            ? renderComponent(sidebarSubtitle, { title })
-            : title}
+          {renderComponent(config.sidebar.subtitle, { title })}
         </div>
       ) : (
         <hr className="mx-2 border-t border-gray-200 dark:border-primary-100/10" />
@@ -334,14 +331,9 @@ export function Sidebar({
                 'dark:bg-dark shadow-[0_2px_14px_6px_#fff] dark:shadow-[0_2px_14px_6px_#111]'
               )}
             >
-              {config.customSearch ||
-                (config.search ? (
-                  config.unstable_flexsearch ? (
-                    <Flexsearch />
-                  ) : (
-                    <MatchSorterSearch directories={flatDirectories} />
-                  )
-                ) : null)}
+              {renderComponent(config.search.component, {
+                directories: flatDirectories
+              })}
             </div>
             <div className="hidden md:block">
               <Menu
@@ -349,7 +341,7 @@ export function Sidebar({
                 directories={docsDirectories}
                 // When the viewport size is larger than `md`, hide the anchors in
                 // the sidebar when `floatTOC` is enabled.
-                anchors={config.floatTOC ? [] : anchors}
+                anchors={config.toc.float ? [] : anchors}
               />
             </div>
             <div className="md:hidden">
@@ -370,11 +362,11 @@ export function Sidebar({
               )}
             >
               <div className="flex gap-1 bg-white py-4 pb-4 dark:bg-dark justify-between">
-                {config.i18n ? (
+                {config.i18n.length > 0 && (
                   <div className="relative">
                     <LocaleSwitch options={config.i18n} />
                   </div>
-                ) : null}
+                )}
                 {config.darkMode ? (
                   <div className="relative">
                     <ThemeSwitch lite={!!config.i18n} />

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -60,7 +60,7 @@ export function TOC({
 
   const hasHeadings = items.length > 0
   const hasMetaInfo =
-    config.feedbackLink || config.footerEditLink || config.tocExtraContent
+    Boolean(config.feedback.link || config.editLink || config.toc.extraContent)
 
   const activeSlug = Object.entries(activeAnchor).find(
     ([, { isActive }]) => isActive
@@ -96,7 +96,7 @@ export function TOC({
       >
         {hasHeadings && (
           <>
-            <p className="mb-4 font-semibold tracking-tight">On This Page</p>
+            <p className="mb-4 font-semibold tracking-tight">{renderComponent(config.toc.title)}</p>
             <ul>
               {items.map(({ slug, text, depth }) => (
                 <li className="my-2 scroll-my-6 scroll-py-6" key={slug}>
@@ -124,44 +124,42 @@ export function TOC({
           </>
         )}
 
-        {hasMetaInfo ? (
-          <div
-            className={cn(
-              hasHeadings &&
-                'mt-8 border-t bg-white pt-8 shadow-[0_-12px_16px_white] dark:bg-dark dark:shadow-[0_-12px_16px_#111]',
-              'sticky bottom-0 pb-8 dark:border-neutral-800 flex flex-col gap-2',
-              'contrast-more:shadow-none contrast-more:border-t contrast-more:border-neutral-400 contrast-more:dark:border-neutral-400'
-            )}
-          >
-            {config.feedbackLink ? (
-              <Anchor
-                className={linkClassName}
-                href={getGitIssueUrl({
-                  repository: config.docsRepositoryBase,
-                  title: `Feedback for “${config.title}”`,
-                  labels: config.feedbackLabels
-                })}
-                newWindow
-              >
-                {renderComponent(config.feedbackLink)}
-              </Anchor>
-            ) : null}
+      {hasMetaInfo && (
+        <div
+          className={cn(
+            hasHeadings &&
+              'mt-8 border-t bg-white pt-8 shadow-[0_-12px_16px_white] dark:bg-dark dark:shadow-[0_-12px_16px_#111]',
+            'sticky bottom-0 pb-8 dark:border-neutral-800 flex flex-col gap-2',
+            'contrast-more:shadow-none contrast-more:border-t contrast-more:border-neutral-400 contrast-more:dark:border-neutral-400'
+          )}
+        >
+          {config.feedback.link ? (
+            <Anchor
+              className={linkClassName}
+              href={getGitIssueUrl({
+                repository: config.docsRepositoryBase,
+                title: `Feedback for “${config.title}”`,
+                labels: config.feedback.labels
+              })}
+              newWindow
+            >
+              {renderComponent(config.feedback.link)}
+            </Anchor>
+          ) : null}
 
-          {config.footerEditLink ? (
+          {config.editLink ? (
             <Anchor
               className={linkClassName}
               href={getEditUrl(filePath)}
               newWindow
             >
-              {renderComponent(config.footerEditLink)}
+              {renderComponent(config.editLink)}
             </Anchor>
           ) : null}
 
-            {config.tocExtraContent
-              ? renderComponent(config.tocExtraContent)
-              : null}
-          </div>
-        ) : null}
+          {renderComponent(config.toc.extraContent)}
+        </div>
+      )}
       </div>
     </div>
   )

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -57,7 +57,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
 
   const hasHeadings = items.length > 0
   const hasMetaInfo = Boolean(
-    config.feedback.link || config.editLink || config.toc.extraContent
+    config.feedback.link || config.editLinkText || config.toc.extraContent
   )
 
   const activeSlug = Object.entries(activeAnchor).find(
@@ -85,81 +85,81 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
   )
 
   return (
-    <div
-      ref={tocRef}
-      className={cn(
-        'sticky top-16 overflow-y-auto pr-4 pt-8 text-sm [hyphens:auto]',
-        'ltr:-mr-4 rtl:-ml-4 max-h-[calc(100vh-4rem-env(safe-area-inset-bottom))]'
-      )}
-    >
-      {hasHeadings && (
-        <>
-          <p className="mb-4 font-semibold tracking-tight">
-            {renderComponent(config.toc.title)}
-          </p>
-          <ul>
-            {items.map(({ slug, text, depth }) => (
-              <li className="my-2 scroll-my-6 scroll-py-6" key={slug}>
-                <a
-                  href={`#${slug}`}
-                  className={cn(
-                    {
-                      2: 'font-semibold',
-                      3: 'ltr:ml-4 rtl:mr-4',
-                      4: 'ltr:ml-8 rtl:mr-8',
-                      5: 'ltr:ml-12 rtl:mr-12',
-                      6: 'ltr:ml-16 rtl:mr-16'
-                    }[depth],
-                    activeAnchor[slug]?.isActive
-                      ? 'text-primary-500 subpixel-antialiased contrast-more:!text-primary-500'
-                      : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-300',
-                    'contrast-more:text-gray-900 contrast-more:underline contrast-more:dark:text-gray-50'
-                  )}
-                >
-                  {text}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+      <div
+        ref={tocRef}
+        className={cn(
+          'sticky top-16 overflow-y-auto pr-4 pt-8 text-sm [hyphens:auto]',
+          'ltr:-mr-4 rtl:-ml-4 max-h-[calc(100vh-4rem-env(safe-area-inset-bottom))]'
+        )}
+      >
+        {hasHeadings && (
+          <>
+            <p className="mb-4 font-semibold tracking-tight">
+              {renderComponent(config.toc.title)}
+            </p>
+            <ul>
+              {items.map(({ slug, text, depth }) => (
+                <li className="my-2 scroll-my-6 scroll-py-6" key={slug}>
+                  <a
+                    href={`#${slug}`}
+                    className={cn(
+                      {
+                        2: 'font-semibold',
+                        3: 'ltr:ml-4 rtl:mr-4',
+                        4: 'ltr:ml-8 rtl:mr-8',
+                        5: 'ltr:ml-12 rtl:mr-12',
+                        6: 'ltr:ml-16 rtl:mr-16'
+                      }[depth],
+                      activeAnchor[slug]?.isActive
+                        ? 'text-primary-500 subpixel-antialiased contrast-more:!text-primary-500'
+                        : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-300',
+                      'contrast-more:text-gray-900 contrast-more:underline contrast-more:dark:text-gray-50'
+                    )}
+                  >
+                    {text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
 
-      {hasMetaInfo && (
-        <div
-          className={cn(
-            hasHeadings &&
-              'mt-8 border-t bg-white pt-8 shadow-[0_-12px_16px_white] dark:bg-dark dark:shadow-[0_-12px_16px_#111]',
-            'sticky bottom-0 pb-8 dark:border-neutral-800 flex flex-col gap-2',
-            'contrast-more:shadow-none contrast-more:border-t contrast-more:border-neutral-400 contrast-more:dark:border-neutral-400'
-          )}
-        >
-          {config.feedback.link ? (
-            <Anchor
-              className={linkClassName}
-              href={getGitIssueUrl({
-                repository: config.docsRepositoryBase,
-                title: `Feedback for “${config.title}”`,
-                labels: config.feedback.labels
-              })}
-              newWindow
-            >
-              {renderComponent(config.feedback.link)}
-            </Anchor>
-          ) : null}
+        {hasMetaInfo && (
+          <div
+            className={cn(
+              hasHeadings &&
+                'mt-8 border-t bg-white pt-8 shadow-[0_-12px_16px_white] dark:bg-dark dark:shadow-[0_-12px_16px_#111]',
+              'sticky bottom-0 pb-8 dark:border-neutral-800 flex flex-col gap-2',
+              'contrast-more:shadow-none contrast-more:border-t contrast-more:border-neutral-400 contrast-more:dark:border-neutral-400'
+            )}
+          >
+            {config.feedback.link ? (
+              <Anchor
+                className={linkClassName}
+                href={getGitIssueUrl({
+                  repository: config.docsRepositoryBase,
+                  title: `Feedback for “${config.title}”`,
+                  labels: config.feedback.labels
+                })}
+                newWindow
+              >
+                {renderComponent(config.feedback.link)}
+              </Anchor>
+            ) : null}
 
-          {config.editLink ? (
-            <Anchor
-              className={linkClassName}
-              href={getEditUrl(filePath)}
-              newWindow
-            >
-              {renderComponent(config.editLink)}
-            </Anchor>
-          ) : null}
+            {config.editLinkText ? (
+              <Anchor
+                className={linkClassName}
+                href={getEditUrl(filePath)}
+                newWindow
+              >
+                {renderComponent(config.editLinkText)}
+              </Anchor>
+            ) : null}
 
-          {renderComponent(config.toc.extraContent)}
-        </div>
-      )}
-    </div>
+            {renderComponent(config.toc.extraContent)}
+          </div>
+        )}
+      </div>
   )
 }

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -27,15 +27,12 @@ const getEditUrl = (filePath?: string): string => {
   return '#'
 }
 
-export function TOC({
-  headings,
-  filePath,
-  className
-}: {
+export type TOCProps = {
   headings: Heading[]
   filePath: string
-  className: string
-}): ReactElement {
+}
+
+export function TOC({ headings, filePath }: TOCProps): ReactElement {
   const slugger = new Slugger()
   const activeAnchor = useActiveAnchor()
   const config = useConfig()
@@ -59,8 +56,9 @@ export function TOC({
   )
 
   const hasHeadings = items.length > 0
-  const hasMetaInfo =
-    Boolean(config.feedback.link || config.editLink || config.toc.extraContent)
+  const hasMetaInfo = Boolean(
+    config.feedback.link || config.editLink || config.toc.extraContent
+  )
 
   const activeSlug = Object.entries(activeAnchor).find(
     ([, { isActive }]) => isActive
@@ -87,42 +85,44 @@ export function TOC({
   )
 
   return (
-    <div ref={tocRef} className={cn('mx-4', className)}>
-      <div
-        className={cn(
-          'sticky top-16 overflow-y-auto pr-4 pt-8 text-sm [hyphens:auto]',
-          'ltr:-mr-4 rtl:-ml-4 max-h-[calc(100vh-4rem-env(safe-area-inset-bottom))]'
-        )}
-      >
-        {hasHeadings && (
-          <>
-            <p className="mb-4 font-semibold tracking-tight">{renderComponent(config.toc.title)}</p>
-            <ul>
-              {items.map(({ slug, text, depth }) => (
-                <li className="my-2 scroll-my-6 scroll-py-6" key={slug}>
-                  <a
-                    href={`#${slug}`}
-                    className={cn(
-                      {
-                        2: 'font-semibold',
-                        3: 'ltr:ml-4 rtl:mr-4',
-                        4: 'ltr:ml-8 rtl:mr-8',
-                        5: 'ltr:ml-12 rtl:mr-12',
-                        6: 'ltr:ml-16 rtl:mr-16'
-                      }[depth],
-                      activeAnchor[slug]?.isActive
-                        ? 'text-primary-500 subpixel-antialiased contrast-more:!text-primary-500'
-                        : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-300',
-                      'contrast-more:text-gray-900 contrast-more:underline contrast-more:dark:text-gray-50'
-                    )}
-                  >
-                    {text}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
+    <div
+      ref={tocRef}
+      className={cn(
+        'sticky top-16 overflow-y-auto pr-4 pt-8 text-sm [hyphens:auto]',
+        'ltr:-mr-4 rtl:-ml-4 max-h-[calc(100vh-4rem-env(safe-area-inset-bottom))]'
+      )}
+    >
+      {hasHeadings && (
+        <>
+          <p className="mb-4 font-semibold tracking-tight">
+            {renderComponent(config.toc.title)}
+          </p>
+          <ul>
+            {items.map(({ slug, text, depth }) => (
+              <li className="my-2 scroll-my-6 scroll-py-6" key={slug}>
+                <a
+                  href={`#${slug}`}
+                  className={cn(
+                    {
+                      2: 'font-semibold',
+                      3: 'ltr:ml-4 rtl:mr-4',
+                      4: 'ltr:ml-8 rtl:mr-8',
+                      5: 'ltr:ml-12 rtl:mr-12',
+                      6: 'ltr:ml-16 rtl:mr-16'
+                    }[depth],
+                    activeAnchor[slug]?.isActive
+                      ? 'text-primary-500 subpixel-antialiased contrast-more:!text-primary-500'
+                      : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-300',
+                    'contrast-more:text-gray-900 contrast-more:underline contrast-more:dark:text-gray-50'
+                  )}
+                >
+                  {text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
 
       {hasMetaInfo && (
         <div
@@ -160,7 +160,6 @@ export function TOC({
           {renderComponent(config.toc.extraContent)}
         </div>
       )}
-      </div>
     </div>
   )
 }

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { DocsThemeConfig, PageTheme } from './types'
 import { useRouter } from 'next/router'
-import { Flexsearch, Footer } from './components'
+import { Flexsearch, Footer, TOC } from './components'
 import { DiscordIcon, GitHubIcon } from 'nextra/icons'
 import { MatchSorterSearch } from './components/match-sorter-search'
 import { useConfig } from './contexts'
@@ -14,7 +14,7 @@ export const IS_BROWSER = typeof window !== 'undefined'
 export const DEFAULT_THEME: DocsThemeConfig = {
   banner: {
     key: 'nextra-banner',
-    text: '',
+    text: ''
   },
   bodyExtraContent: null,
   components: {},
@@ -127,6 +127,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   },
   titleSuffix: ' – Nextra',
   toc: {
+    component: TOC,
     extraContent: null,
     float: true,
     title: 'On This Page'

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -21,7 +21,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   darkMode: true,
   direction: 'ltr',
   docsRepositoryBase: 'https://github.com/shuding/nextra',
-  editLink: 'Edit this page',
+  editLinkText: 'Edit this page',
   feedback: {
     labels: '',
     link: null

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -1,38 +1,51 @@
+/* eslint sort-keys: error */
 import React from 'react'
 import { DocsThemeConfig, PageTheme } from './types'
 import { useRouter } from 'next/router'
+import { Flexsearch, Footer } from './components'
+import { DiscordIcon, GitHubIcon } from 'nextra/icons'
+import { MatchSorterSearch } from './components/match-sorter-search'
+import { useConfig } from './contexts'
 
 export const DEFAULT_LOCALE = 'en-US'
 
 export const IS_BROWSER = typeof window !== 'undefined'
 
 export const DEFAULT_THEME: DocsThemeConfig = {
-  projectLink: 'https://github.com/shuding/nextra',
-  docsRepositoryBase: 'https://github.com/shuding/nextra',
-  titleSuffix: ' – Nextra',
-  nextLinks: true,
-  prevLinks: true,
-  search: true,
-  darkMode: true,
-  nextThemes: {
-    defaultTheme: 'system',
-    storageKey: 'theme'
+  banner: {
+    key: 'nextra-banner',
+    text: '',
   },
-  defaultMenuCollapsed: false,
+  bodyExtraContent: null,
+  components: {},
+  darkMode: true,
+  direction: 'ltr',
+  docsRepositoryBase: 'https://github.com/shuding/nextra',
+  editLink: 'Edit this page',
+  feedback: {
+    labels: '',
+    link: null
+  },
   // @TODO: Can probably introduce a set of options to use Google Fonts directly
-  // font: true,
-  footer: true,
-  footerText: `MIT ${new Date().getFullYear()} © Nextra.`,
-  footerEditLink: 'Edit this page',
-  gitTimestamp: 'Last updated on',
-  logo: (
-    <>
-      <span className="mr-2 hidden font-extrabold md:inline">Nextra</span>
-      <span className="hidden font-normal text-gray-600 md:inline">
-        The Next Docs Builder
-      </span>
-    </>
-  ),
+  font: false,
+  footer: {
+    component: Footer,
+    text: `MIT ${new Date().getFullYear()} © Nextra.`
+  },
+  gitTimestamp({ timestamp }) {
+    const { locale = DEFAULT_LOCALE } = useRouter()
+    return (
+      <>
+        Last updated on{' '}
+        {timestamp.toLocaleDateString(locale, {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric'
+        })}
+      </>
+    )
+  },
+  github: '',
   head: () => (
     <>
       <meta name="msapplication-TileColor" content="#fff" />
@@ -45,33 +58,90 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       <meta name="apple-mobile-web-app-title" content="Nextra" />
     </>
   ),
-  searchPlaceholder() {
-    const { locale } = useRouter()
-    if (locale === 'zh-CN') return '搜索文档...'
-    return 'Search documentation...'
-  },
-  unstable_searchResultEmpty: (
-    <span className="block select-none p-8 text-center text-sm text-gray-400">
-      No results found.
-    </span>
+  i18n: [],
+  logo: (
+    <>
+      <span className="mr-2 hidden font-extrabold md:inline">Nextra</span>
+      <span className="hidden font-normal text-gray-600 md:inline">
+        The Next Docs Builder
+      </span>
+    </>
   ),
-  bannerKey: 'nextra-banner',
-  notFoundLink: 'Submit an issue about broken link →',
-  notFoundLabels: 'bug',
-  serverSideErrorLink: 'Submit an issue about error in url →',
-  serverSideErrorLabels: 'bug'
-  // direction: 'ltr',
-  // i18n: [{ locale: 'en-US', text: 'English', direction: 'ltr' }],
+  navigation: {
+    next: true,
+    prev: true
+  },
+  nextThemes: {
+    defaultTheme: 'system',
+    storageKey: 'theme'
+  },
+  notFound: {
+    labels: 'bug',
+    link: 'Submit an issue about broken link →'
+  },
+  project: {
+    icon: (
+      <>
+        <GitHubIcon />
+        <span className="sr-only">GitHub</span>
+      </>
+    ),
+    link: 'https://github.com/shuding/nextra'
+  },
+  projectChat: {
+    icon: (
+      <>
+        <DiscordIcon />
+        <span className="sr-only">Discord</span>
+      </>
+    ),
+    link: ''
+  },
+  search: {
+    component({ directories }) {
+      const config = useConfig()
+      return config.unstable_flexsearch ? (
+        <Flexsearch />
+      ) : (
+        <MatchSorterSearch directories={directories} />
+      )
+    },
+    emptyResult: (
+      <span className="block select-none p-8 text-center text-sm text-gray-400">
+        No results found.
+      </span>
+    ),
+    placeholder() {
+      const { locale } = useRouter()
+      if (locale === 'zh-CN') return '搜索文档...'
+      return 'Search documentation...'
+    }
+  },
+  serverSideError: {
+    labels: 'bug',
+    link: 'Submit an issue about error in url →'
+  },
+  sidebar: {
+    defaultMenuCollapsed: false,
+    subtitle: null
+  },
+  titleSuffix: ' – Nextra',
+  toc: {
+    extraContent: null,
+    float: true,
+    title: 'On This Page'
+  },
+  unstable_faviconGlyph: ''
 }
 
 export const DEFAULT_PAGE_THEME: PageTheme = {
-  navbar: true,
-  sidebar: true,
-  toc: true,
-  pagination: true,
+  breadcrumb: true,
   footer: true,
   layout: 'default',
-  typesetting: 'default',
-  breadcrumb: true,
-  timestamp: true
+  navbar: true,
+  pagination: true,
+  sidebar: true,
+  timestamp: true,
+  toc: true,
+  typesetting: 'default'
 }

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -86,7 +86,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         <span className="sr-only">GitHub</span>
       </>
     ),
-    link: 'https://github.com/shuding/nextra'
+    // by default should be empty so clicking on project link will go to the github link
+    link: ''
   },
   projectChat: {
     icon: (

--- a/packages/nextra-theme-docs/src/contexts/config.tsx
+++ b/packages/nextra-theme-docs/src/contexts/config.tsx
@@ -103,8 +103,9 @@ export const ConfigProvider = ({
       }
     }
 
-    for (const key of ['search', 'footer']) {
-      const option = (themeConfig as any)[key]
+    for (const key of ['search', 'footer'] as const) {
+      if (key in themeConfig) continue
+      const option = themeConfig[key]
       if (typeof option === 'boolean' || option == null) {
         console.warn(
           `${notice} "${key}".`,

--- a/packages/nextra-theme-docs/src/contexts/config.tsx
+++ b/packages/nextra-theme-docs/src/contexts/config.tsx
@@ -19,10 +19,26 @@ type Config = DocsThemeConfig &
 
 const ConfigContext = createContext<Config>({
   title: '',
-  meta: {}
+  meta: {},
+  ...DEFAULT_THEME
 })
 
 export const useConfig = () => useContext(ConfigContext)
+
+const DEEP_OBJECT_KEYS = [
+  'banner',
+  'feedback',
+  'footer',
+  'navigation',
+  'nextThemes',
+  'notFound',
+  'project',
+  'projectChat',
+  'search',
+  'serverSideError',
+  'sidebar',
+  'toc'
+] as const
 
 export const ConfigProvider = ({
   children,
@@ -33,15 +49,22 @@ export const ConfigProvider = ({
 }): ReactElement => {
   const [menu, setMenu] = useState(false)
   const { themeConfig, pageOpts } = value
-  const extendedConfig = {
+  const extendedConfig: Config = {
     ...DEFAULT_THEME,
     ...themeConfig,
     unstable_flexsearch: pageOpts.unstable_flexsearch,
     newNextLinkBehavior: pageOpts.newNextLinkBehavior,
     title: pageOpts.title,
-    meta: pageOpts.meta
+    meta: pageOpts.meta,
+    ...Object.fromEntries(
+      DEEP_OBJECT_KEYS.map(key => [
+        key,
+        { ...DEFAULT_THEME[key], ...themeConfig[key] }
+      ])
+    )
   }
-  const nextThemes = extendedConfig.nextThemes || {}
+
+  const { nextThemes } = extendedConfig
 
   return (
     <ThemeProvider
@@ -52,15 +75,7 @@ export const ConfigProvider = ({
       forcedTheme={nextThemes.forcedTheme}
     >
       <ConfigContext.Provider value={extendedConfig}>
-        <MenuProvider
-          value={{
-            menu,
-            setMenu,
-            defaultMenuCollapsed: !!extendedConfig.defaultMenuCollapsed
-          }}
-        >
-          {children}
-        </MenuProvider>
+        <MenuProvider value={{ menu, setMenu }}>{children}</MenuProvider>
       </ConfigContext.Provider>
     </ThemeProvider>
   )

--- a/packages/nextra-theme-docs/src/contexts/config.tsx
+++ b/packages/nextra-theme-docs/src/contexts/config.tsx
@@ -113,7 +113,7 @@ export const ConfigProvider = ({
       }
     }
     if (typeof themeConfig.banner === 'string') {
-      console.warn(notice, '"banner". `Rename it to banner: { text: ... }')
+      console.warn(notice, '"banner". Rename it to banner: { text: ... }')
     }
   }
 

--- a/packages/nextra-theme-docs/src/contexts/config.tsx
+++ b/packages/nextra-theme-docs/src/contexts/config.tsx
@@ -40,6 +40,31 @@ const DEEP_OBJECT_KEYS = [
   'toc'
 ] as const
 
+const LegacyOptions: Record<string, string> = {
+  projectLink: 'project.link',
+  projectLinkIcon: 'project.icon',
+  nextLinks: 'navigation.next',
+  prevLinks: 'navigation.prev',
+  defaultMenuCollapsed: 'sidebar.defaultMenuCollapsed',
+  footerText: 'footer.text',
+  footerEditLink: 'editLinkText',
+  floatTOC: 'toc.float',
+  feedbackLink: 'feedback.link',
+  feedbackLabels: 'feedback.labels',
+  customSearch: 'search.component',
+  searchPlaceholder: 'search.placeholder',
+  projectChatLink: 'projectChat.link',
+  projectChatLinkIcon: 'projectChat.icon',
+  sidebarSubtitle: 'sidebar.subtitle',
+  bannerKey: 'banner.key',
+  tocExtraContent: 'toc.extraContent',
+  unstable_searchResultEmpty: 'search.emptyResult',
+  notFoundLink: 'notFound.link',
+  notFoundLabels: 'notFound.labels',
+  serverSideErrorLink: 'serverSideError.link',
+  serverSideErrorLabels: 'serverSideError.labels'
+}
+
 export const ConfigProvider = ({
   children,
   value
@@ -65,6 +90,32 @@ export const ConfigProvider = ({
   }
 
   const { nextThemes } = extendedConfig
+
+  if (process.env.NODE_ENV === 'development') {
+    const notice =
+      '[nextra-theme-docs] ⚠️ You are using legacy theme config option'
+
+    for (const [legacyOption, newPath] of Object.entries(LegacyOptions)) {
+      if (legacyOption in themeConfig) {
+        const [obj, key] = newPath.split('.')
+        const renameTo = key ? `${obj}: { ${key}: ... }` : obj
+        console.warn(`${notice} "${legacyOption}". Rename it to ${renameTo}`)
+      }
+    }
+
+    for (const key of ['search', 'footer']) {
+      const option = (themeConfig as any)[key]
+      if (typeof option === 'boolean' || option == null) {
+        console.warn(
+          `${notice} "${key}".`,
+          option ? 'Remove it' : `Rename it to ${key}: { component: null }`
+        )
+      }
+    }
+    if (typeof themeConfig.banner === 'string') {
+      console.warn(notice, '"banner". `Rename it to banner: { text: ... }')
+    }
+  }
 
   return (
     <ThemeProvider

--- a/packages/nextra-theme-docs/src/contexts/config.tsx
+++ b/packages/nextra-theme-docs/src/contexts/config.tsx
@@ -104,13 +104,14 @@ export const ConfigProvider = ({
     }
 
     for (const key of ['search', 'footer'] as const) {
-      if (key in themeConfig) continue
-      const option = themeConfig[key]
-      if (typeof option === 'boolean' || option == null) {
-        console.warn(
-          `${notice} "${key}".`,
-          option ? 'Remove it' : `Rename it to ${key}: { component: null }`
-        )
+      if (key in themeConfig) {
+        const option = themeConfig[key]
+        if (typeof option === 'boolean' || option == null) {
+          console.warn(
+            `${notice} "${key}".`,
+            option ? 'Remove it' : `Rename it to ${key}: { component: null }`
+          )
+        }
       }
     }
     if (typeof themeConfig.banner === 'string') {

--- a/packages/nextra-theme-docs/src/contexts/menu.ts
+++ b/packages/nextra-theme-docs/src/contexts/menu.ts
@@ -3,13 +3,11 @@ import { useContext, createContext, Dispatch, SetStateAction } from 'react'
 interface Menu {
   menu: boolean
   setMenu: Dispatch<SetStateAction<boolean>>
-  defaultMenuCollapsed: boolean
 }
 
 const MenuContext = createContext<Menu>({
   menu: false,
   setMenu: () => {},
-  defaultMenuCollapsed: true
 })
 
 export const useMenu = () => useContext(MenuContext)

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -13,7 +13,6 @@ import './polyfill'
 import {
   Head,
   Navbar,
-  Footer,
   NavLinks,
   Sidebar,
   TOC,
@@ -29,7 +28,7 @@ import {
 } from './contexts'
 import { DEFAULT_LOCALE, IS_BROWSER } from './constants'
 import { getFSRoute, normalizePages, renderComponent } from './utils'
-import { Context, DocsThemeConfig, PageTheme } from './types'
+import { Context, DocsThemeConfig, PageTheme, RecursivePartial } from './types'
 
 let resizeObserver: ResizeObserver
 if (IS_BROWSER) {
@@ -75,7 +74,6 @@ const Body = ({
 }: BodyProps): ReactElement => {
   const mainElement = useRef<HTMLElement>(null)
   const config = useConfig()
-  const { locale = DEFAULT_LOCALE } = useRouter()
 
   useEffect(() => {
     if (mainElement.current) {
@@ -98,13 +96,7 @@ const Body = ({
 
   const gitTimestampEl = date ? (
     <div className="pointer-default mt-12 mb-8 block ltr:text-right rtl:text-left text-xs text-gray-500 dark:text-gray-400">
-      {typeof config.gitTimestamp === 'string'
-        ? `${config.gitTimestamp} ${date.toLocaleDateString(locale, {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric'
-          })}`
-        : renderComponent(config.gitTimestamp, { timestamp: date })}
+      {renderComponent(config.gitTimestamp, { timestamp: date })}
     </div>
   ) : (
     <div className="mt-16" />
@@ -169,7 +161,7 @@ const InnerLayout = ({
     directories
   } = useDirectoryInfo(pageMap)
 
-  const localeConfig = config.i18n?.find(l => l.locale === locale)
+  const localeConfig = config.i18n.find(l => l.locale === locale)
   const isRTL = localeConfig
     ? localeConfig.direction === 'rtl'
     : config.direction === 'rtl'
@@ -185,7 +177,8 @@ const InnerLayout = ({
   const hideSidebar = !themeContext.sidebar || themeContext.layout === 'raw'
   const asPopover = activeType === 'page' || hideSidebar
 
-  const tocClassName = 'nextra-toc order-last hidden w-64 flex-shrink-0 xl:block'
+  const tocClassName =
+    'nextra-toc order-last hidden w-64 flex-shrink-0 xl:block'
 
   const tocEl =
     activeType === 'page' ||
@@ -196,7 +189,7 @@ const InnerLayout = ({
       )
     ) : (
       <TOC
-        headings={config.floatTOC ? headings : []}
+        headings={config.toc.float ? headings : []}
         filePath={filePath}
         className={tocClassName}
       />
@@ -259,9 +252,9 @@ const InnerLayout = ({
           </Body>
         </ActiveAnchorProvider>
       </div>
-      {themeContext.footer && config.footer ? (
-        <Footer menu={asPopover} />
-      ) : null}
+      {themeContext.footer
+        ? renderComponent(config.footer.component, { menu: asPopover })
+        : null}
     </div>
   )
 }
@@ -301,9 +294,10 @@ export default function withLayout(
   return Layout
 }
 
-export { useConfig, getComponents }
+type PartialDocsThemeConfig = RecursivePartial<DocsThemeConfig>
+
+export { useConfig, getComponents, PartialDocsThemeConfig as DocsThemeConfig }
 export { useTheme } from 'next-themes'
-export * from './types'
 export {
   Bleed,
   Callout,

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -184,15 +184,15 @@ const InnerLayout = ({
     activeType === 'page' ||
     !themeContext.toc ||
     themeContext.layout !== 'default' ? (
-      themeContext.layout === 'full' || themeContext.layout === 'raw' ? null : (
-        <div className={tocClassName} />
-      )
+      themeContext.layout !== 'full' &&
+      themeContext.layout !== 'raw' && <div className={tocClassName} />
     ) : (
-      <TOC
-        headings={config.toc.float ? headings : []}
-        filePath={filePath}
-        className={tocClassName}
-      />
+      <div className={cn(tocClassName, 'mx-4')}>
+        {renderComponent(config.toc.component, {
+          headings: config.toc.float ? headings : [],
+          filePath,
+        })}
+      </div>
     )
 
   return (

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -3,6 +3,7 @@ import { FC, ReactElement, ReactNode } from 'react'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { PageOpts } from 'nextra'
 import { Item } from './utils'
+import { TOCProps } from './components/toc'
 
 export type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
@@ -74,6 +75,7 @@ export interface DocsThemeConfig {
   // Can't be React component, otherwise will get Warning: A title element received an array with more than 1 element as children.
   titleSuffix: string | (() => string)
   toc: {
+    component: ReactNode | FC<TOCProps>
     extraContent: ReactNode | FC
     float: boolean
     title: ReactNode | FC

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -23,7 +23,7 @@ export interface DocsThemeConfig {
   darkMode: boolean
   direction: 'ltr' | 'rtl'
   docsRepositoryBase: string
-  editLink: ReactNode | FC
+  editLinkText: ReactNode | FC
   feedback: {
     labels: string
     link: ReactNode | FC

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -1,64 +1,96 @@
+/* eslint typescript-sort-keys/interface: error */
 import { FC, ReactElement, ReactNode } from 'react'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { PageOpts } from 'nextra'
+import { Item } from './utils'
+
+export type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object
+    ? RecursivePartial<T[P]>
+    : T[P]
+}
 
 export interface DocsThemeConfig {
-  components?: Record<string, FC>
-  projectLink?: string
-  github?: string
-  projectLinkIcon?: ReactNode | FC
-  docsRepositoryBase?: string
-  // Can't be React component, otherwise will get Warning: A title element received an array with more than 1 element as children.
-  titleSuffix?: string | (() => string)
-  nextLinks?: boolean
-  prevLinks?: boolean
-  search?: boolean
-  darkMode?: boolean
-  nextThemes?: Pick<
+  banner: {
+    key: string
+    text: ReactNode | FC
+  }
+  bodyExtraContent: ReactNode | FC
+  components: Record<string, FC>
+  darkMode: boolean
+  direction: 'ltr' | 'rtl'
+  docsRepositoryBase: string
+  editLink: ReactNode | FC
+  feedback: {
+    labels: string
+    link: ReactNode | FC
+  }
+  font: boolean
+  footer: {
+    component: ReactNode | FC<{ menu: boolean }>
+    text: ReactNode | FC
+  }
+  gitTimestamp: ReactNode | FC<{ timestamp: Date }>
+  github: string
+  head: () => ReactElement
+  i18n: { direction?: string; locale: string; text: string }[]
+  logo: ReactNode | FC
+  navigation: {
+    next: boolean
+    prev: boolean
+  }
+  nextThemes: Pick<
     ThemeProviderProps,
     'defaultTheme' | 'storageKey' | 'forcedTheme'
   >
-  defaultMenuCollapsed?: boolean
-  font?: boolean
-  footer?: boolean
-  footerText?: ReactNode | FC
-  footerEditLink?: ReactNode | FC
-  logo?: ReactNode | FC
-  head?: () => ReactElement,
-  direction?: 'ltr' | 'rtl'
-  i18n?: { locale: string; text: string; direction?: string }[]
-  floatTOC?: boolean
-  unstable_faviconGlyph?: string
-  feedbackLink?: ReactNode | FC
-  feedbackLabels?: string
-  customSearch?: ReactNode | false
-  // Can't be React component
-  searchPlaceholder?: string | (() => string)
-  projectChatLink?: string
-  projectChatLinkIcon?: ReactNode | FC
-  sidebarSubtitle?: ReactNode | FC<{ title: string }>
-  banner?: ReactNode | FC
-  bannerKey?: string
-  gitTimestamp?: string | FC<{ timestamp: Date }>
-  tocExtraContent?: ReactNode | FC
-  unstable_searchResultEmpty?: ReactNode | FC
-  notFoundLink?: ReactNode | FC
-  notFoundLabels?: string
-  serverSideErrorLink?: ReactNode | FC
-  serverSideErrorLabels?: string
-  bodyExtraContent?: ReactNode | FC
+  notFound: {
+    labels: string
+    link: ReactNode | FC
+  }
+  project: {
+    icon: ReactNode | FC
+    link: string
+  }
+  projectChat: {
+    icon: ReactNode | FC
+    link: string
+  }
+  search: {
+    component: ReactNode | FC<{ directories: Item[] }>
+    emptyResult: ReactNode | FC
+    // Can't be React component
+    placeholder: string | (() => string)
+  }
+  serverSideError: {
+    labels: string
+    link: ReactNode | FC
+  }
+  sidebar: {
+    defaultMenuCollapsed: boolean
+    subtitle: ReactNode | FC<{ title: string }>
+  }
+  // Can't be React component, otherwise will get Warning: A title element received an array with more than 1 element as children.
+  titleSuffix: string | (() => string)
+  toc: {
+    extraContent: ReactNode | FC
+    float: boolean
+    title: ReactNode | FC
+  }
+  unstable_faviconGlyph: string
 }
 
 export type PageTheme = {
-  navbar: boolean
-  sidebar: boolean
-  toc: boolean
-  pagination: boolean
+  breadcrumb: boolean
   footer: boolean
   layout: 'default' | 'full' | 'raw'
-  typesetting: 'default' | 'article'
-  breadcrumb: boolean
+  navbar: boolean
+  pagination: boolean
+  sidebar: boolean
   timestamp: boolean
+  toc: boolean
+  typesetting: 'default' | 'article'
 }
 
 export type Context = {
@@ -68,8 +100,8 @@ export type Context = {
 }
 
 export type SearchResult = {
-  id: string
-  route: string
-  prefix?: ReactNode
   children: ReactNode
+  id: string
+  prefix?: ReactNode
+  route: string
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ importers:
       '@edge-runtime/vm': 1.1.0-beta.23
       '@typescript-eslint/parser': ^5.32.0
       eslint: ^8.21.0
+      eslint-plugin-typescript-sort-keys: ^2.1.0
       prettier: ^2.7.1
       prettier-plugin-tailwindcss: ^0.1.13
       rimraf: ^3.0.2
@@ -39,6 +40,7 @@ importers:
       '@edge-runtime/vm': 1.1.0-beta.23
       '@typescript-eslint/parser': 5.32.0_qugx7qdu5zevzvxaiqyxfiwquq
       eslint: 8.21.0
+      eslint-plugin-typescript-sort-keys: 2.1.0_iosr3hrei2tubxveewluhu5lhy
       prettier: 2.7.1
       prettier-plugin-tailwindcss: 0.1.13_prettier@2.7.1
       rimraf: 3.0.2
@@ -1128,6 +1130,19 @@ packages:
       - webpack-cli
     dev: true
 
+  /@typescript-eslint/experimental-utils/5.33.1_qugx7qdu5zevzvxaiqyxfiwquq:
+    resolution: {integrity: sha512-wk2o+4wojvKz/x3UCbsgjgXl0lyLPYQsfKP0MdRzj4jtsQr4bVtgWUWck6+N3GzThUTbUFyyKLduWPwePhh0xQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.33.1_qugx7qdu5zevzvxaiqyxfiwquq
+      eslint: 8.21.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/parser/5.32.0_qugx7qdu5zevzvxaiqyxfiwquq:
     resolution: {integrity: sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1156,8 +1171,21 @@ packages:
       '@typescript-eslint/visitor-keys': 5.32.0
     dev: true
 
+  /@typescript-eslint/scope-manager/5.33.1:
+    resolution: {integrity: sha512-8ibcZSqy4c5m69QpzJn8XQq9NnqAToC8OdH/W6IXPXv83vRyEDPYLdjAlUx8h/rbusq6MkW4YdQzURGOqsn3CA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.33.1
+      '@typescript-eslint/visitor-keys': 5.33.1
+    dev: true
+
   /@typescript-eslint/types/5.32.0:
     resolution: {integrity: sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types/5.33.1:
+    resolution: {integrity: sha512-7K6MoQPQh6WVEkMrMW5QOA5FO+BOwzHSNd0j3+BlBwd6vtzfZceJ8xJ7Um2XDi/O3umS8/qDX6jdy2i7CijkwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -1182,11 +1210,58 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.33.1_typescript@4.7.4:
+    resolution: {integrity: sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.33.1
+      '@typescript-eslint/visitor-keys': 5.33.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.33.1_qugx7qdu5zevzvxaiqyxfiwquq:
+    resolution: {integrity: sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.33.1
+      '@typescript-eslint/types': 5.33.1
+      '@typescript-eslint/typescript-estree': 5.33.1_typescript@4.7.4
+      eslint: 8.21.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.21.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys/5.32.0:
     resolution: {integrity: sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.32.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.33.1:
+    resolution: {integrity: sha512-nwIxOK8Z2MPWltLKMLOEZwmfBZReqUdbEoHQXeCpa+sRVARe5twpJGHCB4dk9903Yaf0nMAlGbQfaAH92F60eg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.33.1
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -2421,6 +2496,24 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /eslint-plugin-typescript-sort-keys/2.1.0_iosr3hrei2tubxveewluhu5lhy:
+    resolution: {integrity: sha512-ET7ABypdz19m47QnKynzNfWPi4CTNQ5jQQC1X5d0gojIwblkbGiCa5IilsqzBTmqxZ0yXDqKBO/GBkBFQCOFsg==}
+    engines: {node: 10 - 12 || >= 13.9}
+    peerDependencies:
+      '@typescript-eslint/parser': ^1 || ^2 || ^3 || ^4 || ^5
+      eslint: ^5 || ^6 || ^7 || ^8
+      typescript: ^3 || ^4
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.33.1_qugx7qdu5zevzvxaiqyxfiwquq
+      '@typescript-eslint/parser': 5.32.0_qugx7qdu5zevzvxaiqyxfiwquq
+      eslint: 8.21.0
+      json-schema: 0.4.0
+      natural-compare-lite: 1.4.0
+      typescript: 4.7.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-scope/5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -3280,6 +3373,10 @@ packages:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: true
 
+  /json-schema/0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: true
+
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
@@ -4075,6 +4172,10 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /natural-compare-lite/1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
+    dev: true
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/676 https://github.com/shuding/nextra/issues/669

also, add new option `toc.component` to fix https://github.com/shuding/nextra/issues/564

and fixes `project.link` behaviour https://github.com/shuding/nextra/issues/383

https://github.com/shuding/nextra/blob/bbfe8a37ce59fc0bbb00da7c0d8a04220d111c53/packages/nextra-theme-docs/src/types.ts#L15-L82



@shuding it was hard to implement without too monkey-business code for some options like
```ts
 search: boolean | FC | ReactNode | {
   placeholder?: string | (() => string)
   emptyResult?: ReactNode | FC
 }
```

So I made the following

```ts
 search: { 
     component: ReactNode | FC<{ directories: Item[] }> 
     emptyResult: ReactNode | FC  // will be ignored if component was specified
     placeholder: string | (() => string)  // will be ignored if component was specified
   } 
```

or more complex usage

```ts
  toc: {
    component: ReactNode | FC<TOCProps>
    extraContent: ReactNode | FC // will be ignored if component was specified
    float: boolean // ❗️ headings will be passed in `toc.component` as props based on `headings: config.toc.float ? headings : []` condition
    title: ReactNode | FC // will be ignored if component was specified
  }
```