### PR TITLE
Add correct aria values inside nav

### DIFF
--- a/.changeset/tall-shoes-perform.md
+++ b/.changeset/tall-shoes-perform.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+Add correct aria values inside nav

--- a/packages/nextra-theme-docs/src/components/anchor.tsx
+++ b/packages/nextra-theme-docs/src/components/anchor.tsx
@@ -21,7 +21,6 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(function (
         href={href}
         target="_blank"
         rel="noreferrer"
-        aria-selected={false}
         {...props}
       >
         {children}

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -157,7 +157,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
                 !isActive || page.newWindow ? classes.inactive : classes.active
               )}
               newWindow={page.newWindow}
-              aria-selected={!page.newWindow && isActive}
+              aria-current={!page.newWindow && isActive}
             >
               {page.title}
             </Anchor>


### PR DESCRIPTION
The goal is to use `aria-current` attribute so show only for the current selected element inside the nav, and avoid using `aria-selected` which is meant for `tablist` wrapper aria roles
Example:
```
<nav>
   <div aria-current="true">option1</div>
   <div>option2</div>
</nav>
```