### PR TITLE
feat: ability to use onprem GitHub with custom domain

### DIFF
--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -30,6 +30,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   darkMode: true,
   direction: 'ltr',
   docsRepositoryBase: 'https://github.com/shuding/nextra',
+  docsRepositoryBaseCustom: 'https://github.onprem.com/shuding/nextra',
+  docsRepositoryBaseCustomBranch: 'main',
   editLink: {
     component({ className, filePath, children }) {
       const editUrl = getGitEditUrl(filePath)

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -29,6 +29,8 @@ export interface DocsThemeConfig {
   darkMode: boolean
   direction: 'ltr' | 'rtl'
   docsRepositoryBase: string
+  docsRepositoryBaseCustom: string
+  docsRepositoryBaseCustomBranch: string
   editLink: {
     component: FC<{
       children: ReactNode

--- a/packages/nextra-theme-docs/src/utils/get-git-edit-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-edit-url.ts
@@ -3,6 +3,12 @@ import parseGitUrl from 'parse-git-url'
 
 export const getGitEditUrl = (filePath?: string): string => {
   const config = useConfig()
+
+  if (config.docsRepositoryBaseCustom) {
+    console.log(filePath);
+    return `${config.docsRepositoryBaseCustom}/${config.docsRepositoryBaseCustomBranch || 'main'}/${filePath}`
+  }
+
   const repo = parseGitUrl(config.docsRepositoryBase || '')
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -1,3 +1,4 @@
+import { useConfig } from '../contexts'
 import parseGitUrl from 'parse-git-url'
 
 export const getGitIssueUrl = ({
@@ -9,6 +10,14 @@ export const getGitIssueUrl = ({
   title: string
   labels?: string
 }): string => {
+  const config = useConfig()
+
+  if (config.docsRepositoryBaseCustom) {
+    return `${config.docsRepositoryBaseCustom}/issues/new?title=${encodeURI(title)}${
+      labels ? `&labels=${encodeURI(labels as string)}` : ''
+    }`
+  }
+
   const repo = parseGitUrl(repository)
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 


### PR DESCRIPTION
I've stumbled across https://github.com/shuding/nextra/issues/330 myself and tried to get Nextra running for my Enterprise GitHub instances that use custom domains.

This change focuses on using making small changes to Nextra instead of `parse-git-url `.

Any feedback is welcome or otherwise put it to the bin.