### PR TITLE
make `<Tab />` accept `ComponentProps<'div'>`

### DIFF
--- a/.changeset/few-emus-pull.md
+++ b/.changeset/few-emus-pull.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+make `<Tab />` accept `ComponentProps<'div'>`

--- a/packages/nextra-theme-docs/src/components/tabs.tsx
+++ b/packages/nextra-theme-docs/src/components/tabs.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react'
+import React, { ComponentProps, ReactElement, ReactNode } from 'react'
 import cn from 'clsx'
 import { Tab as HeadlessTab } from '@headlessui/react'
 
@@ -75,9 +75,16 @@ export function Tabs({
   )
 }
 
-export function Tab({ children }: { children: ReactNode }): ReactElement {
+export function Tab({
+  children,
+  className,
+  ...props
+}: ComponentProps<'div'>): ReactElement {
   return (
-    <HeadlessTab.Panel className="focus:outline-none focus-visible:ring">
+    <HeadlessTab.Panel
+      className={cn('focus:outline-none focus-visible:ring', className)}
+      {...props}
+    >
       {children}
     </HeadlessTab.Panel>
   )


### PR DESCRIPTION
I want to pass some `data-*` prop to `<Tab />` but, currently he accept only `children`