### PR TITLE
Allow `head` to be a ReactNode

### DIFF
--- a/.changeset/hot-pianos-try.md
+++ b/.changeset/hot-pianos-try.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+allow head to be a ReactNode

--- a/packages/nextra-theme-docs/src/components/head.tsx
+++ b/packages/nextra-theme-docs/src/components/head.tsx
@@ -13,7 +13,7 @@ export function Head(): ReactElement {
   // `head` can be either FC or ReactNode. We have to directly call it if it's a
   // FC because hooks like Next.js' `useRouter` aren't allowed inside NextHead.
   const head =
-    typeof config.head === 'function' ? config.head() : config.head || null
+    typeof config.head === 'function' ? config.head({}) : config.head || null
 
   return (
     <NextHead>

--- a/packages/nextra-theme-docs/src/components/head.tsx
+++ b/packages/nextra-theme-docs/src/components/head.tsx
@@ -10,6 +10,11 @@ export function Head(): ReactElement {
   const renderedTheme = theme === 'system' ? systemTheme : theme
   const mounted = useMounted()
 
+  // `head` can be either FC or ReactNode. We have to directly call it if it's a
+  // FC because hooks like Next.js' `useRouter` aren't allowed inside NextHead.
+  const head =
+    typeof config.head === 'function' ? config.head() : config.head || null
+
   return (
     <NextHead>
       <title>{config.title + renderString(config.titleSuffix)}</title>
@@ -42,7 +47,7 @@ export function Head(): ReactElement {
         name="viewport"
         content="width=device-width, initial-scale=1.0, viewport-fit=cover"
       />
-      {config.head?.()}
+      {head}
     </NextHead>
   )
 }

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -24,7 +24,7 @@ export interface DocsThemeConfig {
   footerText?: ReactNode | FC
   footerEditLink?: ReactNode | FC
   logo?: ReactNode | FC
-  head?: () => ReactElement,
+  head?: ReactNode | FC
   direction?: 'ltr' | 'rtl'
   i18n?: { locale: string; text: string; direction?: string }[]
   floatTOC?: boolean


### PR DESCRIPTION
This is previously allowed and it makes sense (if the head is totally static).