### PR TITLE
Breaking: Deprecate `hidden` add new `display` option

### DIFF
--- a/.changeset/grumpy-coins-swim.md
+++ b/.changeset/grumpy-coins-swim.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+add new "display" property to \_meta

--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "Nextra",
     "type": "page",
-    "hidden": true,
+    "display": "hidden",,
     "theme": {
       "layout": "raw"
     }

--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "Nextra",
     "type": "page",
-    "display": "hidden",,
+    "display": "hidden",
     "theme": {
       "layout": "raw"
     }

--- a/examples/swr-site/pages/_meta.en-US.json
+++ b/examples/swr-site/pages/_meta.en-US.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "Introduction",
     "type": "page",
-    "hidden": true
+    "display": "hidden"
   },
   "docs": {
     "title": "Docs",

--- a/examples/swr-site/pages/_meta.es-ES.json
+++ b/examples/swr-site/pages/_meta.es-ES.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "Introducción",
     "type": "page",
-    "hidden": true
+    "display": "hidden"
   },
   "docs": {
     "title": "Docs",

--- a/examples/swr-site/pages/_meta.ja.json
+++ b/examples/swr-site/pages/_meta.ja.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "前書き",
     "type": "page",
-    "hidden": true
+    "display": "hidden"
   },
   "docs": {
     "title": "ドキュメント",

--- a/examples/swr-site/pages/_meta.ko.json
+++ b/examples/swr-site/pages/_meta.ko.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "소개",
     "type": "page",
-    "hidden": true
+    "display": "hidden"
   },
   "docs": {
     "title": "문서",

--- a/examples/swr-site/pages/_meta.ru.json
+++ b/examples/swr-site/pages/_meta.ru.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "Введение",
     "type": "page",
-    "hidden": true
+    "display": "hidden"
   },
   "docs": {
     "title": "Документация",

--- a/examples/swr-site/pages/_meta.zh-CN.json
+++ b/examples/swr-site/pages/_meta.zh-CN.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "简介",
     "type": "page",
-    "hidden": true
+    "display": "hidden"
   },
   "docs": {
     "title": "文档",

--- a/examples/swr-site/pages/about/_meta.en-US.json
+++ b/examples/swr-site/pages/about/_meta.en-US.json
@@ -4,7 +4,7 @@
   "a-page": {
     "title": "A Page",
     "type": "page",
-    "hidden": true,
+    "display": "hidden",,
     "theme": {
       "layout": "raw"
     }

--- a/examples/swr-site/pages/about/_meta.en-US.json
+++ b/examples/swr-site/pages/about/_meta.en-US.json
@@ -4,7 +4,7 @@
   "a-page": {
     "title": "A Page",
     "type": "page",
-    "display": "hidden",,
+    "display": "hidden",
     "theme": {
       "layout": "raw"
     }

--- a/examples/swr-site/pages/docs/_meta.en-US.json
+++ b/examples/swr-site/pages/docs/_meta.en-US.json
@@ -9,7 +9,7 @@
   "data-fetching": "Data Fetching",
   "error-handling": {
     "title": "Error Handling",
-    "hidden": true
+    "display": "hidden"
   },
   "revalidation": "Auto Revalidation",
   "conditional-fetching": "Conditional Data Fetching",

--- a/examples/swr-site/pages/docs/advanced/_meta.en-US.json
+++ b/examples/swr-site/pages/docs/advanced/_meta.en-US.json
@@ -5,7 +5,7 @@
     }
   },
   "--- yoo": {
-    "title": "Do Not Use!!",
+    "title": "Do Not Use",
     "type": "separator"
   },
   "more": "More: A Super Super Super Super Long Directory",

--- a/examples/swr-site/pages/docs/advanced/_meta.en-US.json
+++ b/examples/swr-site/pages/docs/advanced/_meta.en-US.json
@@ -5,7 +5,7 @@
     }
   },
   "--- yoo": {
-    "title": "Do Not Use",
+    "title": "Do Not Use!!",
     "type": "separator"
   },
   "more": "More: A Super Super Super Super Long Directory",

