### PR TITLE
use `title` package in nextra to determine sidebar title based on pagename

### DIFF
--- a/.changeset/nice-shrimps-cheat.md
+++ b/.changeset/nice-shrimps-cheat.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+use `title` package in nextra to determine sidebar title based on pagename

--- a/packages/nextra-theme-docs/src/utils/normalize-pages.ts
+++ b/packages/nextra-theme-docs/src/utils/normalize-pages.ts
@@ -1,7 +1,7 @@
 import { PageMapItem } from 'nextra'
 import { DEFAULT_PAGE_THEME } from '../constants'
 import { PageTheme } from '../types'
-import { Folder, MdxFile } from 'nextra/src/types'
+import { Folder, MdxFile } from 'nextra'
 
 function extendMeta(
   meta: string | Record<string, any> = {},

--- a/packages/nextra/__test__/__snapshots__/context.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/context.test.ts.snap
@@ -1035,7 +1035,7 @@ exports[`context > getAllPages() > should work 1`] = `
                 "kind": "MdxPage",
                 "locale": "en-US",
                 "meta": {
-                  "title": "loooooooooooooooooooong-title",
+                  "title": "Loooooooooooooooooooong Title",
                 },
                 "name": "loooooooooooooooooooong-title",
                 "route": "/docs/advanced/more/loooooooooooooooooooong-title",
@@ -1279,7 +1279,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "en-US",
         "meta": {
-          "title": "code-block-without-language",
+          "title": "Code Block without Language",
         },
         "name": "code-block-without-language",
         "route": "/docs/code-block-without-language",
@@ -2749,7 +2749,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
             "kind": "MdxPage",
             "locale": "en-US",
             "meta": {
-              "title": "loooooooooooooooooooong-title",
+              "title": "Loooooooooooooooooooong Title",
             },
             "name": "loooooooooooooooooooong-title",
             "route": "/docs/advanced/more/loooooooooooooooooooong-title",
@@ -2993,7 +2993,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "en-US",
     "meta": {
-      "title": "code-block-without-language",
+      "title": "Code Block without Language",
     },
     "name": "code-block-without-language",
     "route": "/docs/code-block-without-language",
@@ -3162,7 +3162,7 @@ exports[`context > getPagesUnderRoute() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "en-US",
         "meta": {
-          "title": "loooooooooooooooooooong-title",
+          "title": "Loooooooooooooooooooong Title",
         },
         "name": "loooooooooooooooooooong-title",
         "route": "/docs/advanced/more/loooooooooooooooooooong-title",

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -196,7 +196,7 @@ exports[`Page Process > pageMap en-US 1`] = `
               },
               "title": "Change Log",
             },
-            "code-block-without-language": "code-block-without-language",
+            "code-block-without-language": "Code Block without Language",
             "conditional-fetching": "Conditional Data Fetching",
             "data-fetching": "Data Fetching",
             "error-handling": {
@@ -289,7 +289,7 @@ exports[`Page Process > pageMap en-US 1`] = `
                 },
                 {
                   "data": {
-                    "loooooooooooooooooooong-title": "loooooooooooooooooooong-title",
+                    "loooooooooooooooooooong-title": "Loooooooooooooooooooong Title",
                   },
                   "kind": "Meta",
                   "locale": "en-US",
@@ -695,7 +695,7 @@ exports[`Page Process > pageMap zh-CN 1`] = `
                 },
                 {
                   "data": {
-                    "loooooooooooooooooooong-title": "loooooooooooooooooooong-title",
+                    "loooooooooooooooooooong-title": "Loooooooooooooooooooong Title",
                   },
                   "kind": "Meta",
                   "locale": "en-US",

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -86,7 +86,8 @@
     "remark-gfm": "^3.0.1",
     "remark-reading-time": "^2.0.1",
     "shiki": "0.10.1",
-    "slash": "^3.0.0"
+    "slash": "^3.0.0",
+    "title": "^3.5.3"
   },
   "peerDependencies": {
     "next": ">=9.5.3",

--- a/packages/nextra/src/env.d.ts
+++ b/packages/nextra/src/env.d.ts
@@ -5,3 +5,12 @@ declare module globalThis {
     route: string
   }
 }
+
+declare module 'title' {
+  export default function title(
+    title: string,
+    special?: {
+      special: string[]
+    }
+  )
+}

--- a/packages/nextra/src/plugin.ts
+++ b/packages/nextra/src/plugin.ts
@@ -16,6 +16,7 @@ import slash from 'slash'
 import grayMatter from 'gray-matter'
 import { findPagesDir } from 'next/dist/lib/find-pages-dir.js'
 import { Compiler } from 'webpack'
+import title from 'title'
 
 import { restoreCache } from './content-dump'
 import { CWD, MARKDOWN_EXTENSION_REGEX, META_FILENAME } from './constants'
@@ -103,7 +104,10 @@ export async function collectFiles(
     )
     const defaultMeta: [string, string][] = mdxPages
       .filter(item => item.locale === locale)
-      .map(item => [item.name, item.frontMatter?.title || item.name])
+      .map(item => [
+        item.name,
+        item.frontMatter?.title || title(item.name.replace(/[-_]/g, ' '))
+      ])
     const metaFilename = locale
       ? META_FILENAME.replace('.', `.${locale}.`)
       : META_FILENAME

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,7 @@ importers:
       remark-reading-time: ^2.0.1
       shiki: 0.10.1
       slash: ^3.0.0
+      title: ^3.5.3
       vitest: ^0.21.0
     dependencies:
       '@mdx-js/mdx': 2.1.3
@@ -158,6 +159,7 @@ importers:
       remark-reading-time: 2.0.1
       shiki: 0.10.1
       slash: 3.0.0
+      title: 3.5.3
     devDependencies:
       '@types/github-slugger': 1.3.0
       '@types/graceful-fs': 4.1.5
@@ -5774,6 +5776,16 @@ packages:
 
   /title/3.5.1:
     resolution: {integrity: sha512-tf3NFu/EXsIyEN+GKq6ZuDaOw5wiyE6nmp4Yw7BuWZPk9jgE5PpLWH40ekzDW85+8kbcBCcV+Jz2Qfw0D/Y2MQ==}
+    hasBin: true
+    dependencies:
+      arg: 1.0.0
+      chalk: 2.3.0
+      clipboardy: 1.2.2
+      titleize: 1.0.0
+    dev: false
+
+  /title/3.5.3:
+    resolution: {integrity: sha512-20JyowYglSEeCvZv3EZ0nZ046vLarO37prvV0mbtQV7C8DJPGgN967r8SJkqd3XK3K3lD3/Iyfp3avjfil8Q2Q==}
     hasBin: true
     dependencies:
       arg: 1.0.0


### PR DESCRIPTION
1. bring back `title` package but use it not in `nextra-theme-docs` but in `nextra` directly

So follow sidebar links:
![image](https://user-images.githubusercontent.com/7361780/188610657-814bde3c-5aff-4153-9e31-ac6a93fae1bc.png)

will be replaced with:

![image](https://user-images.githubusercontent.com/7361780/188610709-3911e4a5-aa6e-4f25-8a69-29a601629662.png)

2. replace all `-` and `_` characters in pagename to make it looks even better!

![image](https://user-images.githubusercontent.com/7361780/188610810-b126e01a-6c3a-4db3-ae24-1a123c260378.png)
