### PR TITLE
setup `next-seo`

### DIFF
--- a/.changeset/silver-students-return.md
+++ b/.changeset/silver-students-return.md
@@ -1,0 +1,8 @@
+---
+'nextra-theme-docs': patch
+---
+
+remove `titleSuffix` theme option in favor of `defaultSeo.titleTemplate`
+setup `next-seo`
+add new theme option `defaultSeo`
+get `description`, `canonical`, `openGraph` values from `frontMatter` and pass them to `<NextSeo />` component

--- a/.changeset/silver-students-return.md
+++ b/.changeset/silver-students-return.md
@@ -2,7 +2,7 @@
 'nextra-theme-docs': patch
 ---
 
-remove `titleSuffix` theme option in favor of `defaultSeo.titleTemplate`
-setup `next-seo`
-add new theme option `defaultSeo`
-get `description`, `canonical`, `openGraph` values from `frontMatter` and pass them to `<NextSeo />` component
+- setup `next-seo`
+- add new theme option `getNextSeoProps`
+- remove `titleSuffix` theme option in favor of `getNextSeoProps.titleTemplate`
+- by default pass `description`, `canonical`, `openGraph` values to `<NextSeo />` component  from page `frontMatter`, values can be overridden with return value of `getNextSeoProps`

--- a/examples/docs/src/pages/_app.js
+++ b/examples/docs/src/pages/_app.js
@@ -1,6 +1,0 @@
-import 'nextra-theme-docs/style.css'
-
-export default function Nextra({ Component, pageProps }) {
-  const getLayout = Component.getLayout || (page => page)
-  return getLayout(<Component {...pageProps} />)
-}

--- a/examples/docs/src/pages/features/i18n.mdx
+++ b/examples/docs/src/pages/features/i18n.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra-theme-docs'
 
 # Next.js I18n
 
