### PR TITLE
fix missing `Copy Code` button in code-blocks without language

### DIFF
--- a/.changeset/pretty-dolphins-live.md
+++ b/.changeset/pretty-dolphins-live.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+fix missing `Copy Code` button in code-blocks without language

--- a/examples/swr-site/pages/docs/code-block-without-language.en-US.mdx
+++ b/examples/swr-site/pages/docs/code-block-without-language.en-US.mdx
@@ -1,0 +1,5 @@
+# Code blocks without language have `Copy Code` button
+
+```
+hello world
+```

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -93,7 +93,6 @@
     "github-slugger": "^1.4.0",
     "graceful-fs": "^4.2.10",
     "gray-matter": "^4.0.3",
-    "react-children-utilities": "^2.8.0",
     "rehype-mdx-title": "^1.0.0",
     "rehype-pretty-code": "0.2.4",
     "remark-gfm": "^3.0.1",

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -66,16 +66,16 @@ export async function compileMdx(
     ].filter(truthy),
     rehypePlugins: [
       ...(mdxOptions.rehypePlugins || []),
-      [
-        parseMeta,
-        { defaultShowCopyCode: nextraOptions.unstable_defaultShowCopyCode }
-      ],
+      parseMeta,
       [
         rehypePrettyCode,
         { ...rehypePrettyCodeOptions, ...mdxOptions.rehypePrettyCodeOptions }
       ],
       [rehypeMdxTitle, { name: '__nextra_title__' }],
-      attachMeta
+      [
+        attachMeta,
+        { defaultShowCopyCode: nextraOptions.unstable_defaultShowCopyCode }
+      ]
     ]
   })
   try {

--- a/packages/nextra/src/components/copy-to-clipboard.tsx
+++ b/packages/nextra/src/components/copy-to-clipboard.tsx
@@ -1,12 +1,10 @@
 import React, {
   ComponentProps,
   ReactElement,
-  ReactNode,
   useCallback,
   useEffect,
   useState
 } from 'react'
-import { onlyText } from 'react-children-utilities'
 import { CheckIcon, CopyIcon } from '../icons'
 import { Button } from './button'
 
@@ -14,7 +12,7 @@ export const CopyToClipboard = ({
   value,
   className
 }: {
-  value: ReactNode
+  value: string
   className?: string
 }): ReactElement => {
   const [isCopied, setCopied] = useState(false)
@@ -38,7 +36,7 @@ export const CopyToClipboard = ({
       console.error('Access to clipboard rejected!')
     }
     try {
-      await navigator.clipboard.writeText(onlyText(value))
+      await navigator.clipboard.writeText(JSON.parse(value))
     } catch {
       console.error('Failed to copy!')
     }

--- a/packages/nextra/src/components/pre.tsx
+++ b/packages/nextra/src/components/pre.tsx
@@ -6,14 +6,13 @@ import { WordWrapIcon } from '../icons'
 export const Pre = ({
   children,
   className = '',
+  value,
+  filename,
   ...props
 }: ComponentProps<'pre'> & {
-  'data-filename'?: string
-  'data-nextra-copy'?: ''
+  filename?: string
+  value?: string
 }): ReactElement => {
-  const hasCopy = 'data-nextra-copy' in props
-  const filename = props['data-filename']
-
   const toggleWordWrap = useCallback(() => {
     const htmlDataset = document.documentElement.dataset
     const hasWordWrap = 'nextraWordWrap' in htmlDataset
@@ -43,7 +42,7 @@ export const Pre = ({
       </pre>
       <div
         className={[
-          'nextra-code-block-buttons opacity-0 transition-opacity',
+          'nextra-code-block-buttons opacity-0 transition-opacity [div:hover>&]:opacity-100',
           'flex gap-1 absolute m-2 right-0',
           filename ? 'top-8' : 'top-0'
         ].join(' ')}
@@ -51,8 +50,8 @@ export const Pre = ({
         <Button onClick={toggleWordWrap} className="md:hidden">
           <WordWrapIcon className="pointer-events-none w-4 h-4" />
         </Button>
-        {hasCopy && (
-          <CopyToClipboard value={children} className="nextra-copy-button" />
+        {value && (
+          <CopyToClipboard value={value} className="nextra-copy-button" />
         )}
       </div>
     </>

--- a/packages/nextra/src/mdx-plugins/rehype-handler.js
+++ b/packages/nextra/src/mdx-plugins/rehype-handler.js
@@ -9,58 +9,45 @@ function visit(node, tagNames, handler) {
   node.children?.forEach(n => visit(n, tagNames, handler))
 }
 
-export const parseMeta =
+export const parseMeta = () => tree => {
+  visit(tree, ['pre'], node => {
+    const [codeEl] = node.children
+    // Add default language `text` for code-blocks without languages
+    codeEl.properties.className ||= ['language-text']
+    node.__nextra_meta__ = codeEl.data?.meta
+    node.__nextra_text__ = codeEl.children[0].value
+  })
+}
+
+export const attachMeta =
   ({ defaultShowCopyCode }) =>
   tree => {
-    visit(tree, ['pre'], node => {
-      if (
-        // Block code
-        Array.isArray(node.children) &&
-        node.children.length === 1 &&
-        node.children[0].tagName === 'code' &&
-        typeof node.children[0].properties === 'object'
-      ) {
-        const meta =
-          node.children[0].data?.meta ?? node.children[0].properties.metastring
+    const slugger = new Slugger()
 
-        const hasCopy = meta
-          ? (defaultShowCopyCode && !/( |^)copy=false($| )/.test(meta)) ||
-            /( |^)copy($| )/.test(meta)
-          : defaultShowCopyCode
-        if (hasCopy) {
-          node.__nextra_copy__ = true
-        }
+    visit(tree, ['div', 'h2', 'h3', 'h4', 'h5', 'h6'], node => {
+      if (node.tagName !== 'div') {
+        // Attach slug
+        node.properties.id ||= slugger.slug(getFlattenedValue(node))
+        return
+      }
+      if (!('data-rehype-pretty-code-fragment' in node.properties)) {
+        return
+      }
+      const meta = node.__nextra_meta__
+      const hasCopy = meta
+        ? (defaultShowCopyCode && !/( |^)copy=false($| )/.test(meta)) ||
+          /( |^)copy($| )/.test(meta)
+        : defaultShowCopyCode
 
-        if (!meta) {
-          return
-        }
-        const filename = meta.match(/filename="([^"]+)"/)?.[1]
-        if (filename) {
-          node.__nextra_filename__ = filename
-        }
+      const [preEl] = node.children
+      if (hasCopy) {
+        preEl.properties.value = JSON.stringify(node.__nextra_text__)
+      }
+
+      // Attach filename
+      const filename = meta?.match(/filename="([^"]+)"/)?.[1]
+      if (filename) {
+        preEl.properties.filename = filename
       }
     })
   }
-
-export const attachMeta = () => tree => {
-  const slugger = new Slugger()
-
-  visit(tree, ['div', 'h2', 'h3', 'h4', 'h5', 'h6'], node => {
-    if (node.tagName !== 'div') {
-      // Attach slug
-      node.properties.id ||= slugger.slug(getFlattenedValue(node))
-      return
-    }
-    if (!('data-rehype-pretty-code-fragment' in node.properties)) {
-      return
-    }
-    const preElement = node.children[0]
-    if ('__nextra_copy__' in node) {
-      preElement.properties['data-nextra-copy'] = ''
-    }
-    // Attach filename
-    if ('__nextra_filename__' in node) {
-      preElement.properties['data-filename'] = node.__nextra_filename__
-    }
-  })
-}

--- a/packages/nextra/styles/code-block.css
+++ b/packages/nextra/styles/code-block.css
@@ -28,11 +28,6 @@ pre {
   contain: paint;
   code {
     @apply grid min-w-full rounded-none border-none !bg-transparent !p-0 text-sm leading-5 text-current dark:!bg-transparent;
-    /* code blocks without languages don't have children that have px-4 */
-    &:not([data-language]) {
-      @apply !px-4;
-    }
-
     .line {
       @apply border-l-2 border-transparent px-4;
     }
@@ -49,10 +44,6 @@ pre {
 
 [data-rehype-pretty-code-fragment] {
   @apply relative;
-
-  &:hover .nextra-code-block-buttons {
-    @apply opacity-100;
-  }
 }
 
 @supports (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,6 @@ importers:
       gray-matter: ^4.0.3
       next: ^12.2.4
       react: ^18.2.0
-      react-children-utilities: ^2.8.0
       react-dom: ^18.2.0
       rehype-mdx-title: ^1.0.0
       rehype-pretty-code: 0.2.4
@@ -153,7 +152,6 @@ importers:
       github-slugger: 1.4.0
       graceful-fs: 4.2.10
       gray-matter: 4.0.3
-      react-children-utilities: 2.8.0_react@18.2.0
       rehype-mdx-title: 1.0.0
       rehype-pretty-code: 0.2.4_shiki@0.10.1
       remark-gfm: 3.0.1
@@ -6578,7 +6576,7 @@ packages:
     resolution: {directory: packages/nextra-theme-blog, type: directory}
     id: file:packages/nextra-theme-blog
     name: nextra-theme-blog
-    version: 2.0.0-beta.20
+    version: 2.0.0-beta.21
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6599,7 +6597,7 @@ packages:
     resolution: {directory: packages/nextra-theme-docs, type: directory}
     id: file:packages/nextra-theme-docs
     name: nextra-theme-docs
-    version: 2.0.0-beta.20
+    version: 2.0.0-beta.21
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6628,7 +6626,7 @@ packages:
     resolution: {directory: packages/nextra, type: directory}
     id: file:packages/nextra
     name: nextra
-    version: 2.0.0-beta.20
+    version: 2.0.0-beta.21
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'


### PR DESCRIPTION
- [x] add default language for code blocks `language-text` so they will be processed by `rehypePrettyCode`, and copy code button will be present for them
- [x] remove `react-children-utilities` dependecy