### PR TITLE
fix rtl/ltr glitch on initial loading

### DIFF
--- a/.changeset/lucky-chefs-walk.md
+++ b/.changeset/lucky-chefs-walk.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix rtl/ltr glitch on initial loading

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -189,7 +189,7 @@ const InnerLayout = ({
     // This makes sure that selectors like `[dir=ltr] .nextra-container` work
     // before hydration as Tailwind expects the `dir` attribute to exist on the
     // `html` element.
-    <>
+    <div dir={direction}>
       <script
         dangerouslySetInnerHTML={{
           __html: `document.documentElement.setAttribute('dir','${direction}')`
@@ -249,7 +249,7 @@ const InnerLayout = ({
       </div>
       {themeContext.footer &&
         renderComponent(config.footer.component, { menu: hideSidebar })}
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
I guess while using `next export` glitch is still present

see https://f6c0950f.graphql-yoga.pages.dev/