### PR TITLE
replace `main.extraContent` theme option with `main` option

### DIFF
--- a/.changeset/nasty-apples-breathe.md
+++ b/.changeset/nasty-apples-breathe.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+replace `main.extraContent` theme option with `main` option

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -83,7 +83,6 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     </>
   ),
   logoLink: true,
-  main: {},
   navbar: Navbar,
   navigation: {
     next: true,
@@ -161,7 +160,7 @@ export const DEEP_OBJECT_KEYS = Object.entries(DEFAULT_THEME)
 
 export const LEGACY_CONFIG_OPTIONS: Record<string, string> = {
   bannerKey: 'banner.key',
-  bodyExtraContent: 'main.extraContent',
+  bodyExtraContent: 'main',
   customSearch: 'search.component',
   defaultMenuCollapsed: 'sidebar.defaultMenuCollapsed',
   feedbackLabels: 'feedback.labels',

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -97,14 +97,15 @@ const Body = ({
     <div className="mt-16" />
   )
 
-  const body = (
+  const content = (
     <>
       {children}
       {gitTimestampEl}
       {navigation}
-      {renderComponent(config.main.extraContent)}
     </>
   )
+
+  const body = config.main?.({ children: content }) || content
 
   if (themeContext.layout === 'full') {
     return (

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -54,9 +54,7 @@ export interface DocsThemeConfig {
   i18n: { direction?: string; locale: string; text: string }[]
   logo: ReactNode | FC
   logoLink?: boolean | string
-  main: {
-    extraContent?: ReactNode | FC
-  }
+  main?: FC<{ children: ReactNode }>
   navbar: ReactNode | FC<NavBarProps>
   navigation:
     | boolean


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/826#issue-1368578794

> bodyExtraContent → main.extraContent (in the future we can configure the main content area here)