### PR TITLE
allow adding additional navbar content via `navbar.extraContent`

### DIFF
--- a/.changeset/angry-balloons-end.md
+++ b/.changeset/angry-balloons-end.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+allow adding additional navbar content via `navbar.extraContent`

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -184,6 +184,8 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           </Anchor>
         ) : null}
 
+        {renderComponent(config.navbar.extraContent)}
+
         <button
           className="nextra-hamburger rounded active:bg-gray-400/20 p-2 -mr-2 md:hidden"
           onClick={() => setMenu(!menu)}

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -90,7 +90,10 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   main: {
     extraContent: null
   },
-  navbar: Navbar,
+  navbar: {
+    component: Navbar,
+    extraContent: null
+  },
   navigation: {
     next: true,
     prev: true

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -198,7 +198,7 @@ const InnerLayout = ({
       <Head />
       <Banner />
       {themeContext.navbar &&
-        renderComponent(config.navbar, {
+        renderComponent(config.navbar.component, {
           flatDirectories,
           items: topLevelNavbarItems
         })}

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -53,7 +53,10 @@ export interface DocsThemeConfig {
   main: {
     extraContent: ReactNode | FC
   }
-  navbar: ReactNode | FC<NavBarProps>
+  navbar: {
+    component: ReactNode | FC<NavBarProps>,
+    extraContent: ReactNode | FC
+  }
   navigation:
     | boolean
     | {


### PR DESCRIPTION
_tldr_: This PR introduces the ability to add additional content to the navbar in the theme config, analogously to `main.extraContent` or `toc.extraContent`.
<br>
We found the need for this functionality while migrating our existing documentation system to nextra at work. We require an additional login button—ideally in the navbar—for allowing certain clients to authenticate in order to access restricted content. While searching for a solution I stumbled upon #768, however this is not quite what I was looking for as we simply want to augment the navbar with one or two additional components, not rewrite it in it's entirety as its functionality actually suits are needs quite well (other than the aforementioned issue). As far as I could tell this is currently not possible.

I can imagine that this situation is not too uncommon / niche, as this already seems to have been raised before in #745.
