### PR TITLE
Add `nx-` tailwind prefix

### DIFF
--- a/.changeset/hot-rockets-sip.md
+++ b/.changeset/hot-rockets-sip.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+add nx- to all tailwind classes for style isolation

--- a/docs/components/table/index.tsx
+++ b/docs/components/table/index.tsx
@@ -1,27 +1,29 @@
 export function OptionTable({ options }: { options: [string, string, any] }) {
   return (
-    <div className="mt-6 mb-4 pb-4 overflow-x-auto overscroll-x-contain">
-      <table className="border-collapse w-full text-sm">
+    <div className="nx-mt-6 nx-mb-4 nx-pb-4 nx-overflow-x-auto nx-overscroll-x-contain">
+      <table className="nx-border-collapse nx-w-full nx-text-sm">
         <thead>
-          <tr className="border-b text-left py-4 dark:border-primary-100/10">
-            <th className="py-2 font-semibold">Option</th>
-            <th className="py-2 pl-6 font-semibold">Type</th>
-            <th className="py-2 pl-6 pr-6 font-semibold">Description</th>
+          <tr className="nx-border-b nx-text-left nx-py-4 dark:nx-border-primary-100/10">
+            <th className="nx-py-2 nx-font-semibold">Option</th>
+            <th className="nx-py-2 nx-pl-6 nx-font-semibold">Type</th>
+            <th className="nx-py-2 nx-pl-6 nx-pr-6 nx-font-semibold">
+              Description
+            </th>
           </tr>
         </thead>
-        <tbody className="text-gray-900 dark:text-gray-100 align-baseline">
+        <tbody className="nx-text-gray-900 dark:nx-text-gray-100 nx-align-baseline">
           {options.map(([option, type, description]) => (
             <tr
               key={option}
-              className="border-b border-gray-100 dark:border-zinc-800/50"
+              className="nx-border-b nx-border-gray-100 dark:nx-border-zinc-800/50"
             >
-              <td className="py-2 font-mono font-semibold text-xs leading-6 text-violet-600 whitespace-pre dark:text-violet-500">
+              <td className="nx-py-2 nx-font-mono nx-font-semibold nx-text-xs nx-leading-6 nx-text-violet-600 nx-whitespace-pre dark:nx-text-violet-500">
                 {option}
               </td>
-              <td className="py-2 pl-6 font-mono font-semibold text-xs leading-6 text-slate-500 whitespace-pre dark:text-slate-400">
+              <td className="nx-py-2 nx-pl-6 nx-font-mono nx-font-semibold nx-text-xs nx-leading-6 nx-text-slate-500 nx-whitespace-pre dark:nx-text-slate-400">
                 {type}
               </td>
-              <td className="py-2 pl-6">{description}</td>
+              <td className="nx-py-2 nx-pl-6">{description}</td>
             </tr>
           ))}
         </tbody>

--- a/examples/swr-site/components/authors.js
+++ b/examples/swr-site/components/authors.js
@@ -1,6 +1,6 @@
 export default function Authors({ date, children }) {
   return (
-    <div className="mt-8 mb-16 text-gray-400 text-sm">
+    <div className="nx-mt-8 nx-mb-16 nx-text-gray-400 nx-text-sm">
       {date} by {children}
     </div>
   );
@@ -8,12 +8,12 @@ export default function Authors({ date, children }) {
 
 export function Author({ name, link }) {
   return (
-    <span className="after:content-[','] last:after:content-['']">
+    <span className="after:nx-content-[','] last:after:nx-content-['']">
       <a
         key={name}
         href={link}
         target="_blank"
-        className="mx-1 text-gray-800 dark:text-gray-100"
+        className="nx-mx-1 nx-text-gray-800 dark:nx-text-gray-100"
       >
         {name}
       </a>

--- a/packages/nextra-theme-blog/src/constants.tsx
+++ b/packages/nextra-theme-blog/src/constants.tsx
@@ -4,9 +4,9 @@ import { NextraBlogTheme } from './types'
 
 export const DEFAULT_THEME: NextraBlogTheme = {
   footer: (
-    <small className="block mt-32">
+    <small className="nx-block nx-mt-32">
       CC BY-NC 4.0 {new Date().getFullYear()} © Shu Ding.
     </small>
   ),
-  readMore: 'Read More →',
+  readMore: 'Read More →'
 }

--- a/packages/nextra-theme-blog/src/mdx-theme.tsx
+++ b/packages/nextra-theme-blog/src/mdx-theme.tsx
@@ -37,7 +37,7 @@ const createHeaderLink =
     return (
       <Tag className={`subheading-${Tag}`} {...props}>
         {children}
-        <span className="absolute -mt-7" id={id} />
+        <span className="nx-absolute -nx-mt-7" id={id} />
         <a href={`#${id}`} className="subheading-anchor" />
       </Tag>
     )
@@ -70,7 +70,7 @@ const components = {
   h6: createHeaderLink('h6'),
   a: A,
   pre: ({ children, ...props }: ComponentProps<'pre'>) => (
-    <div className="not-prose">
+    <div className="nx-not-prose">
       <Pre {...props}>{children}</Pre>
     </div>
   ),
@@ -78,7 +78,7 @@ const components = {
   th: Th,
   td: Td,
   table: (props: ComponentProps<'table'>) => (
-    <Table className="not-prose" {...props} />
+    <Table className="nx-not-prose" {...props} />
   ),
   code: Code
 }

--- a/packages/nextra-theme-blog/src/meta.tsx
+++ b/packages/nextra-theme-blog/src/meta.tsx
@@ -15,19 +15,19 @@ export default function Meta(): ReactElement {
     <Link key={t} href="/tags/[tag]" as={`/tags/${t}`} passHref>
       <a
         className="
-          select-none
-          rounded-md
-          px-1
-          transition-colors
-          text-sm
-          text-gray-400
-          hover:text-gray-500
-          dark:text-gray-300
-          dark:hover:text-gray-200
-          bg-gray-200
-          hover:bg-gray-300
-          dark:bg-gray-600
-          dark:hover:bg-gray-700
+          nx-select-none
+          nx-rounded-md
+          nx-px-1
+          nx-transition-colors
+          nx-text-sm
+          nx-text-gray-400
+          hover:nx-text-gray-500
+          dark:nx-text-gray-300
+          dark:hover:nx-text-gray-200
+          nx-bg-gray-200
+          hover:nx-bg-gray-300
+          dark:nx-bg-gray-600
+          dark:hover:nx-bg-gray-700
         "
       >
         {t}
@@ -40,11 +40,12 @@ export default function Meta(): ReactElement {
   return (
     <div
       className={
-        'mb-8 flex gap-3 ' + (readingTime ? 'items-start' : 'items-center')
+        'nx-mb-8 nx-flex nx-gap-3 ' +
+        (readingTime ? 'nx-items-start' : 'nx-items-center')
       }
     >
-      <div className="grow text-gray-400">
-        <div className="flex flex-wrap items-center gap-1 not-prose">
+      <div className="nx-grow nx-text-gray-400">
+        <div className="nx-flex nx-flex-wrap nx-items-center nx-gap-1 nx-not-prose">
           {author}
           {author && date && ','}
           {date && (
@@ -56,10 +57,12 @@ export default function Meta(): ReactElement {
           {readingTime || tagsEl}
         </div>
         {readingTime && (
-          <div className="flex flex-wrap items-center gap-1 mt-1 not-prose">{tagsEl}</div>
+          <div className="nx-flex nx-flex-wrap nx-items-center nx-gap-1 nx-mt-1 nx-not-prose">
+            {tagsEl}
+          </div>
         )}
       </div>
-      <div className="flex items-center gap-3">
+      <div className="nx-flex nx-items-center nx-gap-3">
         {back && (
           <Link href={back} passHref>
             <a>Back</a>

--- a/packages/nextra-theme-blog/src/nav.tsx
+++ b/packages/nextra-theme-blog/src/nav.tsx
@@ -8,12 +8,15 @@ export default function Nav(): ReactElement {
   const { opts, config } = useBlogContext()
   const { navPages } = collectPostsAndNavs({ opts, config })
   return (
-    <div className="mb-8 flex items-center gap-3">
-      <div className="flex grow flex-wrap items-center justify-end gap-3">
+    <div className="nx-mb-8 nx-flex nx-items-center nx-gap-3">
+      <div className="nx-flex grow nx-flex-wrap nx-items-center nx-justify-end nx-gap-3">
         {navPages.map(page => {
           if (page.active) {
             return (
-              <span key={page.route} className="cursor-default text-gray-400">
+              <span
+                key={page.route}
+                className="nx-cursor-default nx-text-gray-400"
+              >
                 {page.frontMatter?.title || page.name}
               </span>
             )

--- a/packages/nextra-theme-blog/src/styles.css
+++ b/packages/nextra-theme-blog/src/styles.css
@@ -6,15 +6,15 @@
 @import 'nextra/styles/subheading-anchor.css';
 
 body {
-  @apply px-4;
+  @apply nx-px-4;
 }
 
 article {
-  @apply mx-auto block pt-20 pb-32;
+  @apply nx-mx-auto nx-block nx-pt-20 nx-pb-32;
 }
 
 article img {
-  @apply mx-auto;
+  @apply nx-mx-auto;
 }
 
 h1 {
@@ -24,9 +24,9 @@ h1 {
 .prose code {
   &:before,
   &:after {
-    @apply hidden;
+    @apply nx-hidden;
   }
   .line {
-    @apply font-normal;
+    @apply nx-font-normal;
   }
 }

--- a/packages/nextra-theme-blog/tailwind.config.js
+++ b/packages/nextra-theme-blog/tailwind.config.js
@@ -1,5 +1,7 @@
 const colors = require('tailwindcss/colors')
+
 module.exports = {
+  prefix: 'nx-',
   content: ['./src/**/*.{js,tsx,jsx}', '../nextra/src/components/*.tsx'],
   theme: {
     colors: {
@@ -55,5 +57,5 @@ module.exports = {
     }
   },
   plugins: [require('@tailwindcss/typography')],
-  darkMode: 'class'
+  darkMode: ['class', 'html[class~="dark"]']
 }

--- a/packages/nextra-theme-docs/css/hamburger.css
+++ b/packages/nextra-theme-docs/css/hamburger.css
@@ -1,34 +1,36 @@
 .nextra-hamburger svg {
   g {
-    @apply origin-center;
-    transition: transform 0.2s cubic-bezier(.25, 1, .5, 1);
+    @apply nx-origin-center;
+    transition: transform 0.2s cubic-bezier(0.25, 1, 0.5, 1);
   }
   path {
     opacity: 1;
-    transition: transform 0.2s cubic-bezier(.25, 1, .5, 1) 0.2s, opacity .2s ease .2s;
+    transition: transform 0.2s cubic-bezier(0.25, 1, 0.5, 1) 0.2s,
+      opacity 0.2s ease 0.2s;
   }
 
   &.open {
     path {
-      transition: transform 0.2s cubic-bezier(.25, 1, .5, 1), opacity 0s ease .2s;
+      transition: transform 0.2s cubic-bezier(0.25, 1, 0.5, 1),
+        opacity 0s ease 0.2s;
     }
     g {
-      transition: transform 0.2s cubic-bezier(.25, 1, .5, 1) .2s;
+      transition: transform 0.2s cubic-bezier(0.25, 1, 0.5, 1) 0.2s;
     }
   }
 
   &.open > {
     path {
-      @apply opacity-0
+      @apply nx-opacity-0;
     }
     g:nth-of-type(1) {
-      @apply rotate-45;
+      @apply nx-rotate-45;
       path {
         transform: translate3d(0, 6px, 0);
       }
     }
     g:nth-of-type(2) {
-      @apply -rotate-45;
+      @apply -nx-rotate-45;
       path {
         transform: translate3d(0, -6px, 0);
       }

--- a/packages/nextra-theme-docs/css/scrollbar.css
+++ b/packages/nextra-theme-docs/css/scrollbar.css
@@ -1,20 +1,20 @@
 .nextra-scrollbar {
   scrollbar-width: thin; /* Firefox */
   scrollbar-color: rgba(115, 115, 115, 0.4) transparent; /* Firefox */
-  
+
   scrollbar-gutter: stable;
   &::-webkit-scrollbar {
-    @apply w-1.5 h-1.5;
+    @apply nx-w-1.5 nx-h-1.5;
   }
   &::-webkit-scrollbar-track {
-    @apply bg-transparent;
+    @apply nx-bg-transparent;
   }
   &::-webkit-scrollbar-thumb {
-    @apply rounded-[20px];
+    @apply nx-rounded-[20px];
   }
   &:hover::-webkit-scrollbar-thumb {
-    @apply shadow-[inset_0_0_0_5px_var(--tw-shadow-color)];
-    @apply shadow-neutral-500/20 hover:shadow-neutral-500/40;
+    @apply nx-shadow-[inset_0_0_0_5px_var(--tw-shadow-color)];
+    @apply nx-shadow-neutral-500/20 hover:nx-shadow-neutral-500/40;
   }
 
   @media (max-width: 767px) {
@@ -30,6 +30,6 @@
   -ms-overflow-style: none; /* IE and Edge */
 
   &::-webkit-scrollbar {
-    @apply hidden; /* Chrome, Safari and Opera */
+    @apply nx-hidden; /* Chrome, Safari and Opera */
   }
 }

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -9,13 +9,13 @@
 @import './typesetting-article.css';
 
 html {
-  @apply antialiased text-base;
+  @apply nx-antialiased nx-text-base;
   font-feature-settings: 'rlig' 1, 'calt' 1, 'ss01' 1, 'ss06' 1;
   -webkit-tap-highlight-color: transparent;
 }
 
 body {
-  @apply w-full bg-white dark:bg-dark dark:text-gray-100;
+  @apply nx-w-full nx-bg-white dark:nx-bg-dark dark:nx-text-gray-100;
 }
 
 a,
@@ -23,42 +23,43 @@ summary,
 button,
 input,
 [tabindex]:not([tabindex='-1']) {
-  @apply outline-none;
+  @apply nx-outline-none;
   &:focus-visible {
-    @apply ring-2 ring-primary-200 ring-offset-1 ring-offset-primary-300;
+    @apply nx-ring-2 nx-ring-primary-200 nx-ring-offset-1 nx-ring-offset-primary-300;
   }
 }
 
-a, summary {
-  @apply rounded;
+a,
+summary {
+  @apply nx-rounded;
 }
 
 @media (max-width: 767px) {
   .nextra-sidebar-container {
-    @apply fixed pt-[calc(var(--nextra-navbar-height))] top-0 w-full bottom-24 z-[15] overscroll-contain bg-white dark:bg-dark;
-    transition: transform .8s cubic-bezier(.52, .16, .04, 1);
+    @apply nx-fixed nx-pt-[calc(var(--nextra-navbar-height))] nx-top-0 nx-w-full nx-bottom-24 nx-z-[15] nx-overscroll-contain nx-bg-white dark:nx-bg-dark;
+    transition: transform 0.8s cubic-bezier(0.52, 0.16, 0.04, 1);
     will-change: transform, opacity;
     contain: layout style;
     backface-visibility: hidden;
   }
   .nextra-banner-container ~ div {
     .nextra-sidebar-container {
-      @apply pt-[6.5rem];
+      @apply nx-pt-[6.5rem];
     }
     &.nextra-nav-container {
-      @apply top-10 md:top-0;
+      @apply nx-top-10 md:nx-top-0;
     }
   }
   .nextra-banner-hidden {
     .nextra-banner-container ~ div .nextra-sidebar-container {
-      @apply pt-16;
+      @apply nx-pt-16;
     }
     .nextra-nav-container {
-      @apply !top-0;
+      @apply !nx-top-0;
     }
   }
   .nextra-search .excerpt {
-    @apply overflow-hidden text-ellipsis;
+    @apply nx-overflow-hidden nx-text-ellipsis;
     display: -webkit-box;
     line-clamp: 1;
     -webkit-line-clamp: 1;
@@ -71,14 +72,14 @@ a, summary {
   .nextra-sidebar-container,
   .nextra-sidebar-container.open,
   body.resizing .nextra-sidebar-container {
-    @apply transition-none;
+    @apply nx-transition-none;
   }
 }
 
 /* Content Typography */
 article details > summary {
   &::-webkit-details-marker {
-    @apply hidden;
+    @apply nx-hidden;
   }
   &::before {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z' clip-rule='evenodd' /%3E%3C/svg%3E");
@@ -92,7 +93,7 @@ article details > summary {
   .nextra-toc > .div,
   .nextra-sidebar-container {
     mask-image: linear-gradient(to bottom, transparent, #000 20px),
-    linear-gradient(to left, #000 10px, transparent 10px);
+      linear-gradient(to left, #000 10px, transparent 10px);
   }
 }
 
@@ -100,10 +101,10 @@ article details > summary {
   (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
 ) {
   .nextra-search ul {
-    @apply backdrop-blur-lg bg-white/70 dark:bg-dark/80;
+    @apply nx-backdrop-blur-lg nx-bg-white/70 dark:nx-bg-dark/80;
   }
   .nextra-nav-container-blur {
-    @apply backdrop-blur-md bg-white/[.85] dark:!bg-dark/80;
+    @apply nx-backdrop-blur-md nx-bg-white/[.85] dark:!nx-bg-dark/80;
   }
 }
 
@@ -117,12 +118,12 @@ input[type='search'] {
 }
 
 .contains-task-list {
-  @apply ml-0 list-none;
+  @apply nx-ml-0 nx-list-none;
   input[type='checkbox'] {
-    @apply mr-1;
+    @apply nx-mr-1;
   }
 }
 
 .nextra-banner-hidden .nextra-banner-container {
-  @apply hidden;
+  @apply nx-hidden;
 }

--- a/packages/nextra-theme-docs/css/typesetting-article.css
+++ b/packages/nextra-theme-docs/css/typesetting-article.css
@@ -2,25 +2,25 @@ article.nextra-body-typesetting-article {
   font-size: 17px;
   font-feature-settings: 'rlig' 1, 'calt' 1;
   h1 {
-    @apply mt-6 mb-4 text-center;
+    @apply nx-mt-6 nx-mb-4 nx-text-center;
     font-size: 2.5rem;
   }
   h2 {
-    @apply border-none;
+    @apply nx-border-none;
   }
   a {
-    @apply no-underline hover:underline;
+    @apply nx-no-underline hover:nx-underline;
   }
   p {
-    @apply leading-8;
+    @apply nx-leading-8;
   }
   code {
-    @apply border-none dark:bg-neutral-700;
+    @apply nx-border-none dark:nx-bg-neutral-700;
   }
   pre code {
-    @apply dark:bg-transparent;
+    @apply dark:nx-bg-transparent;
   }
   .subheading-anchor + a {
-    @apply no-underline hover:no-underline after:hidden;
+    @apply nx-no-underline hover:nx-no-underline after:nx-hidden;
   }
 }

--- a/packages/nextra-theme-docs/src/components/banner.tsx
+++ b/packages/nextra-theme-docs/src/components/banner.tsx
@@ -18,19 +18,19 @@ export function Banner(): ReactElement | null {
       <script dangerouslySetInnerHTML={{ __html: hideBannerScript }} />
       <div
         className={cn(
-          'relative z-20 flex justify-center items-center',
-          'bg-neutral-900 text-sm text-slate-50 font-medium',
-          'h-[var(--nextra-banner-height)] [body.nextra-banner-hidden_&]:hidden',
-          'dark:bg-[linear-gradient(1deg,#383838,#212121)] dark:text-white',
-          'py-1 pl-[max(env(safe-area-inset-left),2.5rem)] pr-[max(env(safe-area-inset-right),2.5rem)]'
+          'nx-relative nx-z-20 nx-flex nx-justify-center nx-items-center',
+          'nx-bg-neutral-900 nx-text-sm nx-text-slate-50 nx-font-medium',
+          'nx-h-[var(--nextra-banner-height)] [body.nextra-banner-hidden_&]:nx-hidden',
+          'dark:nx-bg-[linear-gradient(1deg,#383838,#212121)] dark:nx-text-white',
+          'nx-py-1 nx-pl-[max(env(safe-area-inset-left),2.5rem)] nx-pr-[max(env(safe-area-inset-right),2.5rem)]'
         )}
       >
-        <div className="max-w-[90rem] truncate">
+        <div className="nx-max-w-[90rem] nx-truncate">
           {renderComponent(banner.text)}
         </div>
         {banner.dismissible && (
           <button
-            className="opacity-80 absolute ltr:right-0 rtl:left-0 hover:opacity-100"
+            className="nx-opacity-80 nx-absolute ltr:nx-right-0 rtl:nx-left-0 hover:nx-opacity-100"
             onClick={() => {
               try {
                 localStorage.setItem(banner.key, '0')
@@ -38,7 +38,7 @@ export function Banner(): ReactElement | null {
               document.body.classList.add('nextra-banner-hidden')
             }}
           >
-            <XIcon className="h4 w-4 mx-4" />
+            <XIcon className="nx-h4 nx-w-4 nx-mx-4" />
           </button>
         )}
       </div>

--- a/packages/nextra-theme-docs/src/components/bleed.tsx
+++ b/packages/nextra-theme-docs/src/components/bleed.tsx
@@ -11,11 +11,11 @@ export function Bleed({
   return (
     <div
       className={cn(
-        'bleed relative -mx-6 mt-6 md:-mx-8 2xl:-mx-24',
+        'bleed nx-relative -nx-mx-6 nx-mt-6 md:-nx-mx-8 2xl:-nx-mx-24',
         full && [
-          'md:mx:[calc(-50vw+50%+8rem)',
-          'ltr:xl:ml-[calc(50%-50vw+16rem)] ltr:xl:mr-[calc(50%-50vw)]',
-          'rtl:xl:ml-[calc(50%-50vw)] rtl:xl:mr-[calc(50%-50vw+16rem)]'
+          // 'md:mx:[calc(-50vw+50%+8rem)',
+          'ltr:xl:nx-ml-[calc(50%-50vw+16rem)] ltr:xl:nx-mr-[calc(50%-50vw)]',
+          'rtl:xl:nx-ml-[calc(50%-50vw)] rtl:xl:nx-mr-[calc(50%-50vw+16rem)]'
         ]
       )}
     >

--- a/packages/nextra-theme-docs/src/components/breadcrumb.tsx
+++ b/packages/nextra-theme-docs/src/components/breadcrumb.tsx
@@ -10,22 +10,23 @@ export function Breadcrumb({
   activePath: Item[]
 }): ReactElement {
   return (
-    <ul className="nextra-breadcrumb mt-2.5 flex items-center gap-1 overflow-hidden text-sm text-gray-500 contrast-more:text-current">
+    <ul className="nextra-breadcrumb nx-mt-2.5 nx-flex nx-items-center nx-gap-1 nx-overflow-hidden nx-text-sm nx-text-gray-500 contrast-more:nx-text-current">
       {activePath.map((item, index) => {
         const isLink = !item.children || item.withIndexPage
         const isActive = index === activePath.length - 1
 
         return (
           <React.Fragment key={item.route + item.name}>
-            {index > 0 && <ArrowRightIcon className="w-3.5 shrink-0" />}
+            {index > 0 && <ArrowRightIcon className="nx-w-3.5 nx-shrink-0" />}
             <li
               className={cn(
-                'transition-colors whitespace-nowrap',
+                'nx-transition-colors nx-whitespace-nowrap',
                 isActive
-                  ? 'text-gray-700 dark:text-gray-400 font-medium contrast-more:font-bold contrast-more:text-current contrast-more:dark:text-current'
+                  ? 'nx-text-gray-700 dark:nx-text-gray-400 nx-font-medium contrast-more:nx-font-bold contrast-more:nx-text-current contrast-more:dark:nx-text-current'
                   : [
-                      'min-w-[24px] overflow-hidden text-ellipsis',
-                      isLink && 'hover:text-gray-900 dark:hover:text-gray-200'
+                      'nx-min-w-[24px] nx-overflow-hidden nx-text-ellipsis',
+                      isLink &&
+                        'hover:nx-text-gray-900 dark:hover:nx-text-gray-200'
                     ]
               )}
               title={item.title}

--- a/packages/nextra-theme-docs/src/components/callout.tsx
+++ b/packages/nextra-theme-docs/src/components/callout.tsx
@@ -5,7 +5,7 @@ import { InformationCircleIcon } from 'nextra/icons'
 const TypeToEmoji = {
   default: '💡',
   error: '🚫',
-  info: <InformationCircleIcon className="mt-1" />,
+  info: <InformationCircleIcon className="nx-mt-1" />,
   warning: '⚠️'
 }
 
@@ -13,12 +13,12 @@ type CalloutType = keyof typeof TypeToEmoji
 
 const themes: Record<CalloutType, string> = {
   default:
-    'bg-orange-50 border-orange-100 text-orange-800 dark:text-orange-300 dark:bg-orange-400/20 dark:border-orange-400/30',
+    'nx-bg-orange-50 nx-border-orange-100 nx-text-orange-800 dark:nx-text-orange-300 dark:nx-bg-orange-400/20 dark:nx-border-orange-400/30',
   error:
-    'bg-red-100 border-red-200 text-red-900 dark:text-red-200 dark:bg-red-900/30 dark:border-red-200/30',
-  info: 'bg-blue-100 border-blue-200 text-blue-900 dark:text-blue-200 dark:bg-blue-900/30 dark:border-blue-200/30',
+    'nx-bg-red-100 nx-border-red-200 nx-text-red-900 dark:nx-text-red-200 dark:nx-bg-red-900/30 dark:nx-border-red-200/30',
+  info: 'nx-bg-blue-100 nx-border-blue-200 nx-text-blue-900 dark:nx-text-blue-200 dark:nx-bg-blue-900/30 dark:nx-border-blue-200/30',
   warning:
-    'bg-yellow-50 border-yellow-100 text-yellow-900 dark:text-yellow-200 dark:bg-yellow-700/30'
+    'nx-bg-yellow-50 nx-border-yellow-100 nx-text-yellow-900 dark:nx-text-yellow-200 dark:nx-bg-yellow-700/30'
 }
 
 type CalloutProps = {
@@ -35,20 +35,20 @@ export function Callout({
   return (
     <div
       className={cn(
-        'nextra-callout border mt-6 flex rounded-lg py-2 ltr:pr-4 rtl:pl-4',
-        'contrast-more:border-current contrast-more:dark:border-current',
+        'nextra-callout nx-border nx-mt-6 nx-flex nx-rounded-lg nx-py-2 ltr:nx-pr-4 rtl:nx-pl-4',
+        'contrast-more:nx-border-current contrast-more:dark:nx-border-current',
         themes[type]
       )}
     >
       <div
-        className="select-none text-xl ltr:pl-3 ltr:pr-2 rtl:pr-3 rtl:pl-2"
+        className="nx-select-none nx-text-xl ltr:nx-pl-3 ltr:nx-pr-2 rtl:nx-pr-3 rtl:nx-pl-2"
         style={{
           fontFamily: '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'
         }}
       >
         {emoji}
       </div>
-      <div className="min-w-0">{children}</div>
+      <div className="nx-min-w-0">{children}</div>
     </div>
   )
 }

--- a/packages/nextra-theme-docs/src/components/collapse.tsx
+++ b/packages/nextra-theme-docs/src/components/collapse.tsx
@@ -28,14 +28,14 @@ export function Collapse({
       if (container && inner) {
         const contentHeight = innerRef.current.clientHeight
         container.style.maxHeight = contentHeight + 'px'
-        container.classList.remove('duration-500')
-        container.classList.add('duration-300')
+        container.classList.remove('nx-duration-500')
+        container.classList.add('nx-duration-300')
 
         inner.style.opacity = '1'
         animationRef.current = setTimeout(() => {
           const container = containerRef.current
           if (container) {
-            container.style.removeProperty('max-height')
+            container.style.removeProperty('nx-max-height')
           }
         }, 300)
       }
@@ -45,8 +45,8 @@ export function Collapse({
       if (container && inner) {
         const contentHeight = innerRef.current.clientHeight
         container.style.maxHeight = contentHeight + 'px'
-        container.classList.remove('duration-300')
-        container.classList.add('duration-500')
+        container.classList.remove('nx-duration-300')
+        container.classList.add('nx-duration-500')
 
         inner.style.opacity = '0'
         setTimeout(() => {
@@ -66,7 +66,7 @@ export function Collapse({
   return (
     <div
       ref={containerRef}
-      className="transform-gpu overflow-hidden transition-all duration-300 ease-in-out motion-reduce:transition-none"
+      className="nx-transform-gpu nx-overflow-hidden nx-transition-all nx-duration-300 nx-ease-in-out motion-reduce:nx-transition-none"
       style={{
         maxHeight: initialState.current ? undefined : 0
       }}
@@ -74,7 +74,7 @@ export function Collapse({
       <div
         ref={innerRef}
         className={cn(
-          'p-2 transform-gpu overflow-hidden transition-opacity duration-500 ease-in-out motion-reduce:transition-none',
+          'nx-p-2 nx-transform-gpu nx-overflow-hidden nx-transition-opacity nx-duration-500 nx-ease-in-out motion-reduce:nx-transition-none',
           className
         )}
         style={{

--- a/packages/nextra-theme-docs/src/components/flexsearch.tsx
+++ b/packages/nextra-theme-docs/src/components/flexsearch.tsx
@@ -202,8 +202,8 @@ export function Flexsearch({
           prefix: isFirstItemOfPage && (
             <div
               className={cn(
-                'border-b border-black/10 dark:border-white/20 mx-2.5 mb-2 mt-6 select-none px-2.5 pb-1.5 text-xs font-semibold uppercase text-gray-500 first:mt-0 dark:text-gray-300',
-                'contrast-more:border-gray-600 contrast-more:text-gray-900 contrast-more:dark:border-gray-50 contrast-more:dark:text-gray-50'
+                'nx-border-b nx-border-black/10 dark:nx-border-white/20 nx-mx-2.5 nx-mb-2 nx-mt-6 nx-select-none nx-px-2.5 nx-pb-1.5 nx-text-xs nx-font-semibold nx-uppercase nx-text-gray-500 first:nx-mt-0 dark:nx-text-gray-300',
+                'contrast-more:nx-border-gray-600 contrast-more:nx-text-gray-900 contrast-more:dark:nx-border-gray-50 contrast-more:dark:nx-text-gray-50'
               )}
             >
               {result.doc.title}
@@ -211,11 +211,11 @@ export function Flexsearch({
           ),
           children: (
             <>
-              <div className="font-semibold leading-5 text-base">
+              <div className="nx-font-semibold nx-leading-5 nx-text-base">
                 <HighlightMatches match={search} value={title} />
               </div>
               {content && (
-                <div className="excerpt mt-1 text-sm leading-[1.35rem] text-gray-600 dark:text-gray-400 contrast-more:dark:text-gray-50">
+                <div className="excerpt nx-mt-1 nx-text-sm nx-leading-[1.35rem] nx-text-gray-600 dark:nx-text-gray-400 contrast-more:dark:nx-text-gray-50">
                   <HighlightMatches match={search} value={content} />
                 </div>
               )}
@@ -278,7 +278,7 @@ export function Flexsearch({
       onChange={handleChange}
       onActive={preload}
       className={className}
-      overlayClassName="w-screen min-h-[100px] max-w-[min(calc(100vw-2rem),calc(100%+20rem))]"
+      overlayClassName="nx-w-screen nx-min-h-[100px] nx-max-w-[min(calc(100vw-2rem),calc(100%+20rem))]"
       results={results}
     />
   )

--- a/packages/nextra-theme-docs/src/components/footer.tsx
+++ b/packages/nextra-theme-docs/src/components/footer.tsx
@@ -8,21 +8,21 @@ import { renderComponent } from '../utils'
 export function Footer({ menu }: { menu?: boolean }): ReactElement {
   const config = useConfig()
   return (
-    <footer className="bg-gray-100 pb-[env(safe-area-inset-bottom)] dark:bg-neutral-900">
+    <footer className="nx-bg-gray-100 nx-pb-[env(safe-area-inset-bottom)] dark:nx-bg-neutral-900">
       <div
         className={cn(
-          'mx-auto max-w-[90rem] py-2 px-4 flex gap-2',
-          menu ? 'flex' : 'hidden'
+          'nx-mx-auto nx-max-w-[90rem] nx-py-2 nx-px-4 nx-flex nx-gap-2',
+          menu ? 'nx-flex' : 'nx-hidden'
         )}
       >
         {config.i18n.length > 0 && <LocaleSwitch options={config.i18n} />}
         {config.darkMode && <ThemeSwitch />}
       </div>
-      <hr className="dark:border-neutral-800" />
+      <hr className="dark:nx-border-neutral-800" />
       <div
         className={cn(
-          'mx-auto max-w-[90rem] py-12 flex justify-center md:justify-start text-gray-600 dark:text-gray-400',
-          'pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]'
+          'nx-mx-auto nx-max-w-[90rem] nx-py-12 nx-flex nx-justify-center md:nx-justify-start nx-text-gray-600 dark:nx-text-gray-400',
+          'nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]'
         )}
       >
         {renderComponent(config.footer.text)}

--- a/packages/nextra-theme-docs/src/components/highlight-matches.tsx
+++ b/packages/nextra-theme-docs/src/components/highlight-matches.tsx
@@ -5,7 +5,10 @@ type MatchArgs = {
   match: string
 }
 
-export const HighlightMatches = memo<MatchArgs>(function HighlightMatches({ value, match }: MatchArgs) {
+export const HighlightMatches = memo<MatchArgs>(function HighlightMatches({
+  value,
+  match
+}: MatchArgs) {
   const splitText = value ? value.split('') : []
   const escapedSearch = match.trim().replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
   const regexp = RegExp('(' + escapedSearch.replaceAll(' ', '|') + ')', 'ig')
@@ -19,7 +22,7 @@ export const HighlightMatches = memo<MatchArgs>(function HighlightMatches({ valu
       res.push(
         <Fragment key={id++}>
           {splitText.splice(0, result.index - index).join('')}
-          <span className="text-primary-500">
+          <span className="nx-text-primary-500">
             {splitText.splice(0, regexp.lastIndex - result.index).join('')}
           </span>
         </Fragment>

--- a/packages/nextra-theme-docs/src/components/input.tsx
+++ b/packages/nextra-theme-docs/src/components/input.tsx
@@ -5,18 +5,18 @@ type InputProps = ComponentProps<'input'> & { suffix?: ReactNode }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, suffix, ...props }, forwardedRef) => (
-    <div className="relative flex items-center text-gray-900 dark:text-gray-300 contrast-more:text-gray-800 contrast-more:dark:text-gray-300">
+    <div className="nx-relative nx-flex nx-items-center nx-text-gray-900 dark:nx-text-gray-300 contrast-more:nx-text-gray-800 contrast-more:dark:nx-text-gray-300">
       <input
         ref={forwardedRef}
         spellCheck={false}
         className={cn(
           className,
-          'block w-full appearance-none rounded-lg px-3 py-2 transition-colors',
-          'md:text-sm text-base leading-tight',
-          'bg-black/[.03] dark:bg-gray-50/10',
-          'focus:bg-white dark:focus:bg-dark',
-          'placeholder:text-gray-400 dark:placeholder:text-gray-500',
-          'contrast-more:border contrast-more:border-current'
+          'nx-block nx-w-full nx-appearance-none nx-rounded-lg nx-px-3 nx-py-2 nx-transition-colors',
+          'md:nx-text-sm nx-text-base nx-leading-tight',
+          'nx-bg-black/[.03] dark:nx-bg-gray-50/10',
+          'focus:nx-bg-white dark:focus:nx-bg-dark',
+          'placeholder:nx-text-gray-400 dark:placeholder:nx-text-gray-500',
+          'contrast-more:nx-border contrast-more:nx-border-current'
         )}
         {...props}
       />

--- a/packages/nextra-theme-docs/src/components/locale-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/locale-switch.tsx
@@ -31,9 +31,9 @@ export function LocaleSwitch({
       selected={{
         key: selected?.locale || '',
         name: (
-          <div className="flex items-center gap-2">
+          <div className="nx-flex nx-items-center nx-gap-2">
             <GlobeIcon />
-            <span className={lite ? 'hidden' : ''}>{selected?.text}</span>
+            <span className={lite ? 'nx-hidden' : ''}>{selected?.text}</span>
           </div>
         )
       }}

--- a/packages/nextra-theme-docs/src/components/match-sorter-search.tsx
+++ b/packages/nextra-theme-docs/src/components/match-sorter-search.tsx
@@ -35,7 +35,7 @@ export function MatchSorterSearch({
       value={search}
       onChange={setSearch}
       className={className}
-      overlayClassName="w-full"
+      overlayClassName="nx-w-full"
       results={results}
     />
   )

--- a/packages/nextra-theme-docs/src/components/nav-links.tsx
+++ b/packages/nextra-theme-docs/src/components/nav-links.tsx
@@ -12,8 +12,8 @@ interface NavLinkProps {
 }
 
 const classes = {
-  link: 'max-w-[50%] gap-1 [word-break:break-word] flex items-center py-4 text-base font-medium text-gray-600 transition-colors hover:text-primary-500 dark:text-gray-300 md:text-lg',
-  icon: 'h-5 inline flex-shrink-0'
+  link: 'nx-max-w-[50%] nx-gap-1 [word-break:break-word] nx-flex nx-items-center nx-py-4 nx-text-base nx-font-medium nx-text-gray-600 nx-transition-colors hover:nx-text-primary-500 dark:nx-text-gray-300 md:nx-text-lg',
+  icon: 'nx-h-5 nx-inline nx-flex-shrink-0'
 }
 
 export const NavLinks = ({
@@ -32,17 +32,17 @@ export const NavLinks = ({
   return (
     <div
       className={cn(
-        'mb-8 flex items-center border-t pt-8 dark:border-neutral-800',
-        'contrast-more:border-neutral-400 dark:contrast-more:border-neutral-400'
+        'nx-mb-8 nx-flex nx-items-center nx-border-t nx-pt-8 dark:nx-border-neutral-800',
+        'contrast-more:nx-border-neutral-400 dark:contrast-more:nx-border-neutral-400'
       )}
     >
       {prev && (
         <Anchor
           href={prev.route}
           title={prev.title}
-          className={cn(classes.link, 'ltr:pr-4 rtl:pl-4')}
+          className={cn(classes.link, 'ltr:nx-pr-4 rtl:nx-pl-4')}
         >
-          <ArrowRightIcon className={cn(classes.icon, 'ltr:rotate-180')} />
+          <ArrowRightIcon className={cn(classes.icon, 'ltr:nx-rotate-180')} />
           {prev.title}
         </Anchor>
       )}
@@ -52,11 +52,11 @@ export const NavLinks = ({
           title={next.title}
           className={cn(
             classes.link,
-            'ltr:pl-4 rtl:pr-4 ltr:text-right rtl:text-left ltr:ml-auto rtl:mr-auto'
+            'ltr:nx-pl-4 rtl:nx-pr-4 ltr:nx-text-right rtl:nx-text-left ltr:nx-ml-auto rtl:nx-mr-auto'
           )}
         >
           {next.title}
-          <ArrowRightIcon className={cn(classes.icon, 'rtl:rotate-180')} />
+          <ArrowRightIcon className={cn(classes.icon, 'rtl:nx-rotate-180')} />
         </Anchor>
       )}
     </div>

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -42,7 +42,7 @@ function NavbarMenu({
         <Menu.Button
           className={cn(
             className,
-            'nx-rounded nx-items-center nx--ml-2 nx-hidden nx-whitespace-nowrap nx-p-2 md:nx-inline-flex',
+            'nx-rounded nx-items-center -nx-ml-2 nx-hidden nx-whitespace-nowrap nx-p-2 md:nx-inline-flex',
             classes.inactive
           )}
         >

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -16,10 +16,10 @@ export type NavBarProps = {
 }
 
 const classes = {
-  link: 'text-sm contrast-more:text-gray-700 contrast-more:dark:text-gray-100',
-  active: 'subpixel-antialiased contrast-more:font-bold',
+  link: 'nx-text-sm contrast-more:nx-text-gray-700 contrast-more:dark:nx-text-gray-100',
+  active: 'nx-subpixel-antialiased contrast-more:nx-font-bold',
   inactive:
-    'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200'
+    'nx-text-gray-600 hover:nx-text-gray-800 dark:nx-text-gray-400 dark:hover:nx-text-gray-200'
 }
 
 function NavbarMenu({
@@ -37,23 +37,23 @@ function NavbarMenu({
   )
 
   return (
-    <div className="inline-block relative">
+    <div className="nx-inline-block nx-relative">
       <Menu>
         <Menu.Button
           className={cn(
             className,
-            'rounded items-center -ml-2 hidden whitespace-nowrap p-2 md:inline-flex',
+            'nx-rounded nx-items-center nx--ml-2 nx-hidden nx-whitespace-nowrap nx-p-2 md:nx-inline-flex',
             classes.inactive
           )}
         >
           {children}
         </Menu.Button>
         <Transition
-          leave="transition-opacity"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
+          leave="nx-transition-opacity"
+          leaveFrom="nx-opacity-100"
+          leaveTo="nx-opacity-0"
         >
-          <Menu.Items className="absolute right-0 z-20 mt-1 max-h-64 min-w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg dark:bg-neutral-800">
+          <Menu.Items className="nx-absolute nx-right-0 nx-z-20 nx-mt-1 nx-max-h-64 nx-min-w-full nx-overflow-auto nx-rounded-md nx-bg-white nx-py-1 nx-text-sm nx-shadow-lg dark:nx-bg-neutral-800">
             {Object.entries(items || {}).map(([key, item]) => (
               <Menu.Item key={key}>
                 <Anchor
@@ -61,8 +61,8 @@ function NavbarMenu({
                     item.href || routes[key]?.route || menu.route + '/' + key
                   }
                   className={cn(
-                    'hidden whitespace-nowrap md:inline-block text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 relative select-none w-full',
-                    'py-1.5 ltr:pl-3 ltr:pr-9 rtl:pr-3 rtl:pl-9'
+                    'nx-hidden nx-whitespace-nowrap md:nx-inline-block nx-text-gray-600 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-100 nx-relative nx-select-none nx-w-full',
+                    'nx-py-1.5 ltr:nx-pl-3 ltr:nx-pr-9 rtl:nx-pr-3 rtl:nx-pl-9'
                   )}
                   newWindow={item.newWindow}
                 >
@@ -129,7 +129,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
                 {menu.title}
                 <ArrowRightIcon
                   className="nx-h-[18px] nx-min-w-[18px] nx-rounded-sm nx-p-0.5"
-                  pathClassName="origin-center transition-transform rotate-90"
+                  pathClassName="nx-origin-center nx-transition-transform nx-rotate-90"
                 />
               </NavbarMenu>
             )

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -84,25 +84,25 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
   const { menu, setMenu } = useMenu()
 
   return (
-    <div className="nextra-nav-container sticky top-0 z-20 w-full bg-transparent">
+    <div className="nextra-nav-container nx-sticky nx-top-0 nx-z-20 nx-w-full nx-bg-transparent">
       <div
         className={cn(
           'nextra-nav-container-blur',
-          'pointer-events-none absolute z-[-1] h-full w-full bg-white dark:bg-dark',
-          'shadow-[0_2px_4px_rgba(0,0,0,.02),0_-1px_0_rgba(0,0,0,.06)_inset] dark:shadow-[0_-1px_0_rgba(255,255,255,.1)_inset]',
-          'contrast-more:shadow-[0_0_0_1px_#000] contrast-more:dark:shadow-[0_0_0_1px_#fff]'
+          'nx-pointer-events-none nx-absolute nx-z-[-1] nx-h-full nx-w-full nx-bg-white dark:nx-bg-dark',
+          'nx-shadow-[0_2px_4px_rgba(0,0,0,.02),0_-1px_0_rgba(0,0,0,.06)_inset] dark:nx-shadow-[0_-1px_0_rgba(255,255,255,.1)_inset]',
+          'contrast-more:nx-shadow-[0_0_0_1px_#000] contrast-more:dark:nx-shadow-[0_0_0_1px_#fff]'
         )}
       />
-      <nav className="mx-auto flex h-[var(--nextra-navbar-height)] max-w-[90rem] items-center justify-end gap-2 pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
+      <nav className="nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[90rem] nx-items-center nx-justify-end nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]">
         {config.logoLink ? (
           <Anchor
             href={typeof config.logoLink === 'string' ? config.logoLink : '/'}
-            className="flex ltr:mr-auto rtl:ml-auto items-center hover:opacity-75"
+            className="nx-flex ltr:nx-mr-auto rtl:nx-ml-auto nx-items-center hover:nx-opacity-75"
           >
             {renderComponent(config.logo)}
           </Anchor>
         ) : (
-          <div className="flex ltr:mr-auto rtl:ml-auto items-center">
+          <div className="nx-flex ltr:nx-mr-auto rtl:nx-ml-auto nx-items-center">
             {renderComponent(config.logo)}
           </div>
         )}
@@ -128,7 +128,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
               >
                 {menu.title}
                 <ArrowRightIcon
-                  className="h-[18px] min-w-[18px] rounded-sm p-0.5"
+                  className="nx-h-[18px] nx-min-w-[18px] nx-rounded-sm nx-p-0.5"
                   pathClassName="origin-center transition-transform rotate-90"
                 />
               </NavbarMenu>
@@ -153,7 +153,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
               key={page.route}
               className={cn(
                 classes.link,
-                '-ml-2 hidden whitespace-nowrap p-2 md:inline-block',
+                '-nx-ml-2 nx-hidden nx-whitespace-nowrap nx-p-2 md:nx-inline-block',
                 !isActive || page.newWindow ? classes.inactive : classes.active
               )}
               newWindow={page.newWindow}
@@ -166,12 +166,12 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
 
         {renderComponent(config.search.component, {
           directories: flatDirectories,
-          className: 'hidden md:inline-block min-w-[200px]'
+          className: 'nx-hidden md:nx-inline-block mx-min-w-[200px]'
         })}
 
         {config.project.link ? (
           <Anchor
-            className="p-2 text-current"
+            className="nx-p-2 nx-text-current"
             href={config.project.link}
             newWindow
           >
@@ -185,7 +185,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
 
         {config.chat.link ? (
           <Anchor
-            className="p-2 text-current"
+            className="nx-p-2 nx-text-current"
             href={config.chat.link}
             newWindow
           >
@@ -198,7 +198,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         ) : null}
 
         <button
-          className="nextra-hamburger rounded active:bg-gray-400/20 p-2 -mr-2 md:hidden"
+          className="nextra-hamburger nx-rounded active:nx-bg-gray-400/20 nx-p-2 -nx-mr-2 md:nx-hidden"
           onClick={() => setMenu(!menu)}
         >
           <MenuIcon className={cn({ open: menu })} />

--- a/packages/nextra-theme-docs/src/components/not-found.tsx
+++ b/packages/nextra-theme-docs/src/components/not-found.tsx
@@ -15,7 +15,7 @@ export function NotFoundPage(): ReactElement | null {
   }
 
   return (
-    <p className="text-center">
+    <p className="nx-text-center">
       <Anchor
         href={getGitIssueUrl({
           repository: config.docsRepositoryBase,
@@ -23,7 +23,7 @@ export function NotFoundPage(): ReactElement | null {
           labels
         })}
         newWindow
-        className="text-primary-500 underline decoration-from-font [text-underline-position:under]"
+        className="nx-text-primary-500 nx-underline nx-decoration-from-font [text-underline-position:under]"
       >
         {renderComponent(content)}
       </Anchor>

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -139,23 +139,23 @@ export function Search({
     <Transition
       show={mounted && (!show || Boolean(value))}
       as={React.Fragment}
-      enter="transition-opacity"
-      enterFrom="opacity-0"
-      enterTo="opacity-100"
-      leave="transition-opacity"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
+      enter="nx-transition-opacity"
+      enterFrom="nx-opacity-0"
+      enterTo="nx-opacity-100"
+      leave="nx-transition-opacity"
+      leaveFrom="nx-opacity-100"
+      leaveTo="nx-opacity-0"
     >
       <kbd
         className={cn(
-          'absolute ltr:right-1.5 rtl:left-1.5 my-1.5 select-none',
-          'rounded bg-white px-1.5 h-5 font-mono font-medium text-gray-500 text-[10px]',
-          'border dark:bg-dark/50 dark:border-gray-100/20',
-          'contrast-more:border-current contrast-more:text-current contrast-more:dark:border-current',
-          'items-center gap-1 transition-opacity',
+          'nx-absolute ltr:nx-right-1.5 rtl:nx-left-1.5 nx-my-1.5 nx-select-none',
+          'nx-rounded nx-bg-white nx-px-1.5 nx-h-5 nx-font-mono nx-font-medium nx-text-gray-500 nx-text-[10px]',
+          'nx-border dark:nx-bg-dark/50 dark:nx-border-gray-100/20',
+          'contrast-more:nx-border-current contrast-more:nx-text-current contrast-more:dark:nx-border-current',
+          'nx-items-center nx-gap-1 nx-transition-opacity',
           value
-            ? 'cursor-pointer hover:opacity-70 z-20 flex'
-            : 'hidden sm:flex pointer-events-none'
+            ? 'nx-cursor-pointer hover:nx-opacity-70 nx-z-20 nx-flex'
+            : 'nx-hidden sm:nx-flex nx-pointer-events-none'
         )}
         title={value ? 'Clear' : undefined}
         onClick={() => {
@@ -167,7 +167,7 @@ export function Search({
           : mounted &&
             (navigator.userAgent.includes('Macintosh') ? (
               <>
-                <span className="text-xs">⌘</span>K
+                <span className="nx-text-xs">⌘</span>K
               </>
             ) : (
               'CTRL K'
@@ -185,9 +185,12 @@ export function Search({
   )
 
   return (
-    <div className={cn('nextra-search relative md:w-64', className)}>
+    <div className={cn('nextra-search nx-relative md:nx-w-64', className)}>
       {renderList && (
-        <div className="fixed inset-0 z-10" onClick={() => setShow(false)} />
+        <div
+          className="nx-fixed nx-inset-0 nx-z-10"
+          onClick={() => setShow(false)}
+        />
       )}
 
       <Input
@@ -208,20 +211,20 @@ export function Search({
         show={renderList}
         // Transition.Child is required here, otherwise popup will be still present in DOM after focus out
         as={Transition.Child}
-        leave="transition-opacity duration-100"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
+        leave="nx-transition-opacity nx-duration-100"
+        leaveFrom="nx-opacity-100"
+        leaveTo="nx-opacity-0"
       >
         <ul
           className={cn(
             'nextra-scrollbar',
             // Using bg-white as background-color when the browser didn't support backdrop-filter
-            'bg-white text-gray-100 dark:bg-neutral-900',
-            'absolute top-full z-20 mt-2 overscroll-contain rounded-xl py-2.5 shadow-xl overflow-auto',
-            'max-h-[min(calc(50vh-11rem-env(safe-area-inset-bottom)),400px)]',
-            'md:max-h-[min(calc(100vh-5rem-env(safe-area-inset-bottom)),400px)]',
-            'right-0 left-0 ltr:md:left-auto rtl:md:right-auto',
-            'contrast-more:border contrast-more:border-gray-900 contrast-more:dark:border-gray-50',
+            'nx-bg-white nx-text-gray-100 dark:nx-bg-neutral-900',
+            'nx-absolute nx-top-full nx-z-20 nx-mt-2 nx-overscroll-contain nx-rounded-xl nx-py-2.5 nx-shadow-xl nx-overflow-auto',
+            'nx-max-h-[min(calc(50vh-11rem-env(safe-area-inset-bottom)),400px)]',
+            'md:nx-max-h-[min(calc(100vh-5rem-env(safe-area-inset-bottom)),400px)]',
+            'nx-right-0 nx-left-0 ltr:md:nx-left-auto rtl:md:nx-right-auto',
+            'contrast-more:nx-border contrast-more:nx-border-gray-900 contrast-more:dark:nx-border-gray-50',
             overlayClassName
           )}
           ref={ulRef}
@@ -230,8 +233,8 @@ export function Search({
           }}
         >
           {loading ? (
-            <span className="flex select-none justify-center p-8 text-center text-sm text-gray-400 gap-2">
-              <SpinnerIcon className="h-5 w-5 animate-spin" />
+            <span className="nx-flex nx-select-none nx-justify-center nx-p-8 nx-text-center nx-text-sm nx-text-gray-400 nx-gap-2">
+              <SpinnerIcon className="nx-h-5 nx-w-5 nx-animate-spin" />
               Loading...
             </span>
           ) : results.length > 0 ? (
@@ -240,15 +243,15 @@ export function Search({
                 {prefix}
                 <li
                   className={cn(
-                    'mx-2.5 rounded-md break-words',
-                    'contrast-more:border',
+                    'nx-mx-2.5 nx-rounded-md nx-break-words',
+                    'contrast-more:nx-border',
                     i === active
-                      ? 'bg-primary-500/10 text-primary-500 contrast-more:border-primary-500'
-                      : 'text-gray-800 dark:text-gray-300 contrast-more:border-transparent'
+                      ? 'nx-bg-primary-500/10 nx-text-primary-500 contrast-more:nx-border-primary-500'
+                      : 'nx-text-gray-800 dark:nx-text-gray-300 contrast-more:nx-border-transparent'
                   )}
                 >
                   <Anchor
-                    className="block px-2.5 py-2 scroll-m-12"
+                    className="nx-block nx-px-2.5 nx-py-2 nx-scroll-m-12"
                     href={route}
                     data-index={i}
                     onFocus={handleActive}

--- a/packages/nextra-theme-docs/src/components/select.tsx
+++ b/packages/nextra-theme-docs/src/components/select.tsx
@@ -50,10 +50,10 @@ export function Select({
           ref={trigger}
           title={title}
           className={cn(
-            'h-7 rounded-md px-2 text-left text-xs font-medium text-gray-600 transition-colors dark:text-gray-400',
+            'nx-h-7 nx-rounded-md nx-px-2 nx-text-left nx-text-xs nx-font-medium nx-text-gray-600 nx-transition-colors dark:nx-text-gray-400',
             open
-              ? 'bg-gray-200 text-gray-900 dark:bg-primary-100/10 dark:text-gray-50'
-              : 'hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-primary-100/5 dark:hover:text-gray-50',
+              ? 'nx-bg-gray-200 nx-text-gray-900 dark:nx-bg-primary-100/10 dark:nx-text-gray-50'
+              : 'hover:nx-bg-gray-100 hover:nx-text-gray-900 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50',
             className
           )}
         >
@@ -64,10 +64,10 @@ export function Select({
               ref={container}
               show={open}
               as={Listbox.Options}
-              className="border border-black/5 dark:border-white/20 z-20 max-h-64 overflow-auto rounded-md bg-white py-1 text-sm shadow-lg dark:bg-neutral-800"
-              leave="transition-opacity"
-              leaveFrom="opacity-100"
-              leaveTo="opacity-0"
+              className="nx-border nx-border-black/5 dark:nx-border-white/20 nx-z-20 nx-max-h-64 nx-overflow-auto nx-rounded-md nx-bg-white nx-py-1 nx-text-sm nx-shadow-lg dark:nx-bg-neutral-800"
+              leave="nx-transition-opacity"
+              leaveFrom="nx-opacity-100"
+              leaveTo="nx-opacity-0"
             >
               {options.map(option => (
                 <Listbox.Option
@@ -76,16 +76,16 @@ export function Select({
                   className={({ active }) =>
                     cn(
                       active
-                        ? 'bg-primary-50 text-primary-500 dark:bg-primary-500/10'
-                        : 'text-gray-800 dark:text-gray-100',
-                      'relative cursor-pointer whitespace-nowrap py-1.5',
-                      'ltr:pl-3 ltr:pr-9 rtl:pr-3 rtl:pl-9'
+                        ? 'nx-bg-primary-50 nx-text-primary-500 dark:nx-bg-primary-500/10'
+                        : 'nx-text-gray-800 dark:nx-text-gray-100',
+                      'nx-relative nx-cursor-pointer nx-whitespace-nowrap nx-py-1.5',
+                      'ltr:nx-pl-3 ltr:nx-pr-9 rtl:nx-pr-3 rtl:nx-pl-9'
                     )
                   }
                 >
                   {option.name}
                   {option.key === selected.key && (
-                    <span className="absolute inset-y-0 ltr:right-3 rtl:left-3 flex items-center">
+                    <span className="nx-absolute nx-inset-y-0 ltr:nx-right-3 rtl:nx-left-3 nx-flex nx-items-center">
                       <CheckIcon />
                     </span>
                   )}

--- a/packages/nextra-theme-docs/src/components/server-side-error.tsx
+++ b/packages/nextra-theme-docs/src/components/server-side-error.tsx
@@ -15,7 +15,7 @@ export function ServerSideErrorPage(): ReactElement | null {
   }
 
   return (
-    <p className="text-center">
+    <p className="nx-text-center">
       <Anchor
         href={getGitIssueUrl({
           repository: config.docsRepositoryBase,
@@ -25,7 +25,7 @@ export function ServerSideErrorPage(): ReactElement | null {
           labels
         })}
         newWindow
-        className="text-primary-500 underline decoration-from-font [text-underline-position:under]"
+        className="nx-text-primary-500 nx-underline nx-decoration-from-font [text-underline-position:under]"
       >
         {renderComponent(content)}
       </Anchor>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -34,24 +34,24 @@ const Folder = memo(FolderImpl)
 
 const classes = {
   link: cn(
-    'flex rounded px-2 py-1.5 text-sm transition-colors [word-break:break-word]',
-    '[-webkit-tap-highlight-color:transparent] [-webkit-touch-callout:none] contrast-more:border'
+    'nx-flex nx-rounded nx-px-2 nx-py-1.5 nx-text-sm nx-transition-colors [word-break:break-word]',
+    '[-webkit-tap-highlight-color:transparent] [-webkit-touch-callout:none] contrast-more:nx-border'
   ),
   inactive: cn(
-    'hover:bg-gray-100 text-gray-500 hover:text-gray-900',
-    'dark:hover:bg-primary-100/5 dark:text-neutral-500 dark:hover:text-gray-50',
-    'contrast-more:text-gray-900 contrast-more:dark:text-gray-50',
-    'contrast-more:border-transparent contrast-more:hover:border-gray-900 contrast-more:dark:hover:border-gray-50'
+    'hover:nx-bg-gray-100 nx-text-gray-500 hover:nx-text-gray-900',
+    'dark:hover:nx-bg-primary-100/5 dark:nx-text-neutral-500 dark:hover:nx-text-gray-50',
+    'contrast-more:nx-text-gray-900 contrast-more:dark:nx-text-gray-50',
+    'contrast-more:nx-border-transparent contrast-more:hover:nx-border-gray-900 contrast-more:dark:hover:nx-border-gray-50'
   ),
   active: cn(
-    'bg-primary-50 text-primary-500 dark:bg-primary-500/10 font-bold',
-    'contrast-more:border-primary-500 contrast-more:dark:border-primary-500'
+    'nx-bg-primary-50 nx-text-primary-500 dark:nx-bg-primary-500/10 nx-font-bold',
+    'contrast-more:nx-border-primary-500 contrast-more:dark:nx-border-primary-500'
   ),
-  list: 'flex gap-1 flex-col',
+  list: 'nx-flex nx-gap-1 nx-flex-col',
   border: cn(
-    'relative before:absolute before:top-1.5 before:bottom-1.5',
-    'before:content-[""] before:w-px before:bg-gray-200 dark:before:bg-neutral-800',
-    'ltr:pl-3 rtl:pr-3 ltr:before:left-0 rtl:before:right-0'
+    'nx-relative before:nx-absolute before:nx-top-1.5 before:nx-bottom-1.5',
+    'before:nx-content-[""] before:nx-w-px before:nx-bg-gray-200 dark:before:nx-bg-neutral-800',
+    'ltr:nx-pl-3 rtl:nx-pr-3 ltr:before:nx-left-0 rtl:before:nx-right-0'
   )
 }
 
@@ -142,17 +142,17 @@ function FolderImpl({
           type: item.type
         })}
         <ArrowRightIcon
-          className="h-[18px] min-w-[18px] rounded-sm p-0.5 hover:bg-gray-800/5 dark:hover:bg-gray-100/5"
+          className="nx-h-[18px] nx-min-w-[18px] nx-rounded-sm nx-p-0.5 hover:nx-bg-gray-800/5 dark:hover:nx-bg-gray-100/5"
           pathClassName={cn(
-            'origin-center transition-transform rtl:-rotate-180',
-            open && 'ltr:rotate-90 rtl:rotate-[-270deg]'
+            'nx-origin-center nx-transition-transform rtl:-nx-rotate-180',
+            open && 'ltr:nx-rotate-90 rtl:nx-rotate-[-270deg]'
           )}
         />
       </Anchor>
       <Collapse className="ltr:pr-0 rtl:pl-0" open={open}>
         {Array.isArray(item.children) ? (
           <Menu
-            className={cn(classes.border, 'ltr:ml-1 rtl:mr-1')}
+            className={cn(classes.border, 'ltr:nx-ml-1 rtl:nx-mr-1')}
             directories={item.children}
             base={item.route}
             anchors={anchors}
@@ -170,8 +170,8 @@ function Separator({ title }: { title: string }): ReactElement {
       className={cn(
         '[word-break:break-word]',
         title
-          ? 'first:mt-0 mt-5 mb-2 px-2 py-1.5 text-sm font-semibold text-gray-900 dark:text-gray-100'
-          : 'my-4'
+          ? 'first:nx-mt-0 nx-mt-5 nx-mb-2 nx-px-2 nx-py-1.5 nx-text-sm nx-font-semibold nx-text-gray-900 dark:nx-text-gray-100'
+          : 'nx-my-4'
       )}
     >
       {title ? (
@@ -180,7 +180,7 @@ function Separator({ title }: { title: string }): ReactElement {
           type: 'separator'
         })
       ) : (
-        <hr className="mx-2 border-t border-gray-200 dark:border-primary-100/10" />
+        <hr className="nx-mx-2 nx-border-t nx-border-gray-200 dark:nx-border-primary-100/10" />
       )}
     </li>
   )
@@ -221,7 +221,13 @@ function File({
         })}
       </Anchor>
       {active && anchors.length > 0 && (
-        <ul className={cn(classes.list, classes.border, 'ltr:ml-3 rtl:mr-3')}>
+        <ul
+          className={cn(
+            classes.list,
+            classes.border,
+            'ltr:nx-ml-3 rtl:nx-mr-3'
+          )}
+        >
           {anchors.map(text => {
             const slug = slugger.slug(text)
             return (
@@ -230,7 +236,7 @@ function File({
                   href={`#${slug}`}
                   className={cn(
                     classes.link,
-                    'before:opacity-25 flex gap-2 before:content-["#"]',
+                    'before:nx-opacity-25 nx-flex nx-gap-2 before:nx-content-["#"]',
                     activeAnchor[slug]?.isActive
                       ? classes.active
                       : classes.inactive
@@ -306,9 +312,12 @@ export function Sidebar({
 
   useEffect(() => {
     if (menu) {
-      document.body.classList.add('overflow-hidden', 'md:overflow-auto')
+      document.body.classList.add('nx-overflow-hidden', 'md:nx-overflow-auto')
     } else {
-      document.body.classList.remove('overflow-hidden', 'md:overflow-auto')
+      document.body.classList.remove(
+        'nx-overflow-hidden',
+        'md:nx-overflow-auto'
+      )
     }
   }, [menu])
 
@@ -338,22 +347,22 @@ export function Sidebar({
   return (
     <>
       {includePlaceholder && asPopover ? (
-        <div className="hidden h-0 w-64 flex-shrink-0 xl:block" />
+        <div className="nx-hidden nx-h-0 nx-w-64 nx-flex-shrink-0 xl:nx-block" />
       ) : null}
       <div
         className={cn(
-          '[transition:background-color_1.5s_ease] motion-reduce:transition-none',
+          '[transition:background-color_1.5s_ease] motion-reduce:nx-transition-none',
           menu
-            ? 'fixed inset-0 z-10 bg-black/80 dark:bg-black/60'
-            : 'bg-transparent'
+            ? 'nx-fixed nx-inset-0 nx-z-10 nx-bg-black/80 dark:nx-bg-black/60'
+            : 'nx-bg-transparent'
         )}
         onClick={() => setMenu(false)}
       />
       <aside
         className={cn(
-          'nextra-sidebar-container flex flex-col',
-          'md:top-16 md:flex-shrink-0 md:w-64 md:transform-none',
-          asPopover ? 'md:hidden' : 'md:sticky md:self-start',
+          'nextra-sidebar-container nx-flex nx-flex-col',
+          'md:nx-top-16 md:nx-flex-shrink-0 md:nx-w-64 md:nx-transform-none',
+          asPopover ? 'md:nx-hidden' : 'md:nx-sticky md:nx-self-start',
           menu
             ? '[transform:translate3d(0,0,0)]'
             : '[transform:translate3d(0,-100%,0)]'
@@ -362,10 +371,10 @@ export function Sidebar({
       >
         <div
           className={cn(
-            'z-[1]', // for bottom box shadow
-            'md:hidden p-4',
-            'shadow-[0_2px_14px_6px_#fff] dark:shadow-[0_2px_14px_6px_#111]',
-            'contrast-more:shadow-none dark:contrast-more:shadow-none'
+            'nx-z-[1]', // for bottom box shadow
+            'md:nx-hidden nx-p-4',
+            'nx-shadow-[0_2px_14px_6px_#fff] dark:nx-shadow-[0_2px_14px_6px_#111]',
+            'contrast-more:nx-shadow-none dark:contrast-more:nx-shadow-none'
           )}
         >
           {renderComponent(config.search.component, {
@@ -374,13 +383,13 @@ export function Sidebar({
         </div>
         <div
           className={cn(
-            'px-4 pb-4 md:pt-4 overflow-y-auto nextra-scrollbar',
-            'grow md:h-[calc(100vh-var(--nextra-navbar-height)-3.75rem)]'
+            'nx-px-4 nx-pb-4 md:nx-pt-4 nx-overflow-y-auto nextra-scrollbar',
+            'nx-grow md:nx-h-[calc(100vh-var(--nextra-navbar-height)-3.75rem)]'
           )}
           ref={sidebarRef}
         >
           <Menu
-            className="hidden md:flex"
+            className="nx-hidden md:nx-flex"
             // The sidebar menu, shows only the docs directories.
             directories={docsDirectories}
             // When the viewport size is larger than `md`, hide the anchors in
@@ -388,7 +397,7 @@ export function Sidebar({
             anchors={config.toc.float ? [] : anchors}
           />
           <Menu
-            className="md:hidden"
+            className="md:nx-hidden"
             // The mobile dropdown menu, shows all the directories.
             directories={fullDirectories}
             // Always show the anchor links on mobile (`md`).
@@ -399,11 +408,11 @@ export function Sidebar({
         {hasMenu && (
           <div
             className={cn(
-              'z-[1] relative', // for top box shadow
-              'mx-4 py-4 border-t shadow-[0_-12px_16px_#fff]',
-              'flex gap-2 items-center gap-2',
-              'dark:border-neutral-800 dark:shadow-[0_-12px_16px_#111]',
-              'contrast-more:shadow-none contrast-more:dark:shadow-none contrast-more:border-neutral-400'
+              'nx-z-[1] nx-relative', // for top box nx-shadow
+              'nx-mx-4 nx-py-4 nx-border-t nx-shadow-[0_-12px_16px_#fff]',
+              'nx-flex nx-gap-2 nx-items-center',
+              'dark:nx-border-neutral-800 dark:nx-shadow-[0_-12px_16px_#111]',
+              'contrast-more:nx-shadow-none contrast-more:dark:nx-shadow-none contrast-more:nx-border-neutral-400'
             )}
           >
             {config.i18n.length > 0 && (

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -35,7 +35,7 @@ const Folder = memo(FolderImpl)
 const classes = {
   link: cn(
     'nx-flex nx-rounded nx-px-2 nx-py-1.5 nx-text-sm nx-transition-colors [word-break:break-word]',
-    '[-webkit-tap-highlight-color:transparent] [-webkit-touch-callout:none] contrast-more:nx-border'
+    '[-webkit-tap-highlight-color:transparent] [-webkit-touch-callout:none] contrast-more:nx-border nx-cursor-pointer'
   ),
   inactive: cn(
     'hover:nx-bg-gray-100 nx-text-gray-500 hover:nx-text-gray-900',

--- a/packages/nextra-theme-docs/src/components/tabs.tsx
+++ b/packages/nextra-theme-docs/src/components/tabs.tsx
@@ -38,8 +38,8 @@ export function Tabs({
       defaultIndex={defaultIndex}
       onChange={onChange}
     >
-      <div className="no-scrollbar -m-2 overflow-x-auto overflow-y-hidden overscroll-x-contain p-2">
-        <HeadlessTab.List className="mt-4 flex w-max min-w-full border-b border-gray-200 pb-px dark:border-neutral-800">
+      <div className="nx-no-scrollbar -nx-m-2 nx-overflow-x-auto nx-overflow-y-hidden nx-overscroll-x-contain nx-p-2">
+        <HeadlessTab.List className="nx-mt-4 nx-flex nx-w-max nx-min-w-full nx-border-b nx-border-gray-200 nx-pb-px dark:nx-border-neutral-800">
           {items.map((item, index) => {
             const disabled = !!(
               item &&
@@ -54,14 +54,14 @@ export function Tabs({
                 disabled={disabled}
                 className={({ selected }) =>
                   cn(
-                    'rounded-t',
-                    'text-md mr-2 p-2 font-medium leading-5 transition-colors',
-                    '-mb-0.5 select-none border-b-2',
+                    'nx-rounded-t',
+                    'nx-text-md nx-mr-2 nx-p-2 nx-font-medium nx-leading-5 nx-transition-colors',
+                    '-nx-mb-0.5 nx-select-none nx-border-b-2',
                     selected
-                      ? 'border-primary-500 text-primary-500'
-                      : 'border-transparent text-gray-600 hover:border-gray-200 hover:text-black dark:text-gray-200 dark:hover:border-neutral-800 dark:hover:text-white',
+                      ? 'nx-border-primary-500 nx-text-primary-500'
+                      : 'nx-border-transparent nx-text-gray-600 hover:nx-border-gray-200 hover:nx-text-black dark:nx-text-gray-200 dark:hover:nx-border-neutral-800 dark:hover:nx-text-white',
                     disabled &&
-                      'pointer-events-none text-gray-400 dark:text-neutral-600'
+                      'nx-pointer-events-none nx-text-gray-400 dark:nx-text-neutral-600'
                   )
                 }
               >
@@ -81,7 +81,7 @@ export function Tab({
   ...props
 }: ComponentProps<'div'>): ReactElement {
   return (
-    <HeadlessTab.Panel {...props} className="rounded">
+    <HeadlessTab.Panel {...props} className="nx-rounded">
       {children}
     </HeadlessTab.Panel>
   )

--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -19,25 +19,25 @@ export function ThemeSwitch({ lite }: ThemeSwitchProps): ReactElement {
   const mounted = useMounted()
   const IconToUse = mounted && resolvedTheme === 'dark' ? MoonIcon : SunIcon
   return (
-  <div className="relative">
-    <Select
-      title="Change theme"
-      options={OPTIONS}
-      onChange={option => {
-        setTheme(option.key)
-      }}
-      selected={{
-        key: theme,
-        name: (
-          <div className="flex items-center gap-2 capitalize">
-            <IconToUse />
-            <span className={lite ? 'md:hidden' : ''}>
-              {mounted ? theme : 'light'}
-            </span>
-          </div>
-        )
-      }}
-    />
-  </div>
+    <div className="nx-relative">
+      <Select
+        title="Change theme"
+        options={OPTIONS}
+        onChange={option => {
+          setTheme(option.key)
+        }}
+        selected={{
+          key: theme,
+          name: (
+            <div className="nx-flex nx-items-center nx-gap-2 nx-capitalize">
+              <IconToUse />
+              <span className={lite ? 'md:nx-hidden' : ''}>
+                {mounted ? theme : 'light'}
+              </span>
+            </div>
+          )
+        }}
+      />
+    </div>
   )
 }

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -63,41 +63,41 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
   }, [activeSlug])
 
   const linkClassName = cn(
-    'text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100',
-    'contrast-more:text-gray-800 contrast-more:dark:text-gray-50'
+    'nx-text-xs nx-font-medium nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-100',
+    'contrast-more:nx-text-gray-800 contrast-more:dark:nx-text-gray-50'
   )
 
   return (
     <div
       ref={tocRef}
       className={cn(
-        'nextra-scrollbar sticky top-16 overflow-y-auto pr-4 pt-8 text-sm [hyphens:auto]',
-        'ltr:-mr-4 rtl:-ml-4 max-h-[calc(100vh-var(--nextra-navbar-height)-env(safe-area-inset-bottom))]'
+        'nextra-scrollbar nx-sticky nx-top-16 nx-overflow-y-auto nx-pr-4 nx-pt-8 nx-text-sm nx-[hyphens:auto]',
+        'ltr:-nx-mr-4 rtl:-nx-ml-4 nx-max-h-[calc(100vh-var(--nextra-navbar-height)-env(safe-area-inset-bottom))]'
       )}
     >
       {hasHeadings && (
         <>
-          <p className="mb-4 font-semibold tracking-tight">
+          <p className="nx-mb-4 nx-font-semibold nx-tracking-tight">
             {renderComponent(config.toc.title)}
           </p>
           <ul>
             {items.map(({ slug, text, depth }) => (
-              <li className="my-2 scroll-my-6 scroll-py-6" key={slug}>
+              <li className="nx-my-2 nx-scroll-my-6 nx-scroll-py-6" key={slug}>
                 <a
                   href={`#${slug}`}
                   className={cn(
                     {
-                      2: 'font-semibold',
-                      3: 'ltr:ml-4 rtl:mr-4',
-                      4: 'ltr:ml-8 rtl:mr-8',
-                      5: 'ltr:ml-12 rtl:mr-12',
-                      6: 'ltr:ml-16 rtl:mr-16'
+                      2: 'nx-font-semibold',
+                      3: 'ltr:nx-ml-4 rtl:nx-mr-4',
+                      4: 'ltr:nx-ml-8 rtl:nx-mr-8',
+                      5: 'ltr:nx-ml-12 rtl:nx-mr-12',
+                      6: 'ltr:nx-ml-16 rtl:nx-mr-16'
                     }[depth],
-                    'inline-block',
+                    'nx-inline-block',
                     activeAnchor[slug]?.isActive
-                      ? 'text-primary-500 subpixel-antialiased contrast-more:!text-primary-500'
-                      : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-300',
-                    'contrast-more:text-gray-900 contrast-more:underline contrast-more:dark:text-gray-50'
+                      ? 'nx-text-primary-500 nx-subpixel-antialiased contrast-more:!nx-text-primary-500'
+                      : 'nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-300',
+                    'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50'
                   )}
                 >
                   {text}
@@ -112,9 +112,9 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
         <div
           className={cn(
             hasHeadings &&
-              'mt-8 border-t bg-white pt-8 shadow-[0_-12px_16px_white] dark:bg-dark dark:shadow-[0_-12px_16px_#111]',
-            'sticky bottom-0 pb-8 dark:border-neutral-800 flex flex-col items-start gap-2',
-            'contrast-more:shadow-none contrast-more:border-t contrast-more:border-neutral-400 contrast-more:dark:border-neutral-400'
+              'nx-mt-8 nx-border-t nx-bg-white nx-pt-8 nx-shadow-[0_-12px_16px_white] dark:nx-bg-dark dark:nx-shadow-[0_-12px_16px_#111]',
+            'nx-sticky nx-bottom-0 nx-pb-8 dark:nx-border-neutral-800 nx-flex nx-flex-col nx-items-start nx-gap-2',
+            'contrast-more:nx-shadow-none contrast-more:nx-border-t contrast-more:nx-border-neutral-400 contrast-more:dark:nx-border-neutral-400'
           )}
         >
           {config.feedback.content ? (

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -21,7 +21,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     icon: (
       <>
         <DiscordIcon />
-        <span className="sr-only">Discord</span>
+        <span className="nx-sr-only">Discord</span>
       </>
     )
   },
@@ -105,7 +105,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     icon: (
       <>
         <GitHubIcon />
-        <span className="sr-only">GitHub</span>
+        <span className="nx-sr-only">GitHub</span>
       </>
     )
   },

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -29,7 +29,9 @@ let resizeObserver: ResizeObserver
 if (IS_BROWSER) {
   resizeObserver ||= new ResizeObserver(entries => {
     if (location.hash) {
-      const node = entries[0].target.ownerDocument.getElementById(location.hash.slice(1))
+      const node = entries[0].target.ownerDocument.getElementById(
+        location.hash.slice(1)
+      )
       if (node) {
         scrollIntoView(node)
       }
@@ -81,7 +83,7 @@ const Body = ({
   }, [])
 
   if (themeContext.layout === 'raw') {
-    return <div className="w-full overflow-x-hidden">{children}</div>
+    return <div className="nx-w-full nx-overflow-x-hidden">{children}</div>
   }
 
   const date =
@@ -90,11 +92,11 @@ const Body = ({
       : null
 
   const gitTimestampEl = date ? (
-    <div className="pointer-default mt-12 mb-8 block ltr:text-right rtl:text-left text-xs text-gray-500 dark:text-gray-400">
+    <div className="nx-pointer-default nx-mt-12 nx-mb-8 nx-block ltr:nx-text-right rtl:nx-text-left nx-text-xs nx-text-gray-500 dark:nx-text-gray-400">
       {renderComponent(config.gitTimestamp, { timestamp: date })}
     </div>
   ) : (
-    <div className="mt-16" />
+    <div className="nx-mt-16" />
   )
 
   const body = (
@@ -108,7 +110,7 @@ const Body = ({
 
   if (themeContext.layout === 'full') {
     return (
-      <article className="min-h-[calc(100vh-4rem)] w-full overflow-x-hidden pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-right),1.5rem)]">
+      <article className="nx-min-h-[calc(100vh-4rem)] nx-w-full nx-overflow-x-hidden nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]">
         {body}
       </article>
     )
@@ -117,13 +119,13 @@ const Body = ({
   return (
     <article
       className={cn(
-        'min-h-[calc(100vh-4rem)] w-full flex min-w-0 max-w-full justify-center pb-8 pr-[calc(env(safe-area-inset-right)-1.5rem)]',
+        'nx-min-h-[calc(100vh-4rem)] nx-w-full nx-flex nx-min-w-0 nx-max-w-full nx-justify-center nx-pb-8 nx-pr-[calc(env(safe-area-inset-right)-1.5rem)]',
         themeContext.typesetting === 'article' &&
           'nextra-body-typesetting-article'
       )}
     >
       <main
-        className="w-full min-w-0 max-w-4xl px-6 pt-4 md:px-8"
+        className="nx-w-full nx-min-w-0 nx-max-w-4xl nx-px-6 nx-pt-4 md:nx-px-8"
         ref={mainElement}
       >
         {breadcrumb}
@@ -161,7 +163,7 @@ const InnerLayout = ({
     activeType === 'page'
 
   const tocClassName =
-    'nextra-toc order-last hidden w-64 flex-shrink-0 xl:block'
+    'nextra-toc nx-order-last nx-hidden nx-w-64 nx-flex-shrink-0 xl:nx-block'
 
   const tocEl =
     activeType === 'page' ||
@@ -170,7 +172,7 @@ const InnerLayout = ({
       themeContext.layout !== 'full' &&
       themeContext.layout !== 'raw' && <div className={tocClassName} />
     ) : (
-      <div className={cn(tocClassName, 'px-4')}>
+      <div className={cn(tocClassName, 'nx-px-4')}>
         {renderComponent(config.toc.component, {
           headings: config.toc.float ? headings : [],
           filePath
@@ -205,8 +207,8 @@ const InnerLayout = ({
         })}
       <div
         className={cn(
-          'mx-auto flex',
-          themeContext.layout !== 'raw' && 'max-w-[90rem]'
+          'nx-mx-auto nx-flex',
+          themeContext.layout !== 'raw' && 'nx-max-w-[90rem]'
         )}
       >
         <ActiveAnchorProvider>
@@ -283,5 +285,5 @@ export {
   Tabs,
   Tab,
   Navbar,
-  ThemeSwitch,
+  ThemeSwitch
 } from './components'

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -108,19 +108,19 @@ const createHeaderLink = (
     return (
       <Tag
         className={cn(
-          'font-semibold tracking-tight',
+          'nx-font-semibold nx-tracking-tight',
           {
-            h2: 'mt-10 text-3xl border-b pb-1 dark:border-primary-100/10 contrast-more:border-neutral-400 contrast-more:dark:border-neutral-400',
-            h3: 'mt-8 text-2xl',
-            h4: 'mt-8 text-xl',
-            h5: 'mt-8 text-lg',
-            h6: 'mt-8 text-base'
+            h2: 'nx-mt-10 nx-text-3xl nx-border-b nx-pb-1 dark:nx-border-primary-100/10 contrast-more:nx-border-neutral-400 contrast-more:dark:nx-border-neutral-400',
+            h3: 'nx-mt-8 nx-text-2xl',
+            h4: 'nx-mt-8 nx-text-xl',
+            h5: 'nx-mt-8 nx-text-lg',
+            h6: 'nx-mt-8 nx-text-base'
           }[Tag]
         )}
         {...props}
       >
         {children}
-        <span className="absolute -mt-20" id={id} ref={obRef} />
+        <span className="nx-absolute -nx-mt-20" id={id} ref={obRef} />
         <a href={`#${id}`} className="subheading-anchor" />
       </Tag>
     )
@@ -180,7 +180,7 @@ const Details = ({
 
   return (
     <details
-      className="my-4 rounded border border-gray-200 bg-white p-2 shadow-sm dark:border-neutral-800 dark:bg-neutral-900 first:mt-0 last:mb-0"
+      className="nx-my-4 nx-rounded nx-border nx-border-gray-200 nx-bg-white nx-p-2 nx-shadow-sm dark:nx-border-neutral-800 dark:nx-bg-neutral-900 first:nx-mt-0 last:nx-mb-0"
       {...props}
       open={delayedOpenState}
       {...(openState && { 'data-expanded': true })}
@@ -196,9 +196,9 @@ const Summary = (props: ComponentProps<'summary'>): ReactElement => {
   return (
     <summary
       className={cn(
-        'list-none cursor-pointer p-1 transition-colors hover:bg-gray-100 dark:hover:bg-neutral-800',
-        "before:mr-1 before:content-[''] before:inline-block before:transition-transform dark:before:invert",
-        '[[data-expanded]>&]:before:rotate-90 rtl:before:rotate-180'
+        'nx-list-none nx-cursor-pointer nx-p-1 nx-transition-colors hover:nx-bg-gray-100 dark:hover:nx-bg-neutral-800',
+        "before:nx-mr-1 before:content-[''] before:nx-inline-block before:nx-transition-transform dark:before:nx-invert",
+        '[[data-expanded]>&]:before:nx-rotate-90 rtl:before:nx-rotate-180'
       )}
       {...props}
       onClick={e => {
@@ -227,7 +227,10 @@ export const getComponents = ({
   const context = { index: 0 }
   return {
     h1: (props: ComponentProps<'h1'>) => (
-      <h1 className="mt-2 text-4xl font-bold tracking-tight" {...props} />
+      <h1
+        className="nx-mt-2 nx-text-4xl nx-font-bold nx-tracking-tight"
+        {...props}
+      />
     ),
     h2: createHeaderLink('h2', context),
     h3: createHeaderLink('h3', context),
@@ -235,35 +238,44 @@ export const getComponents = ({
     h5: createHeaderLink('h5', context),
     h6: createHeaderLink('h6', context),
     ul: (props: ComponentProps<'ul'>) => (
-      <ul className="ltr:ml-6 rtl:mr-6 mt-6 list-disc first:mt-0" {...props} />
+      <ul
+        className="ltr:nx-ml-6 rtl:nx-mr-6 nx-mt-6 nx-list-disc first:nx-mt-0"
+        {...props}
+      />
     ),
     ol: (props: ComponentProps<'ol'>) => (
-      <ol className="ltr:ml-6 rtl:mr-6 mt-6 list-decimal" {...props} />
+      <ol
+        className="ltr:nx-ml-6 rtl:nx-mr-6 nx-mt-6 nx-list-decimal"
+        {...props}
+      />
     ),
-    li: (props: ComponentProps<'li'>) => <li className="my-2" {...props} />,
+    li: (props: ComponentProps<'li'>) => <li className="nx-my-2" {...props} />,
     blockquote: (props: ComponentProps<'blockquote'>) => (
       <blockquote
         className={cn(
-          'mt-6 first:mt-0 border-gray-300 italic text-gray-700 dark:border-gray-700 dark:text-gray-400',
-          'rtl:border-r-2 rtl:pr-6 ltr:border-l-2 ltr:pl-6'
+          'nx-mt-6 first:nx-mt-0 nx-border-gray-300 nx-italic nx-text-gray-700 dark:nx-border-gray-700 dark:nx-text-gray-400',
+          'rtl:nx-border-r-2 rtl:nx-pr-6 ltr:nx-border-l-2 ltr:nx-pl-6'
         )}
         {...props}
       />
     ),
     hr: (props: ComponentProps<'hr'>) => (
-      <hr className="my-8 dark:border-gray-900" {...props} />
+      <hr className="nx-my-8 dark:nx-border-gray-900" {...props} />
     ),
     a: props => (
       <A
         {...props}
-        className="text-primary-500 underline decoration-from-font [text-underline-position:under]"
+        className="nx-text-primary-500 nx-underline nx-decoration-from-font [text-underline-position:under]"
       />
     ),
     table: (props: ComponentProps<'table'>) => (
-      <Table className="nextra-scrollbar mt-6 first:mt-0 p-0" {...props} />
+      <Table
+        className="nextra-scrollbar nx-mt-6 first:nx-mt-0 nx-p-0"
+        {...props}
+      />
     ),
     p: (props: ComponentProps<'p'>) => (
-      <p className="mt-6 first:mt-0 leading-7" {...props} />
+      <p className="nx-mt-6 first:nx-mt-0 nx-leading-7" {...props} />
     ),
     tr: Tr,
     th: Th,

--- a/packages/nextra-theme-docs/tailwind.config.js
+++ b/packages/nextra-theme-docs/tailwind.config.js
@@ -72,5 +72,5 @@ module.exports = {
       }
     }
   },
-  darkMode: 'class'
+  darkMode: ['class', 'html[class~="dark"]']
 }

--- a/packages/nextra-theme-docs/tailwind.config.js
+++ b/packages/nextra-theme-docs/tailwind.config.js
@@ -10,6 +10,7 @@ const makePrimaryColor =
   }
 
 module.exports = {
+  prefix: 'nx-',
   content: [
     './src/**/*.tsx',
     '../nextra/src/icons/*.tsx',

--- a/packages/nextra/src/components/button.tsx
+++ b/packages/nextra/src/components/button.tsx
@@ -8,9 +8,9 @@ export const Button = ({
   return (
     <button
       className={[
-        'nextra-button transition-colors',
-        'bg-primary-700/5 border border-black/5 text-gray-600 hover:text-gray-900 rounded-md p-2',
-        'dark:bg-primary-300/10 dark:border-white/10 dark:text-gray-400 dark:hover:text-gray-50',
+        'nextra-button nx-transition-colors',
+        'nx-bg-primary-700/5 nx-border nx-border-black/5 nx-text-gray-600 hover:nx-text-gray-900 nx-rounded-md nx-p-2',
+        'dark:nx-bg-primary-300/10 dark:nx-border-white/10 dark:nx-text-gray-400 dark:hover:nx-text-gray-50',
         className
       ].join(' ')}
       {...props}

--- a/packages/nextra/src/components/code.tsx
+++ b/packages/nextra/src/components/code.tsx
@@ -9,8 +9,8 @@ export const Code = ({
   return (
     <code
       className={[
-        'border-black/5 bg-black/5 break-words rounded-md border py-0.5 px-[.25em] text-[.9em]',
-        'dark:border-white/10 dark:bg-white/10',
+        'nx-border-black/5 nx-bg-black/5 nx-break-words nx-rounded-md nx-border nx-py-0.5 nx-px-[.25em] nx-text-[.9em]',
+        'dark:nx-border-white/10 dark:nx-bg-white/10',
         hasLineNumbers ? '[counter-reset:line]' : '',
         className
       ].join(' ')}

--- a/packages/nextra/src/components/copy-to-clipboard.tsx
+++ b/packages/nextra/src/components/copy-to-clipboard.tsx
@@ -45,7 +45,7 @@ export const CopyToClipboard = ({
 
   return (
     <Button onClick={handleClick} title="Copy code" {...props}>
-      <IconToUse className="pointer-events-none h-4 w-4" />
+      <IconToUse className="nx-pointer-events-none nx-h-4 nx-w-4" />
     </Button>
   )
 }

--- a/packages/nextra/src/components/pre.tsx
+++ b/packages/nextra/src/components/pre.tsx
@@ -26,15 +26,15 @@ export const Pre = ({
   return (
     <>
       {filename && (
-        <div className="bg-primary-700/5 text-gray-700 absolute top-0 z-[1] w-full truncate rounded-t-xl py-2 px-4 text-xs dark:bg-primary-300/10 dark:text-gray-200">
+        <div className="nx-bg-primary-700/5 nx-text-gray-700 nx-absolute nx-top-0 nx-z-[1] nx-w-full nx-truncate nx-rounded-t-xl nx-py-2 nx-px-4 nx-text-xs dark:nx-bg-primary-300/10 dark:nx-text-gray-200">
           {filename}
         </div>
       )}
       <pre
         className={[
-          'bg-primary-700/5 mt-6 mb-4 overflow-x-auto rounded-xl font-medium subpixel-antialiased dark:bg-primary-300/10',
-          'contrast-more:border contrast-more:border-primary-900/20 contrast-more:contrast-150 contrast-more:dark:border-primary-100/40',
-          filename ? 'pt-12 pb-4' : 'py-4',
+          'nx-bg-primary-700/5 nx-mt-6 nx-mb-4 nx-overflow-x-auto nx-rounded-xl nx-font-medium nx-subpixel-antialiased dark:nx-bg-primary-300/10',
+          'contrast-more:nx-border contrast-more:nx-border-primary-900/20 contrast-more:nx-contrast-150 contrast-more:dark:nx-border-primary-100/40',
+          filename ? 'nx-pt-12 nx-pb-4' : 'nx-py-4',
           className
         ].join(' ')}
         {...props}
@@ -43,18 +43,18 @@ export const Pre = ({
       </pre>
       <div
         className={[
-          'opacity-0 transition-opacity [div:hover>&]:opacity-100',
-          'flex gap-1 absolute m-2 right-0',
-          filename ? 'top-8' : 'top-0'
+          'nx-opacity-0 nx-transition-opacity [div:hover>&]:nx-opacity-100',
+          'nx-flex nx-gap-1 nx-absolute nx-m-2 nx-right-0',
+          filename ? 'nx-top-8' : 'nx-top-0'
         ].join(' ')}
       >
         <Button
           tabIndex={-1}
           onClick={toggleWordWrap}
-          className="md:hidden"
+          className="md:nx-hidden"
           title="Toggle word wrap"
         >
-          <WordWrapIcon className="pointer-events-none w-4 h-4" />
+          <WordWrapIcon className="nx-pointer-events-none nx-w-4 nx-h-4" />
         </Button>
         {value && <CopyToClipboard tabIndex={-1} value={value} />}
       </div>

--- a/packages/nextra/src/components/td.tsx
+++ b/packages/nextra/src/components/td.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps } from 'react'
 
 export const Td = (props: ComponentProps<'td'>) => (
   <td
-    className="m-0 border border-gray-300 px-4 py-2 dark:border-gray-600"
+    className="nx-m-0 nx-border nx-border-gray-300 nx-px-4 nx-py-2 dark:nx-border-gray-600"
     {...props}
   />
 )

--- a/packages/nextra/styles/code-block.css
+++ b/packages/nextra/styles/code-block.css
@@ -3,22 +3,22 @@ code {
   font-feature-settings: 'rlig' 1, 'calt' 1, 'ss01' 1;
 
   &[data-line-numbers] > .line {
-    @apply inline-flex pl-2;
+    @apply nx-inline-flex nx-pl-2;
     &::before {
       counter-increment: line;
       content: counter(line);
-      @apply h-full float-left pr-4 text-right min-w-[2.6rem] text-gray-500;
+      @apply nx-h-full nx-float-left nx-pr-4 nx-text-right nx-min-w-[2.6rem] nx-text-gray-500;
     }
   }
 
   .line {
     &.highlighted {
-      @apply border-primary-600/60 bg-primary-600/10;
+      @apply nx-border-primary-600/60 nx-bg-primary-600/10;
     }
     .highlighted {
-      @apply rounded-sm shadow-[0_0_0_3px_rgba(0,0,0,.3)];
-      @apply bg-primary-800/10 shadow-primary-800/10;
-      @apply dark:bg-primary-300/10 dark:shadow-primary-300/10;
+      @apply nx-rounded-sm nx-shadow-[0_0_0_3px_rgba(0,0,0,.3)];
+      @apply nx-bg-primary-800/10 nx-shadow-primary-800/10;
+      @apply dark:nx-bg-primary-300/10 dark:nx-shadow-primary-300/10;
     }
   }
 }
@@ -27,29 +27,29 @@ pre {
   /* content-visibility: auto; */
   contain: paint;
   code {
-    @apply grid min-w-full rounded-none border-none !bg-transparent !p-0 text-sm leading-5 text-current dark:!bg-transparent;
+    @apply nx-grid nx-min-w-full nx-rounded-none nx-border-none !nx-bg-transparent !nx-p-0 nx-text-sm nx-leading-5 nx-text-current dark:!nx-bg-transparent;
     .line {
-      @apply border-l-2 border-transparent px-4;
+      @apply nx-border-l-2 nx-border-transparent nx-px-4;
     }
   }
 
   html[data-nextra-word-wrap] & {
     word-break: break-word;
-    @apply whitespace-pre-wrap md:whitespace-pre;
+    @apply nx-whitespace-pre-wrap md:nx-whitespace-pre;
     .line {
-      @apply inline-block;
+      @apply nx-inline-block;
     }
   }
 }
 
 [data-rehype-pretty-code-fragment] {
-  @apply relative;
+  @apply nx-relative;
 }
 
 @supports (
   (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
 ) {
   .nextra-button {
-    @apply backdrop-blur-md bg-opacity-[.85] dark:bg-opacity-80;
+    @apply nx-backdrop-blur-md nx-bg-opacity-[.85] dark:nx-bg-opacity-80;
   }
 }

--- a/packages/nextra/styles/subheading-anchor.css
+++ b/packages/nextra/styles/subheading-anchor.css
@@ -1,17 +1,17 @@
 .subheading-anchor {
-  @apply opacity-0 transition-opacity ltr:ml-1 rtl:mr-1;
+  @apply nx-opacity-0 nx-transition-opacity ltr:nx-ml-1 rtl:nx-mr-1;
 
   span:target + &,
   :hover > & {
-    @apply no-underline opacity-100;
+    @apply nx-no-underline nx-opacity-100;
   }
 
   &:after {
-    @apply content-['#'] px-1;
-    @apply text-gray-300 dark:text-neutral-700;
+    @apply nx-content-['#'] nx-px-1;
+    @apply nx-text-gray-300 dark:nx-text-neutral-700;
     span:target + & {
-      @apply text-gray-400;
-      @apply dark:text-neutral-500;
+      @apply nx-text-gray-400;
+      @apply dark:nx-text-neutral-500;
     }
   }
 }


### PR DESCRIPTION
We need to isolate these classnames in case the website itself also uses Tailwind.

~_Seems like dark + prefix doesn't always work: `dark:nx-shadow-[0_-12px_16px_#111]`_~ _changing to `darkMode: ['class', 'html[class~="dark"]']` fixes it, see https://github.com/tailwindlabs/tailwindcss/issues/5754_