### PR TITLE
fix(docs): correct query for hash with leading num

### DIFF
--- a/.changeset/moody-buses-arrive.md
+++ b/.changeset/moody-buses-arrive.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+fix(docs): correct query for hash with leading num

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -28,7 +28,7 @@ let resizeObserver: ResizeObserver
 if (IS_BROWSER) {
   resizeObserver ||= new ResizeObserver(entries => {
     if (location.hash) {
-      const node = entries[0].target.ownerDocument.querySelector(location.hash)
+      const node = entries[0].target.ownerDocument.getElementById(location.hash.slice(1))
       if (node) {
         scrollIntoView(node)
       }


### PR DESCRIPTION
Fixes an issue when a heading contains a leading number. For example:

### 2. Create a new package

---

This is technically an invalid HTML id (can't start an ID with a number), and `querySelector` is unable to handle this:
```
3680-40188720ff3a5e8f.js:1 Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#2-create-a-new-package' is not a valid selector.
    at ResizeObserver.<anonymous> (https://turborepo.org/_next/static/chunks/3680-40188720ff3a5e8f.js:1:180836)
```

This PR fixes this by using `getElementById` instead of `querySelector`

This could also be fixed by sanitizing the IDs when they are created, but this could lead to collisions (`#1-header`, `#2-header` could collapse to `#header`) 