-<Callout emoji="⚠️">This feature is only available in the docs theme.</Callout>
+<Callout type="warning">This feature is only available in the docs theme.</Callout>
 
 Nextra supports [Next.js Internationalized Routing](https://nextjs.org/docs/advanced-features/i18n-routing) out of the box.
 
@@ -10,6 +10,7 @@ To add multi-language pages to your Nextra application, just need to config `i18
 
 ```js filename="next.config.js"
 const withNextra = require('nextra')('nextra-theme-docs', './theme.config.js')
+
 module.exports = withNextra({
   i18n: {
     locales: ['en', 'zh', 'de'],
@@ -20,7 +21,7 @@ module.exports = withNextra({
 
 Then, add the locale codes to your file extensions (required for the default locale too):
 
-```plaintext
+```text
 /pages
   index.en.md
   index.zh.md

--- a/examples/docs/src/pages/features/image.mdx
+++ b/examples/docs/src/pages/features/image.mdx
@@ -14,7 +14,7 @@ import Image from 'next/image'
 
 import { Callout } from 'nextra-theme-docs'
 
-<Callout emoji="⚠️">
+<Callout type="warning">
   You need to opt-in to this feature by enabling [`unstable_staticImage:
   true`](/get-started#create-manually).
 </Callout>
@@ -22,12 +22,10 @@ import { Callout } from 'nextra-theme-docs'
 Nextra also supports automatic static image imports, you no longer need to specify the width and height of the image manually,
 and you can directly use the Markdown syntax to display the same image:
 
-```markdown
-![Hello](../../../public/demo.png)
+```md
+![Hello](/demo.png)
 ```
 
 With Next.js Image, there will be no layout shift, and a beautiful blury placeholder will be shown by default when loading the images:
 
-<br />
-
-![Nextra](../../../public/og.png)
+![Nextra](/og.png)

--- a/examples/docs/src/pages/get-started.mdx
+++ b/examples/docs/src/pages/get-started.mdx
@@ -73,17 +73,19 @@ module.exports = withNextra()
  * @type {import('nextra-theme-docs').DocsThemeConfig}
  */
 export default {
-  projectLink: 'https://github.com/shuding/nextra', // GitHub link in the navbar
+  project:{
+    link: 'https://github.com/shuding/nextra' // GitHub link in the navbar
+  },
   docsRepositoryBase: 'https://github.com/shuding/nextra/blob/master', // base URL for the docs repository
-  titleSuffix: ' – Nextra',
-  nextLinks: true,
-  prevLinks: true,
-  search: true,
-  customSearch: null, // customizable, you can use algolia for example
+  getNextSeoProps: () => ({ titleTemplate: '%s – Nextra' }),
+  navigation: true,
   darkMode: true,
-  footer: true,
-  footerText: `MIT ${new Date().getFullYear()} © Shu Ding.`,
-  footerEditLink: `Edit this page on GitHub`,
+  footer: {
+    text: `MIT ${new Date().getFullYear()} © Shu Ding.`
+  },
+  editLink: {
+    text: 'Edit this page on GitHub'
+  },
   logo: (
     <>
       <svg>...</svg>
@@ -96,7 +98,11 @@ export default {
       <meta name="description" content="Nextra: the next docs builder" />
       <meta name="og:title" content="Nextra: the next docs builder" />
     </>
-  )
+  ),
+  primaryHue: {
+    dark: 204,
+    light: 212
+  }
 }
 ```
 
@@ -105,18 +111,7 @@ export default {
   [here](/themes/docs/configuration).
 </Callout>
 
-5. Create `pages/_app.js` and include the theme stylesheet:
-
-```jsx filename="_app.js"
-import 'nextra-theme-docs/style.css'
-
-export default function Nextra({ Component, pageProps }) {
-  const getLayout = Component.getLayout || (page => page)
-  return getLayout(<Component {...pageProps} />)
-}
-```
-
-6. You are good to go! Run `yarn next` to start.
+5. You are good to go! Run `yarn next` to start.
 
 ---
 

--- a/examples/docs/src/pages/index.mdx
+++ b/examples/docs/src/pages/index.mdx
@@ -1,6 +1,6 @@
 import { Bleed } from 'nextra-theme-docs'
 
-# Nextra
+# Introduction
 
 **Nextra** is a [Next.js](https://nextjs.org) based static site generator.
 
@@ -8,4 +8,4 @@ It supports Markdown and React components ([MDX](/features/mdx)), automatically 
 
 Here's what you will get in 1 minute:
 
-<Bleed>![Nextra Example](../../public/demo.png)</Bleed>
+<Bleed>![Nextra Example](/demo.png)</Bleed>

--- a/examples/docs/src/pages/themes/docs/callout.mdx
+++ b/examples/docs/src/pages/themes/docs/callout.mdx
@@ -28,24 +28,24 @@ import { Callout } from 'nextra-theme-docs'
 
 ### Warning
 
-<Callout type="warning" emoji="⚠️">
+<Callout type="warning">
   This API will be deprecated soon.
 </Callout>
 
 ```mdx
-<Callout type="warning" emoji="⚠️">
+<Callout type="warning">
   This API will be deprecated soon.
 </Callout>
 ```
 
 ### Error
 
-<Callout type="error" emoji="🚫">
+<Callout type="error">
   This is a dangerous feature that can cause everything to explode.
 </Callout>
 
 ```mdx
-<Callout type="error" emoji="️🚫">
+<Callout type="error">
   This is a dangerous feature that can cause everything to explode.
 </Callout>
 ```
@@ -54,6 +54,7 @@ import { Callout } from 'nextra-theme-docs'
 
 ```jsx filename="callout.jsx"
 import { Callout } from 'nextra-theme-docs'
+
 const Component = () => {
   return (
     <Callout emoji="👾">

--- a/examples/docs/src/pages/themes/docs/configuration.mdx
+++ b/examples/docs/src/pages/themes/docs/configuration.mdx
@@ -1,7 +1,7 @@
 import { Callout } from 'nextra-theme-docs'
 
 export const Unstable = () => (
-  <Callout type="error" emoji="">
+  <Callout type="error">
     This is an unstable and experimental feature and not recommended for general
     use.
   </Callout>
@@ -41,25 +41,6 @@ The URL that the button in the top right will point to.
  */
 export default {
   projectLink: 'https://gitlab.com/librewolf-community/browser'
-}
-```
-
-## `github`
-
-The URL that the button in the top right will point to.
-
-**Type:** `string`
-
-**Default:** `https://github.com/shuding/nextra`
-
-**Example:**
-
-```js filename="theme.config.js"
-/**
- * @type {import('nextra-theme-docs').DocsThemeConfig}
- */
-export default {
-  github: 'https://gitlab.com/librewolf-community/browser'
 }
 ```
 

--- a/examples/docs/src/theme.config.js
+++ b/examples/docs/src/theme.config.js
@@ -1,3 +1,5 @@
+import { useConfig } from 'nextra-theme-docs'
+
 /* eslint sort-keys: error */
 /**
  * @type {import('nextra-theme-docs').DocsThemeConfig}
@@ -5,61 +7,69 @@
 export default {
   banner: {
     key: 'Nextra 2',
-    text: 'Nextra 2 Alpha',
+    text: 'Nextra 2 Alpha'
   },
-  docsRepositoryBase: 'https://github.com/shuding/nextra/blob/core/examples/docs',
+  chat: {
+    link: 'https://discord.gg/hEM84NMkRv' // Next.js discord server,
+  },
+  docsRepositoryBase:
+    'https://github.com/shuding/nextra/blob/core/examples/docs',
   editLink: {
     text: 'Edit this page on GitHub'
   },
-  head: () => (
-    <>
-      <meta name="msapplication-TileColor" content="#ffffff" />
-      <meta name="theme-color" content="#ffffff" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta httpEquiv="Content-Language" content="en" />
-      <meta name="description" content="Nextra: the Next.js site builder" />
-      <meta name="og:description" content="Nextra: the Next.js site builder" />
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:image" content="https://nextra.vercel.app/og.png" />
-      <meta name="twitter:site:domain" content="nextra.vercel.app" />
-      <meta name="twitter:url" content="https://nextra.vercel.app" />
-      <meta name="og:title" content="Nextra: Next.js static site generator" />
-      <meta name="og:image" content="https://nextra.vercel.app/og.png" />
-      <meta name="apple-mobile-web-app-title" content="Nextra" />
-      <link
-        rel="apple-touch-icon"
-        sizes="180x180"
-        href="/apple-icon-180x180.png"
-      />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="192x192"
-        href="/android-icon-192x192.png"
-      />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="/favicon-32x32.png"
-      />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="96x96"
-        href="/favicon-96x96.png"
-      />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="16x16"
-        href="/favicon-16x16.png"
-      />
-      <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
-    </>
-  ),
-  projectChat: {
-    link: 'https://discord.gg/hEM84NMkRv', // Next.js discord server,
+  getNextSeoProps() {
+    const { frontMatter } = useConfig()
+    return {
+      additionalLinkTags: [
+        {
+          href: '/apple-icon-180x180.png',
+          rel: 'apple-touch-icon',
+          sizes: '180x180'
+        },
+        {
+          href: '/android-icon-192x192.png',
+          rel: 'icon',
+          sizes: '192x192',
+          type: 'image/png'
+        },
+        {
+          href: '/favicon-96x96.png',
+          rel: 'icon',
+          sizes: '96x96',
+          type: 'image/png'
+        },
+        {
+          href: '/favicon-32x32.png',
+          rel: 'icon',
+          sizes: '32x32',
+          type: 'image/png'
+        },
+        {
+          href: '/favicon-16x16.png',
+          rel: 'icon',
+          sizes: '16x16',
+          type: 'image/png'
+        }
+      ],
+      additionalMetaTags: [
+        { content: 'en', httpEquiv: 'Content-Language' },
+        { content: 'Nextra', name: 'apple-mobile-web-app-title' },
+        { content: '#fff', name: 'msapplication-TileColor' },
+        { content: '/ms-icon-144x144.png', name: 'msapplication-TileImage' }
+      ],
+      description:
+        frontMatter.description || 'Nextra: the Next.js site builder',
+      openGraph: {
+        images: [
+          { url: frontMatter.image || 'https://nextra.vercel.app/og.png' }
+        ]
+      },
+      titleTemplate: '%s – Nextra',
+      twitter: {
+        cardType: 'summary_large_image',
+        site: 'https://nextra.vercel.app'
+      }
+    }
   },
-  unstable_faviconGlyph: '✦',
+  unstable_faviconGlyph: '✦'
 }

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -121,6 +121,12 @@ const config: DocsThemeConfig = {
       );
     },
   },
+  getNextSeoProps() {
+    const { locale } = useRouter();
+    return {
+      titleTemplate: `%s | SWR (${locale})`
+    }
+  },
   gitTimestamp: ({ timestamp }) => <>Last updated on {timestamp.toString()}</>,
   head() {
     const config = useConfig();
@@ -208,10 +214,6 @@ const config: DocsThemeConfig = {
       ) : (
         <>{title}</>
       ),
-  },
-  titleSuffix() {
-    const { locale } = useRouter();
-    return ` – SWR (${locale})`;
   },
   toc: {
     extraContent: <img src="https://placekitten.com/g/300/200" />,

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -53,6 +53,7 @@
     "github-slugger": "^1.4.0",
     "intersection-observer": "^0.12.2",
     "match-sorter": "^6.3.1",
+    "next-seo": "^5.5.0",
     "next-themes": "^0.2.0-beta.2",
     "parse-git-url": "^1.0.1",
     "scroll-into-view-if-needed": "^2.2.29"

--- a/packages/nextra-theme-docs/src/components/head.tsx
+++ b/packages/nextra-theme-docs/src/components/head.tsx
@@ -2,54 +2,62 @@ import React, { ReactElement } from 'react'
 import NextHead from 'next/head'
 import { useTheme } from 'next-themes'
 import { useMounted } from 'nextra/hooks'
-import { renderString } from '../utils'
 import { useConfig } from '../contexts'
+import { NextSeo, NextSeoProps } from 'next-seo'
 
 export function Head(): ReactElement {
   const config = useConfig()
   const { resolvedTheme } = useTheme()
   const mounted = useMounted()
 
-  // `head` can be either FC or ReactNode. We have to directly call it if it's a
+  // `head` can be either FC or ReactNode. We have to directly call it if it's an
   // FC because hooks like Next.js' `useRouter` aren't allowed inside NextHead.
   const head = typeof config.head === 'function' ? config.head({}) : config.head
   const hue = config.primaryHue
   const { dark: darkHue, light: lightHue } =
     typeof hue === 'number' ? { dark: hue, light: hue } : hue
+  const frontMatter = config.frontMatter as NextSeoProps
 
   return (
-    <NextHead>
-      <title>{config.title + renderString(config.titleSuffix)}</title>
-      {config.faviconGlyph ? (
-        <link
-          rel="icon"
-          href={`data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text x='50' y='.9em' font-size='90' text-anchor='middle'>${config.faviconGlyph}</text><style>text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";fill:black}@media(prefers-color-scheme:dark){text{fill:white}}</style></svg>`}
-        />
-      ) : null}
-      {mounted ? (
-        <meta
-          name="theme-color"
-          content={resolvedTheme === 'dark' ? '#111' : '#fff'}
-        />
-      ) : (
-        <>
-          <meta
-            name="theme-color"
-            content="#ffffff"
-            media="(prefers-color-scheme: light)"
-          />
-          <meta
-            name="theme-color"
-            content="#111111"
-            media="(prefers-color-scheme: dark)"
-          />
-        </>
-      )}
-      <meta
-        name="viewport"
-        content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    <>
+      <NextSeo
+        title={config.title}
+        description={frontMatter.description}
+        canonical={frontMatter.canonical}
+        openGraph={frontMatter.openGraph}
+        {...config.getNextSeoProps?.()}
       />
-      <style>{`
+      <NextHead>
+        {config.faviconGlyph ? (
+          <link
+            rel="icon"
+            href={`data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text x='50' y='.9em' font-size='90' text-anchor='middle'>${config.faviconGlyph}</text><style>text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";fill:black}@media(prefers-color-scheme:dark){text{fill:white}}</style></svg>`}
+          />
+        ) : null}
+        {mounted ? (
+          <meta
+            name="theme-color"
+            content={resolvedTheme === 'dark' ? '#111' : '#fff'}
+          />
+        ) : (
+          <>
+            <meta
+              name="theme-color"
+              content="#ffffff"
+              media="(prefers-color-scheme: light)"
+            />
+            <meta
+              name="theme-color"
+              content="#111111"
+              media="(prefers-color-scheme: dark)"
+            />
+          </>
+        )}
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+        />
+        <style>{`
         :root {
           --nextra-primary-hue: ${lightHue}deg;
           --nextra-navbar-height: 4rem;
@@ -61,7 +69,8 @@ export function Head(): ReactElement {
           --nextra-primary-hue: ${darkHue}deg;
         }
       `}</style>
-      {head}
-    </NextHead>
+        {head}
+      </NextHead>
+    </>
   )
 }

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -15,8 +15,7 @@ export const IS_BROWSER = typeof window !== 'undefined'
 export const DEFAULT_THEME: DocsThemeConfig = {
   banner: {
     dismissible: true,
-    key: 'nextra-banner',
-    text: ''
+    key: 'nextra-banner'
   },
   chat: {
     icon: (
@@ -24,10 +23,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         <DiscordIcon />
         <span className="sr-only">Discord</span>
       </>
-    ),
-    link: ''
+    )
   },
-  components: {},
   darkMode: true,
   direction: 'ltr',
   docsRepositoryBase: 'https://github.com/shuding/nextra',
@@ -45,11 +42,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     },
     text: 'Edit this page'
   },
-  faviconGlyph: '',
-  feedback: {
-    content: null,
-    labels: ''
-  },
+  feedback: {},
   footer: {
     component: Footer,
     text: `MIT ${new Date().getFullYear()} © Nextra.`
@@ -89,9 +82,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     </>
   ),
   logoLink: true,
-  main: {
-    extraContent: null
-  },
+  main: {},
   navbar: Navbar,
   navigation: {
     next: true,
@@ -115,9 +106,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         <GitHubIcon />
         <span className="sr-only">GitHub</span>
       </>
-    ),
-    // by default should be empty so clicking on project link will go to the github link
-    link: ''
+    )
   },
   search: {
     component({ className, directories }) {
@@ -135,8 +124,10 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     ),
     placeholder() {
       const { locale } = useRouter()
-      if (locale === 'zh-CN') return '搜索文档...'
-      return 'Search documentation...'
+      if (locale === 'zh-CN') return '搜索文档…'
+      if (locale === 'ru-RU') return 'Поиск документации…'
+      if (locale === 'fr-FR') return 'Rechercher de la documentation…'
+      return 'Search documentation…'
     }
   },
   serverSideError: {
@@ -147,10 +138,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     defaultMenuCollapsed: false,
     titleComponent: ({ title }) => <>{title}</>
   },
-  titleSuffix: ' – Nextra',
   toc: {
     component: TOC,
-    extraContent: null,
     float: true,
     title: 'On This Page'
   }

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -47,6 +47,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     component: Footer,
     text: `MIT ${new Date().getFullYear()} © Nextra.`
   },
+  getNextSeoProps: () => ({ titleTemplate: '%s – Nextra' }),
   gitTimestamp({ timestamp }) {
     const { locale = DEFAULT_LOCALE } = useRouter()
     return (

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -2,6 +2,7 @@
 import { FC, ReactNode } from 'react'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { PageOpts } from 'nextra'
+import { NextSeoProps } from 'next-seo'
 import { Item } from './utils'
 import { TOCProps } from './components/toc'
 import { NavBarProps } from './components/navbar'
@@ -20,13 +21,13 @@ export interface DocsThemeConfig {
   banner: {
     dismissible: boolean
     key: string
-    text: ReactNode | FC
+    text?: ReactNode | FC
   }
   chat: {
     icon: ReactNode | FC
-    link: string
+    link?: string
   }
-  components: Record<string, FC>
+  components?: Record<string, FC>
   darkMode: boolean
   direction: 'ltr' | 'rtl'
   docsRepositoryBase: string
@@ -38,22 +39,23 @@ export interface DocsThemeConfig {
     }>
     text: ReactNode | FC
   }
-  faviconGlyph: string
+  faviconGlyph?: string
   feedback: {
-    content: ReactNode | FC
-    labels: string
+    content?: ReactNode | FC
+    labels?: string
   }
   footer: {
     component: ReactNode | FC<{ menu: boolean }>
     text: ReactNode | FC
   }
+  getNextSeoProps?: () => NextSeoProps
   gitTimestamp: ReactNode | FC<{ timestamp: Date }>
   head: ReactNode | FC
   i18n: { direction?: string; locale: string; text: string }[]
   logo: ReactNode | FC
   logoLink?: boolean | string
   main: {
-    extraContent: ReactNode | FC
+    extraContent?: ReactNode | FC
   }
   navbar: ReactNode | FC<NavBarProps>
   navigation:
@@ -67,7 +69,7 @@ export interface DocsThemeConfig {
     'defaultTheme' | 'storageKey' | 'forcedTheme'
   >
   notFound: {
-    content: ReactNode | FC,
+    content: ReactNode | FC
     labels: string
   }
   primaryHue:
@@ -78,7 +80,7 @@ export interface DocsThemeConfig {
       }
   project: {
     icon: ReactNode | FC
-    link: string
+    link?: string
   }
   search: {
     component:
@@ -92,18 +94,16 @@ export interface DocsThemeConfig {
     placeholder: string | (() => string)
   }
   serverSideError: {
-    content: ReactNode | FC,
+    content: ReactNode | FC
     labels: string
   }
   sidebar: {
     defaultMenuCollapsed: boolean
     titleComponent: ReactNode | FC<{ title: string; type: string }>
   }
-  // Can't be React component, otherwise will get Warning: A title element received an array with more than 1 element as children.
-  titleSuffix: string | (() => string)
   toc: {
     component: ReactNode | FC<TOCProps>
-    extraContent: ReactNode | FC
+    extraContent?: ReactNode | FC
     float: boolean
     title: ReactNode | FC
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,7 @@ importers:
       lightningcss-cli: ^1.16.0
       match-sorter: ^6.3.1
       next: ^12.2.4
+      next-seo: ^5.5.0
       next-themes: ^0.2.0-beta.2
       nextra: workspace:*
       parse-git-url: ^1.0.1
@@ -262,6 +263,7 @@ importers:
       github-slugger: 1.4.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
+      next-seo: 5.8.0_c3hne4hwj64hb7tofigd3bvkji
       next-themes: 0.2.0_c3hne4hwj64hb7tofigd3bvkji
       parse-git-url: 1.0.1
       scroll-into-view-if-needed: 2.2.29
@@ -4302,6 +4304,18 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
+  /next-seo/5.8.0_c3hne4hwj64hb7tofigd3bvkji:
+    resolution: {integrity: sha512-V5W/JwqdoX6/0zG4S7m5g8zNajYffytWigkPo2hrbHhLD18yGFBU9607OPhvbI9zX3QjWQFMBSmlUY456xt9cA==}
+    peerDependencies:
+      next: ^8.1.1-canary.54 || >=9.0.0
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+    dependencies:
+      next: 12.3.0_biqbaboplfbrettd7655fr4n2y
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /next-themes/0.2.0_c3hne4hwj64hb7tofigd3bvkji:
     resolution: {integrity: sha512-myhpDL4vadBD9YDSHiewqvzorGzB03N84e+3LxCwHRlM/hiBOaW+UsKsQojQAzC7fdcJA0l2ppveXcYaVV+hxQ==}
     peerDependencies:
@@ -6302,7 +6316,7 @@ packages:
     resolution: {directory: packages/nextra-theme-blog, type: directory}
     id: file:packages/nextra-theme-blog
     name: nextra-theme-blog
-    version: 2.0.0-beta.30
+    version: 2.0.0-beta.32
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6323,7 +6337,7 @@ packages:
     resolution: {directory: packages/nextra-theme-docs, type: directory}
     id: file:packages/nextra-theme-docs
     name: nextra-theme-docs
-    version: 2.0.0-beta.30
+    version: 2.0.0-beta.32
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'
@@ -6340,6 +6354,7 @@ packages:
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
       next: 12.3.0_biqbaboplfbrettd7655fr4n2y
+      next-seo: 5.8.0_c3hne4hwj64hb7tofigd3bvkji
       next-themes: 0.2.0_c3hne4hwj64hb7tofigd3bvkji
       parse-git-url: 1.0.1
       react: 18.2.0
@@ -6351,7 +6366,7 @@ packages:
     resolution: {directory: packages/nextra, type: directory}
     id: file:packages/nextra
     name: nextra
-    version: 2.0.0-beta.30
+    version: 2.0.0-beta.32
     peerDependencies:
       next: '>=9.5.3'
       react: '>=16.13.1'


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/113
- setup `next-seo`
- add new theme option `getNextSeoProps`
- remove `titleSuffix` theme option in favor of `getNextSeoProps.titleTemplate`
- by default pass `description`, `canonical`, `openGraph` values to `<NextSeo />` component  from page `frontMatter`, values can be overridden with return value of `getNextSeoProps`