### PR TITLE
Allow Custom Git Hostnames

### DIFF
--- a/.changeset/funny-houses-tickle.md
+++ b/.changeset/funny-houses-tickle.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': major
+---
+
+allowed custom git domains

--- a/.changeset/funny-houses-tickle.md
+++ b/.changeset/funny-houses-tickle.md
@@ -1,5 +1,5 @@
 ---
-'nextra-theme-docs': major
+'nextra-theme-docs': minor
 ---
 
-allowed custom git domains
+allow custom github domains

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -50,12 +50,12 @@
     "clsx": "^1.2.1",
     "flexsearch": "^0.7.21",
     "focus-visible": "^5.2.0",
+    "git-url-parse": "^13.1.0",
     "github-slugger": "^1.4.0",
     "intersection-observer": "^0.12.2",
     "match-sorter": "^6.3.1",
     "next-seo": "^5.5.0",
     "next-themes": "^0.2.0-beta.2",
-    "parse-git-url": "^1.0.1",
     "scroll-into-view-if-needed": "^2.2.29"
   },
   "peerDependencies": {
@@ -67,6 +67,7 @@
     "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",
     "@tailwindcss/typography": "^0.5.4",
     "@types/flexsearch": "^0.7.3",
+    "@types/git-url-parse": "^9.0.1",
     "@types/github-slugger": "^1.3.0",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/packages/nextra-theme-docs/src/utils/get-git-edit-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-edit-url.ts
@@ -1,9 +1,9 @@
 import { useConfig } from '../contexts'
-import parseGitUrl from 'git-url-parse'
+import gitUrlParse from 'git-url-parse'
 
 export const getGitEditUrl = (filePath?: string): string => {
   const config = useConfig()
-  const repo = parseGitUrl(config.docsRepositoryBase || '')
+  const repo = gitUrlParse(config.docsRepositoryBase || '')
 
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 

--- a/packages/nextra-theme-docs/src/utils/get-git-edit-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-edit-url.ts
@@ -1,19 +1,11 @@
 import { useConfig } from '../contexts'
-import parseGitUrl from 'parse-git-url'
+import parseGitUrl from 'git-url-parse'
 
 export const getGitEditUrl = (filePath?: string): string => {
   const config = useConfig()
   const repo = parseGitUrl(config.docsRepositoryBase || '')
+
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
-  const subdir = repo.subdir ? `${repo.subdir}/` : ''
-  const path = `blob/${repo.branch || 'main'}/${subdir}${filePath}`
-
-  switch (repo.type) {
-    case 'github':
-      return `https://github.com/${repo.owner}/${repo.name}/${path}`
-    case 'gitlab':
-      return `https://gitlab.com/${repo.owner}/${repo.name}/-/${path}`
-  }
-  return ''
+  return `${repo.href}/${filePath}`
 }

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -1,4 +1,4 @@
-import gitUrlParse from 'git-url-parse'
+import parseGitUrl from 'git-url-parse'
 
 export const getGitIssueUrl = ({
   repository = '',
@@ -9,17 +9,17 @@ export const getGitIssueUrl = ({
   title: string
   labels?: string
 }): string => {
-  const repo = gitUrlParse(repository)
+  const repo = parseGitUrl(repository)
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
   if (repo.resource.includes('gitlab')) {
     return `https://gitlab.com/${repo.owner}/${
-        repo.name
-      }/-/issues/new?issue[title]=${encodeURIComponent(title)}`
-  } else if (repo.href.includes('github')) {
+      repo.name
+    }/-/issues/new?issue[title]=${encodeURIComponent(title)}`
+  } else if (repo.resource.includes('github')) {
     return `${repo.resource}/${repo.owner}/${
-        repo.name
-      }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
+      repo.name
+    }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
   } else {
     return '#'
   }

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -13,11 +13,11 @@ export const getGitIssueUrl = ({
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
   if (repo.resource.includes('gitlab')) {
-    return `https://gitlab.com/${repo.owner}/${
+    return `${repo.protocol}:${repo.resource}/${repo.owner}/${
       repo.name
     }/-/issues/new?issue[title]=${encodeURIComponent(title)}`
   } else if (repo.resource.includes('github')) {
-    return `https://github.com/${repo.owner}/${
+    return `${repo.protocol}:${repo.resource}/${
       repo.name
     }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
   } else {

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -1,4 +1,4 @@
-import parseGitUrl from 'git-url-parse'
+import gitUrlParse from 'git-url-parse'
 
 export const getGitIssueUrl = ({
   repository = '',
@@ -9,7 +9,7 @@ export const getGitIssueUrl = ({
   title: string
   labels?: string
 }): string => {
-  const repo = parseGitUrl(repository)
+  const repo = gitUrlParse(repository)
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
   if (repo.resource.includes('gitlab')) {

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -1,4 +1,4 @@
-import parseGitUrl from 'parse-git-url'
+import parseGitUrl from 'git-url-parse'
 
 export const getGitIssueUrl = ({
   repository = '',
@@ -12,16 +12,15 @@ export const getGitIssueUrl = ({
   const repo = parseGitUrl(repository)
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
-  switch (repo.type) {
-    case 'github':
-      return `https://github.com/${repo.owner}/${
-        repo.name
-      }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
-    case 'gitlab':
-      return `https://gitlab.com/${repo.owner}/${
+  if (repo.href.includes('gitlab')) {
+    return `https://gitlab.com/${repo.owner}/${
         repo.name
       }/-/issues/new?issue[title]=${encodeURIComponent(title)}`
+  } else if (repo.href.includes('github')) {
+    return `${repo.resource}/${repo.owner}/${
+        repo.name
+      }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
+  } else {
+    return '#'
   }
-
-  return '#'
 }

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -13,11 +13,11 @@ export const getGitIssueUrl = ({
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
   if (repo.resource.includes('gitlab')) {
-    return `${repo.protocol}:${repo.resource}/${repo.owner}/${
+    return `${repo.protocol}://${repo.resource}/${repo.owner}/${
       repo.name
     }/-/issues/new?issue[title]=${encodeURIComponent(title)}`
   } else if (repo.resource.includes('github')) {
-    return `${repo.protocol}:${repo.resource}/${repo.owner}/${
+    return `${repo.protocol}://${repo.resource}/${repo.owner}/${
       repo.name
     }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
   } else {

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -17,7 +17,7 @@ export const getGitIssueUrl = ({
       repo.name
     }/-/issues/new?issue[title]=${encodeURIComponent(title)}`
   } else if (repo.resource.includes('github')) {
-    return `${repo.resource}/${repo.owner}/${
+    return `https://github.com/${repo.owner}/${
       repo.name
     }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
   } else {

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -17,7 +17,7 @@ export const getGitIssueUrl = ({
       repo.name
     }/-/issues/new?issue[title]=${encodeURIComponent(title)}`
   } else if (repo.resource.includes('github')) {
-    return `${repo.protocol}:${repo.resource}/${
+    return `${repo.protocol}:${repo.resource}/${repo.owner}/${
       repo.name
     }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`
   } else {

--- a/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
+++ b/packages/nextra-theme-docs/src/utils/get-git-issue-url.ts
@@ -1,4 +1,4 @@
-import parseGitUrl from 'git-url-parse'
+import gitUrlParse from 'git-url-parse'
 
 export const getGitIssueUrl = ({
   repository = '',
@@ -9,10 +9,10 @@ export const getGitIssueUrl = ({
   title: string
   labels?: string
 }): string => {
-  const repo = parseGitUrl(repository)
+  const repo = gitUrlParse(repository)
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
 
-  if (repo.href.includes('gitlab')) {
+  if (repo.resource.includes('gitlab')) {
     return `https://gitlab.com/${repo.owner}/${
         repo.name
       }/-/issues/new?issue[title]=${encodeURIComponent(title)}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,7 @@ importers:
       '@tailwindcss/nesting': ^0.0.0-insiders.565cd3e
       '@tailwindcss/typography': ^0.5.4
       '@types/flexsearch': ^0.7.3
+      '@types/git-url-parse': ^9.0.1
       '@types/github-slugger': ^1.3.0
       '@types/react': ^18.0.15
       '@types/react-dom': ^18.0.6
@@ -235,6 +236,7 @@ importers:
       concurrently: ^7.3.0
       flexsearch: ^0.7.21
       focus-visible: ^5.2.0
+      git-url-parse: ^13.1.0
       github-slugger: ^1.4.0
       intersection-observer: ^0.12.2
       lightningcss-cli: ^1.16.0
@@ -243,7 +245,6 @@ importers:
       next-seo: ^5.5.0
       next-themes: ^0.2.0-beta.2
       nextra: workspace:*
-      parse-git-url: ^1.0.1
       postcss: ^8.4.14
       postcss-cli: ^8.3.1
       postcss-import: ^14.1.0
@@ -260,17 +261,18 @@ importers:
       clsx: 1.2.1
       flexsearch: 0.7.21
       focus-visible: 5.2.0
+      git-url-parse: 13.1.0
       github-slugger: 1.4.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
       next-seo: 5.8.0_c3hne4hwj64hb7tofigd3bvkji
       next-themes: 0.2.0_c3hne4hwj64hb7tofigd3bvkji
-      parse-git-url: 1.0.1
       scroll-into-view-if-needed: 2.2.29
     devDependencies:
       '@tailwindcss/nesting': 0.0.0-insiders.565cd3e_postcss@8.4.14
       '@tailwindcss/typography': 0.5.4_tailwindcss@3.1.8
       '@types/flexsearch': 0.7.3
+      '@types/git-url-parse': 9.0.1
       '@types/github-slugger': 1.3.0
       '@types/react': 18.0.20
       '@types/react-dom': 18.0.6
@@ -1050,6 +1052,10 @@ packages:
 
   /@types/flexsearch/0.7.3:
     resolution: {integrity: sha512-HXwADeHEP4exXkCIwy2n1+i0f1ilP1ETQOH5KDOugjkTFZPntWo0Gr8stZOaebkxsdx+k0X/K6obU/+it07ocg==}
+    dev: true
+
+  /@types/git-url-parse/9.0.1:
+    resolution: {integrity: sha512-Zf9mY4Mz7N3Nyi341nUkOtgVUQn4j6NS4ndqEha/lOgEbTkHzpD7wZuRagYKzrXNtvawWfsrojoC1nhsQexvNA==}
     dev: true
 
   /@types/github-slugger/1.3.0:
@@ -2958,6 +2964,19 @@ packages:
       get-intrinsic: 1.1.2
     dev: true
 
+  /git-up/7.0.0:
+    resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
+    dependencies:
+      is-ssh: 1.4.0
+      parse-url: 8.1.0
+    dev: false
+
+  /git-url-parse/13.1.0:
+    resolution: {integrity: sha512-5FvPJP/70WkIprlUZ33bm4UAaFdjcLkJLpWft1BeZKqwR0uhhNGoKwlUaPtVb4LxCSQ++erHapRak9kWGj+FCA==}
+    dependencies:
+      git-up: 7.0.0
+    dev: false
+
   /github-slugger/1.4.0:
     resolution: {integrity: sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==}
     dev: false
@@ -3325,6 +3344,12 @@ packages:
     dependencies:
       call-bind: 1.0.2
     dev: true
+
+  /is-ssh/1.4.0:
+    resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
+    dependencies:
+      protocols: 2.0.1
+    dev: false
 
   /is-stream/1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
@@ -4559,6 +4584,18 @@ packages:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
     dev: false
 
+  /parse-path/7.0.0:
+    resolution: {integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==}
+    dependencies:
+      protocols: 2.0.1
+    dev: false
+
+  /parse-url/8.1.0:
+    resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
+    dependencies:
+      parse-path: 7.0.0
+    dev: false
+
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -4794,6 +4831,10 @@ packages:
 
   /property-information/6.1.1:
     resolution: {integrity: sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==}
+    dev: false
+
+  /protocols/2.0.1:
+    resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
     dev: false
 
   /pseudomap/1.0.2:
@@ -6316,7 +6357,7 @@ packages:
     resolution: {directory: packages/nextra-theme-blog, type: directory}
     id: file:packages/nextra-theme-blog
     name: nextra-theme-blog
-    version: 2.0.0-beta.32
+    version: 2.0.0-beta.38
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6337,7 +6378,7 @@ packages:
     resolution: {directory: packages/nextra-theme-docs, type: directory}
     id: file:packages/nextra-theme-docs
     name: nextra-theme-docs
-    version: 2.0.0-beta.32
+    version: 2.0.0-beta.38
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6350,6 +6391,7 @@ packages:
       clsx: 1.2.1
       flexsearch: 0.7.21
       focus-visible: 5.2.0
+      git-url-parse: 13.1.0
       github-slugger: 1.4.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
@@ -6366,7 +6408,7 @@ packages:
     resolution: {directory: packages/nextra, type: directory}
     id: file:packages/nextra
     name: nextra
-    version: 2.0.0-beta.32
+    version: 2.0.0-beta.38
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'


### PR DESCRIPTION
A follow-up on my last try: I've used a different git url parser this time, changes the approach of getting the git url and issue path quite a bit, but does the job. Makes getting the complete path of a file easier..
Tested with custom GitHub and GitLab domain (sub-domain).

Happy to hear your feedback

---

I've stumbled across https://github.com/shuding/nextra/issues/330 myself and tried to get Nextra running for my Enterprise GitHub instances that use custom domains.

This change focuses on using making small changes to Nextra instead of parse-git-url .

Any feedback is welcome or otherwise put it to the bin.