### PR TITLE
remove `getComponents` export, export `useMDXComponents` from `@mdx-js/react` instead

### DIFF
--- a/.changeset/quick-rabbits-care.md
+++ b/.changeset/quick-rabbits-care.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+remove `getComponents` export, export `useMDXComponents` from `@mdx-js/react` instead

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -275,7 +275,8 @@ export default function Layout(props: any): ReactElement {
 
 type PartialDocsThemeConfig = RecursivePartial<DocsThemeConfig>
 
-export { useConfig, getComponents, PartialDocsThemeConfig as DocsThemeConfig }
+export { useConfig, PartialDocsThemeConfig as DocsThemeConfig }
+export { useMDXComponents } from '@mdx-js/react'
 export { useTheme } from 'next-themes'
 export {
   Bleed,


### PR DESCRIPTION
to render remote markdown with nextra styles
```ts
  const components = useMDXComponents()
  return (
      <MDXRemote compiledSource={packageData.compiledSource} components={components} />
  )
```