--- a/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
+++ b/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
@@ -1104,7 +1104,7 @@ exports[`normalize-page > en-US home 1`] = `
       "frontMatter": {
         "title": "React Hooks for Data Fetching",
       },
-      "display": "hidden",,
+      "display": "hidden",
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "index",
@@ -2768,7 +2768,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "frontMatter": {
         "title": "用于数据请求的 React Hooks 库",
       },
-      "display": "hidden",,
+      "display": "hidden",
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "index",

--- a/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
+++ b/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
@@ -379,6 +379,18 @@ exports[`normalize-page > en-US getting-started 1`] = `
   "activeType": "doc",
   "directories": [
     {
+      "frontMatter": {
+        "title": "React Hooks for Data Fetching",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "en-US",
+      "name": "index",
+      "route": "/",
+      "title": "Introduction",
+      "type": "nav",
+    },
+    {
       "children": [
         {
           "kind": "MdxPage",
@@ -641,6 +653,18 @@ exports[`normalize-page > en-US getting-started 1`] = `
   ],
   "docsDirectories": [],
   "flatDirectories": [
+    {
+      "frontMatter": {
+        "title": "React Hooks for Data Fetching",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "en-US",
+      "name": "index",
+      "route": "/",
+      "title": "Introduction",
+      "type": "nav",
+    },
     {
       "kind": "MdxPage",
       "locale": "en-US",
@@ -1104,7 +1128,7 @@ exports[`normalize-page > en-US home 1`] = `
       "frontMatter": {
         "title": "React Hooks for Data Fetching",
       },
-      "display": "hidden",
+      "hidden": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "index",
@@ -1127,6 +1151,18 @@ exports[`normalize-page > en-US home 1`] = `
   },
   "activeType": "nav",
   "directories": [
+    {
+      "frontMatter": {
+        "title": "React Hooks for Data Fetching",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "en-US",
+      "name": "index",
+      "route": "/",
+      "title": "Introduction",
+      "type": "nav",
+    },
     {
       "children": [
         {
@@ -1390,6 +1426,18 @@ exports[`normalize-page > en-US home 1`] = `
   ],
   "docsDirectories": [],
   "flatDirectories": [
+    {
+      "frontMatter": {
+        "title": "React Hooks for Data Fetching",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "en-US",
+      "name": "index",
+      "route": "/",
+      "title": "Introduction",
+      "type": "nav",
+    },
     {
       "kind": "MdxPage",
       "locale": "en-US",
@@ -2043,6 +2091,18 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
   "activeType": "doc",
   "directories": [
     {
+      "frontMatter": {
+        "title": "用于数据请求的 React Hooks 库",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "zh-CN",
+      "name": "index",
+      "route": "/",
+      "title": "简介",
+      "type": "nav",
+    },
+    {
       "children": [
         {
           "kind": "MdxPage",
@@ -2305,6 +2365,18 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
   ],
   "docsDirectories": [],
   "flatDirectories": [
+    {
+      "frontMatter": {
+        "title": "用于数据请求的 React Hooks 库",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "zh-CN",
+      "name": "index",
+      "route": "/",
+      "title": "简介",
+      "type": "nav",
+    },
     {
       "kind": "MdxPage",
       "locale": "zh-CN",
@@ -2768,7 +2840,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "frontMatter": {
         "title": "用于数据请求的 React Hooks 库",
       },
-      "display": "hidden",
+      "hidden": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "index",
@@ -2791,6 +2863,18 @@ exports[`normalize-page > zh-CN home 1`] = `
   },
   "activeType": "nav",
   "directories": [
+    {
+      "frontMatter": {
+        "title": "用于数据请求的 React Hooks 库",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "zh-CN",
+      "name": "index",
+      "route": "/",
+      "title": "简介",
+      "type": "nav",
+    },
     {
       "children": [
         {
@@ -3054,6 +3138,18 @@ exports[`normalize-page > zh-CN home 1`] = `
   ],
   "docsDirectories": [],
   "flatDirectories": [
+    {
+      "frontMatter": {
+        "title": "用于数据请求的 React Hooks 库",
+      },
+      "hidden": true,
+      "kind": "MdxPage",
+      "locale": "zh-CN",
+      "name": "index",
+      "route": "/",
+      "title": "简介",
+      "type": "nav",
+    },
     {
       "kind": "MdxPage",
       "locale": "zh-CN",

--- a/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
+++ b/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
@@ -1104,7 +1104,7 @@ exports[`normalize-page > en-US home 1`] = `
       "frontMatter": {
         "title": "React Hooks for Data Fetching",
       },
-      "hidden": true,
+      "display": "hidden",,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "index",
@@ -2768,7 +2768,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "frontMatter": {
         "title": "用于数据请求的 React Hooks 库",
       },
-      "hidden": true,
+      "display": "hidden",,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "index",

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -107,7 +107,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           </div>
         )}
         {items.map(pageOrMenu => {
-          if (pageOrMenu.hidden) return null
+          if (pageOrMenu.display === 'hidden') return null
 
           if (pageOrMenu.type === 'menu') {
             const menu = pageOrMenu as MenuItem

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -10,15 +10,7 @@ import cn from 'clsx'
 import { MDXProvider } from '@mdx-js/react'
 
 import './polyfill'
-import {
-  Head,
-  Navbar,
-  NavLinks,
-  Sidebar,
-  Breadcrumb,
-  Banner,
-  ThemeSwitch
-} from './components'
+import { Head, NavLinks, Sidebar, Breadcrumb, Banner } from './components'
 import { getComponents } from './mdx-components'
 import { ActiveAnchorProvider, ConfigProvider, useConfig } from './contexts'
 import { DEFAULT_LOCALE, IS_BROWSER } from './constants'

--- a/packages/nextra/__test__/__snapshots__/context.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/context.test.ts.snap
@@ -34,7 +34,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "en-US",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Introduction",
       "type": "page",
     },
@@ -48,7 +48,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "es-ES",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Introduction",
       "type": "page",
     },
@@ -62,7 +62,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ja",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Introduction",
       "type": "page",
     },
@@ -76,7 +76,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ko",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Introduction",
       "type": "page",
     },
@@ -90,7 +90,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ru",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Introduction",
       "type": "page",
     },
@@ -104,7 +104,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "zh-CN",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Introduction",
       "type": "page",
     },
@@ -333,7 +333,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "en-US",
         "meta": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -343,7 +343,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "es-ES",
         "meta": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -353,7 +353,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "ja",
         "meta": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -363,7 +363,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "ko",
         "meta": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -373,7 +373,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "ru",
         "meta": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -383,7 +383,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "zh-CN",
         "meta": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -1399,7 +1399,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "en-US",
         "meta": {
-          "display": "hidden",,
+          "display": "hidden",
           "theme": {
             "layout": "raw",
           },
@@ -2125,7 +2125,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "en-US",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2135,7 +2135,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "es-ES",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2145,7 +2145,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ja",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2155,7 +2155,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ko",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2165,7 +2165,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ru",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2175,7 +2175,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "zh-CN",
     "meta": {
-      "display": "hidden",,
+      "display": "hidden",
       "title": "Error Handling",
     },
     "name": "error-handling",

--- a/packages/nextra/__test__/__snapshots__/context.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/context.test.ts.snap
@@ -34,7 +34,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "en-US",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Introduction",
       "type": "page",
     },
@@ -48,7 +48,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "es-ES",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Introduction",
       "type": "page",
     },
@@ -62,7 +62,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ja",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Introduction",
       "type": "page",
     },
@@ -76,7 +76,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ko",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Introduction",
       "type": "page",
     },
@@ -90,7 +90,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ru",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Introduction",
       "type": "page",
     },
@@ -104,7 +104,7 @@ exports[`context > getAllPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "zh-CN",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Introduction",
       "type": "page",
     },
@@ -333,7 +333,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "en-US",
         "meta": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -343,7 +343,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "es-ES",
         "meta": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -353,7 +353,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "ja",
         "meta": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -363,7 +363,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "ko",
         "meta": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -373,7 +373,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "ru",
         "meta": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -383,7 +383,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "zh-CN",
         "meta": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "Error Handling",
         },
         "name": "error-handling",
@@ -1399,7 +1399,7 @@ exports[`context > getAllPages() > should work 1`] = `
         "kind": "MdxPage",
         "locale": "en-US",
         "meta": {
-          "hidden": true,
+          "display": "hidden",,
           "theme": {
             "layout": "raw",
           },
@@ -2125,7 +2125,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "en-US",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2135,7 +2135,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "es-ES",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2145,7 +2145,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ja",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2155,7 +2155,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ko",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2165,7 +2165,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "ru",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Error Handling",
     },
     "name": "error-handling",
@@ -2175,7 +2175,7 @@ exports[`context > getCurrentLevelPages() > should work 1`] = `
     "kind": "MdxPage",
     "locale": "zh-CN",
     "meta": {
-      "hidden": true,
+      "display": "hidden",,
       "title": "Error Handling",
     },
     "name": "error-handling",

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -75,7 +75,7 @@ exports[`Page Process > pageMap en-US 1`] = `
           "type": "page",
         },
         "index": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "Introduction",
           "type": "page",
         },
@@ -94,7 +94,7 @@ exports[`Page Process > pageMap en-US 1`] = `
         {
           "data": {
             "a-page": {
-              "hidden": true,
+              "display": "hidden",,
               "theme": {
                 "layout": "raw",
               },
@@ -205,7 +205,7 @@ exports[`Page Process > pageMap en-US 1`] = `
             "conditional-fetching": "Conditional Data Fetching",
             "data-fetching": "Data Fetching",
             "error-handling": {
-              "hidden": true,
+              "display": "hidden",,
               "title": "Error Handling",
             },
             "getting-started": "Getting Started",
@@ -592,7 +592,7 @@ exports[`Page Process > pageMap zh-CN 1`] = `
           "type": "page",
         },
         "index": {
-          "hidden": true,
+          "display": "hidden",,
           "title": "简介",
           "type": "page",
         },
@@ -605,7 +605,7 @@ exports[`Page Process > pageMap zh-CN 1`] = `
         {
           "data": {
             "a-page": {
-              "hidden": true,
+              "display": "hidden",,
               "theme": {
                 "layout": "raw",
               },

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -75,7 +75,7 @@ exports[`Page Process > pageMap en-US 1`] = `
           "type": "page",
         },
         "index": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "Introduction",
           "type": "page",
         },
@@ -94,7 +94,7 @@ exports[`Page Process > pageMap en-US 1`] = `
         {
           "data": {
             "a-page": {
-              "display": "hidden",,
+              "display": "hidden",
               "theme": {
                 "layout": "raw",
               },
@@ -205,7 +205,7 @@ exports[`Page Process > pageMap en-US 1`] = `
             "conditional-fetching": "Conditional Data Fetching",
             "data-fetching": "Data Fetching",
             "error-handling": {
-              "display": "hidden",,
+              "display": "hidden",
               "title": "Error Handling",
             },
             "getting-started": "Getting Started",
@@ -592,7 +592,7 @@ exports[`Page Process > pageMap zh-CN 1`] = `
           "type": "page",
         },
         "index": {
-          "display": "hidden",,
+          "display": "hidden",
           "title": "简介",
           "type": "page",
         },
@@ -605,7 +605,7 @@ exports[`Page Process > pageMap zh-CN 1`] = `
         {
           "data": {
             "a-page": {
-              "display": "hidden",,
+              "display": "hidden",
               "theme": {
                 "layout": "raw",
               },


### PR DESCRIPTION
This PR deprecates the `hidden: true` property in _meta, with a new option `display: 'normal' | 'hidden' | 'children'`, where `display: 'hidden'` is the same as `hidden: true`. And `display: 'children'` will make a `doc` directory hide itself, but put all its children in the current level.

This option allows us to put items inside directories in pages/, without affecting the sidebar structure.