### PR TITLE
feat(docs): support logoLink config option

### DIFF
--- a/.changeset/olive-otters-float.md
+++ b/.changeset/olive-otters-float.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+feat(docs): support logoLink config option

--- a/examples/docs/src/pages/themes/docs/configuration.mdx
+++ b/examples/docs/src/pages/themes/docs/configuration.mdx
@@ -355,6 +355,36 @@ export default {
 }
 ```
 
+## `logoLink`
+
+Enable automaticaly linking the logo to root, or provide a custom url.
+
+**Type:** `string` | `boolean`
+
+**Default:** `true` (links to `/` by default)
+
+**Example:**
+
+```js filename="theme.config.js"
+/**
+ * @type {import('nextra-theme-docs').DocsThemeConfig}
+ */
+export default {
+  logoLink: '/about'
+}
+```
+
+Or to disable the logo link:
+
+```js filename="theme.config.js"
+/**
+ * @type {import('nextra-theme-docs').DocsThemeConfig}
+ */
+export default {
+  logoLink: false
+}
+```
+
 ## `head`
 
 The head that should be inserted into the html document.

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -94,13 +94,18 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         )}
       />
       <nav className="mx-auto flex h-[var(--nextra-navbar-height)] max-w-[90rem] items-center justify-end gap-2 pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
-        <Anchor
-          href="/"
-          className="flex ltr:mr-auto rtl:ml-auto items-center hover:opacity-75"
-        >
-          {renderComponent(config.logo)}
-        </Anchor>
-
+        {config.logoLink ? (
+          <Anchor
+            href={typeof config.logoLink === 'string' ? config.logoLink : '/'}
+            className="flex ltr:mr-auto rtl:ml-auto items-center hover:opacity-75"
+          >
+            {renderComponent(config.logo)}
+          </Anchor>
+        ) : (
+          <div className="flex ltr:mr-auto rtl:ml-auto items-center">
+            {renderComponent(config.logo)}
+          </div>
+        )}
         {items.map(pageOrMenu => {
           if (pageOrMenu.hidden) return null
 

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -87,6 +87,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       </span>
     </>
   ),
+  logoLink: true,
   main: {
     extraContent: null
   },

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -50,6 +50,7 @@ export interface DocsThemeConfig {
   head: ReactNode | FC
   i18n: { direction?: string; locale: string; text: string }[]
   logo: ReactNode | FC
+  logoLink?: boolean | string
   main: {
     extraContent: ReactNode | FC
   }


### PR DESCRIPTION
Support a configuration option to disable the logo being linked to / by default. 

This also supports providing a custom route to link to from the logo if desired. 