### PR TITLE
do not hide default logo on mobile

### DIFF
--- a/.changeset/thirty-suns-help.md
+++ b/.changeset/thirty-suns-help.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+do not hide default logo on mobile

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -81,8 +81,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   i18n: [],
   logo: (
     <>
-      <span className="mr-2 hidden font-extrabold md:inline">Nextra</span>
-      <span className="hidden font-normal text-gray-600 md:inline">
+      <span className="font-extrabold">Nextra</span>
+      <span className="ml-2 hidden font-normal text-gray-600 md:inline">
         The Next Docs Builder
       </span>
     </>


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/747

> site title is hidden in small viewport
![image](https://user-images.githubusercontent.com/7361780/195901261-47739ebe-5adb-456b-a576-d30dc88dea2f.png)
