### PR TITLE
fix search input `ESC` icon vertical alignment

### DIFF
--- a/.changeset/young-cows-serve.md
+++ b/.changeset/young-cows-serve.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix search input `ESC` icon vertical alignment

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -141,7 +141,7 @@ export function Search({
     >
       <kbd
         className={cn(
-          'absolute ltr:right-1.5 rtl:left-1.5 top-0 my-1.5 select-none',
+          'absolute ltr:right-1.5 rtl:left-1.5 my-1.5 select-none',
           'rounded bg-white px-1.5 h-5 font-mono font-medium text-gray-500 text-[10px]',
           'border dark:bg-dark/50 dark:border-gray-100/20',
           'contrast-more:border-current contrast-more:text-current contrast-more:dark:border-current',
@@ -155,7 +155,7 @@ export function Search({
           onChange('')
         }}
       >
-        {value
+        {hasValue
           ? 'ESC'
           : mounted &&
             (navigator.userAgent.includes('Macintosh') ? (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7361780/186550825-12f8a32b-1d6c-4832-af6d-14dc6e9a1c60.png)
