### PR TITLE
fix: ctrl+k check with e.ctrlKey

### DIFF
--- a/.changeset/lovely-boxes-impress.md
+++ b/.changeset/lovely-boxes-impress.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix CTRL+K, on non non-mac use `e.ctrlKey` instead `e.metaKey`

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -59,7 +59,11 @@ export function Search({
     const down = (e: globalThis.KeyboardEvent): void => {
       const tagName = document.activeElement?.tagName.toLowerCase()
       if (!input.current || !tagName || INPUTS.includes(tagName)) return
-      if (e.key === '/' || (e.key === 'k' && (e.metaKey || e.ctrlKey))) {
+      if (
+        e.key === '/' ||
+        (e.key === 'k' &&
+          (e.metaKey /* for Mac */ || /* for non-Mac */ e.ctrlKey))
+      ) {
         e.preventDefault()
         input.current.focus()
       } else if (e.key === 'Escape') {

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -59,7 +59,7 @@ export function Search({
     const down = (e: globalThis.KeyboardEvent): void => {
       const tagName = document.activeElement?.tagName.toLowerCase()
       if (!input.current || !tagName || INPUTS.includes(tagName)) return
-      if (e.key === '/' || (e.key === 'k' && e.metaKey)) {
+      if (e.key === '/' || (e.key === 'k' && (e.metaKey || e.ctrlKey))) {
         e.preventDefault()
         input.current.focus()
       } else if (e.key === 'Escape') {


### PR DESCRIPTION
On chrome in non-mac, metaKey is not mapped into ctrlKey. We must use ctrlKey explicitly to check