### PR TITLE
change default options for `compileMdx`, set `jsx: false` and `outputFormat: 'function-body'` by default

### DIFF
--- a/.changeset/fresh-ads-chew.md
+++ b/.changeset/fresh-ads-chew.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+change default options for `compileMdx`, set `jsx: false` and `outputFormat: 'function-body'` by default

--- a/packages/nextra/__test__/compile.test.ts
+++ b/packages/nextra/__test__/compile.test.ts
@@ -16,30 +16,35 @@ function loadFixture(name: Name) {
   return fs.readFile(filePath, 'utf8')
 }
 
+const mdxOptions = {
+  jsx: true,
+  outputFormat: 'program' as const
+}
+
 describe('process heading', () => {
   it('code-h1', async () => {
     const data = await loadFixture('code-h1.mdx')
-    const result = await compileMdx(data)
+    const result = await compileMdx(data, { mdxOptions })
     expect(result).toMatchSnapshot()
   })
   it('code-with-text-h1', async () => {
     const data = await loadFixture('code-with-text-h1.mdx')
-    const result = await compileMdx(data)
+    const result = await compileMdx(data, { mdxOptions })
     expect(result).toMatchSnapshot()
   })
   it('static-h1', async () => {
     const data = await loadFixture('static-h1.mdx')
-    const result = await compileMdx(data)
+    const result = await compileMdx(data, { mdxOptions })
     expect(result).toMatchSnapshot()
   })
   it('dynamic-h1', async () => {
     const data = await loadFixture('dynamic-h1.mdx')
-    const result = await compileMdx(data)
+    const result = await compileMdx(data, { mdxOptions })
     expect(result).toMatchSnapshot()
   })
   it('no-h1', async () => {
     const data = await loadFixture('no-h1.mdx')
-    const result = await compileMdx(data)
+    const result = await compileMdx(data, { mdxOptions })
     expect(result).toMatchSnapshot()
   })
 })

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -60,8 +60,8 @@ export async function compileMdx(
   const mdxOptions = loaderOptions.mdxOptions || {}
 
   const compiler = createCompiler({
-    jsx: mdxOptions.jsx ?? true,
-    outputFormat: mdxOptions.outputFormat,
+    jsx: mdxOptions.jsx || false,
+    outputFormat: mdxOptions.outputFormat || 'function-body',
     providerImportSource: '@mdx-js/react',
     remarkPlugins: [
       ...(mdxOptions.remarkPlugins || []),

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -119,7 +119,11 @@ async function loader(
     await compileMdx(
       content,
       {
-        mdxOptions,
+        mdxOptions: {
+          ...mdxOptions,
+          jsx: true,
+          outputFormat: 'program',
+        },
         unstable_readingTime,
         unstable_defaultShowCopyCode,
         unstable_staticImage,


### PR DESCRIPTION
while compiling mdx and rendering via `next-remote-mdx`, every time we pass these values by default, I guess we can simplify to make them by default and only in loader overwrite them

<img width="433" alt="image" src="https://user-images.githubusercontent.com/7361780/193835516-a2de7688-f028-484a-8e3e-30b485061e77.png">
