### PR TITLE
Fix full docs directory list and active link

### DIFF
--- a/.changeset/young-jeans-know.md
+++ b/.changeset/young-jeans-know.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Fix full docs directory list and active link

--- a/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
+++ b/packages/nextra-theme-docs/__test__/__snapshots__/normalize-page.spec.ts.snap
@@ -35,6 +35,7 @@ exports[`normalize-page > /404 page 1`] = `
   ],
   "docsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "index",
       "route": "/",
@@ -42,6 +43,7 @@ exports[`normalize-page > /404 page 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "get-started",
       "route": "/get-started",
@@ -67,6 +69,7 @@ exports[`normalize-page > /404 page 1`] = `
   ],
   "flatDocsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "index",
       "route": "/",
@@ -74,6 +77,7 @@ exports[`normalize-page > /404 page 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "get-started",
       "route": "/get-started",
@@ -131,6 +135,7 @@ exports[`normalize-page > /500 page 1`] = `
   ],
   "docsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "index",
       "route": "/",
@@ -138,6 +143,7 @@ exports[`normalize-page > /500 page 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "get-started",
       "route": "/get-started",
@@ -163,6 +169,7 @@ exports[`normalize-page > /500 page 1`] = `
   ],
   "flatDocsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "index",
       "route": "/",
@@ -170,6 +177,7 @@ exports[`normalize-page > /500 page 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "name": "get-started",
       "route": "/get-started",
@@ -892,6 +900,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
   ],
   "flatDocsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "getting-started",
@@ -900,6 +909,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "options",
@@ -908,6 +918,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "global-configuration",
@@ -916,6 +927,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "data-fetching",
@@ -924,6 +936,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "error-handling",
@@ -932,6 +945,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "revalidation",
@@ -940,6 +954,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "conditional-fetching",
@@ -948,6 +963,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "arguments",
@@ -956,6 +972,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "mutation",
@@ -964,6 +981,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "pagination",
@@ -972,6 +990,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "prefetching",
@@ -980,6 +999,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "with-nextjs",
@@ -988,6 +1008,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "typescript",
@@ -996,6 +1017,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "suspense",
@@ -1004,6 +1026,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "middleware",
@@ -1012,6 +1035,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "cache",
@@ -1020,6 +1044,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "performance",
@@ -1028,6 +1053,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "react-native",
@@ -1036,6 +1062,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "change-log",
@@ -1048,6 +1075,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
         "full": true,
         "title": "Basic Usage",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "basic",
@@ -1060,6 +1088,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
         "full": true,
         "title": "Authentication",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "auth",
@@ -1072,6 +1101,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
         "full": true,
         "title": "Infinite Loading",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "infinite-loading",
@@ -1084,6 +1114,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
         "full": true,
         "title": "Error Handling",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "error-handling",
@@ -1096,6 +1127,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
         "full": true,
         "title": "Next.js SSR",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "ssr",
@@ -1108,6 +1140,7 @@ exports[`normalize-page > en-US getting-started 1`] = `
         "description": "Almost 2 years ago we open sourced SWR, the tiny data-fetching React library that people love. Today we are reaching another milestone: the 1.0 version of SWR.",
         "image": "https://assets.vercel.com/image/upload/v1630059453/swr/v1.png",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "swr-v1",
@@ -1665,6 +1698,7 @@ exports[`normalize-page > en-US home 1`] = `
   ],
   "flatDocsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "getting-started",
@@ -1673,6 +1707,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "options",
@@ -1681,6 +1716,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "global-configuration",
@@ -1689,6 +1725,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "data-fetching",
@@ -1697,6 +1734,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "error-handling",
@@ -1705,6 +1743,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "revalidation",
@@ -1713,6 +1752,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "conditional-fetching",
@@ -1721,6 +1761,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "arguments",
@@ -1729,6 +1770,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "mutation",
@@ -1737,6 +1779,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "pagination",
@@ -1745,6 +1788,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "prefetching",
@@ -1753,6 +1797,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "with-nextjs",
@@ -1761,6 +1806,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "typescript",
@@ -1769,6 +1815,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "suspense",
@@ -1777,6 +1824,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "middleware",
@@ -1785,6 +1833,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "cache",
@@ -1793,6 +1842,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "performance",
@@ -1801,6 +1851,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "react-native",
@@ -1809,6 +1860,7 @@ exports[`normalize-page > en-US home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "change-log",
@@ -1821,6 +1873,7 @@ exports[`normalize-page > en-US home 1`] = `
         "full": true,
         "title": "Basic Usage",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "basic",
@@ -1833,6 +1886,7 @@ exports[`normalize-page > en-US home 1`] = `
         "full": true,
         "title": "Authentication",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "auth",
@@ -1845,6 +1899,7 @@ exports[`normalize-page > en-US home 1`] = `
         "full": true,
         "title": "Infinite Loading",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "infinite-loading",
@@ -1857,6 +1912,7 @@ exports[`normalize-page > en-US home 1`] = `
         "full": true,
         "title": "Error Handling",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "error-handling",
@@ -1869,6 +1925,7 @@ exports[`normalize-page > en-US home 1`] = `
         "full": true,
         "title": "Next.js SSR",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "ssr",
@@ -1881,6 +1938,7 @@ exports[`normalize-page > en-US home 1`] = `
         "description": "Almost 2 years ago we open sourced SWR, the tiny data-fetching React library that people love. Today we are reaching another milestone: the 1.0 version of SWR.",
         "image": "https://assets.vercel.com/image/upload/v1630059453/swr/v1.png",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "swr-v1",
@@ -2604,6 +2662,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
   ],
   "flatDocsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "getting-started",
@@ -2612,6 +2671,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "options",
@@ -2620,6 +2680,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "global-configuration",
@@ -2628,6 +2689,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "data-fetching",
@@ -2636,6 +2698,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "error-handling",
@@ -2644,6 +2707,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "revalidation",
@@ -2652,6 +2716,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "conditional-fetching",
@@ -2660,6 +2725,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "arguments",
@@ -2668,6 +2734,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "mutation",
@@ -2676,6 +2743,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "pagination",
@@ -2684,6 +2752,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "prefetching",
@@ -2692,6 +2761,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "with-nextjs",
@@ -2700,6 +2770,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "typescript",
@@ -2708,6 +2779,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "suspense",
@@ -2716,6 +2788,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "middleware",
@@ -2724,6 +2797,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "cache",
@@ -2732,6 +2806,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "performance",
@@ -2740,6 +2815,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "react-native",
@@ -2748,6 +2824,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "change-log",
@@ -2760,6 +2837,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
         "full": true,
         "title": "基本用法",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "basic",
@@ -2772,6 +2850,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
         "full": true,
         "title": "身份验证",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "auth",
@@ -2784,6 +2863,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
         "full": true,
         "title": "无限加载",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "infinite-loading",
@@ -2796,6 +2876,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
         "full": true,
         "title": "错误处理",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "error-handling",
@@ -2808,6 +2889,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
         "full": true,
         "title": "Next.js SSR",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "ssr",
@@ -2820,6 +2902,7 @@ exports[`normalize-page > zh-CN getting-started 1`] = `
         "description": "大约两年前，我们开源了 SWR，大家喜爱的小型数据请求 React 库。今天，我们迎来了另一个里程碑：SWR 1.0 版本发布。",
         "image": "https://assets.vercel.com/image/upload/v1630059453/swr/v1.png",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "swr-v1",
@@ -3377,6 +3460,7 @@ exports[`normalize-page > zh-CN home 1`] = `
   ],
   "flatDocsDirectories": [
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "getting-started",
@@ -3385,6 +3469,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "options",
@@ -3393,6 +3478,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "global-configuration",
@@ -3401,6 +3487,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "data-fetching",
@@ -3409,6 +3496,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "error-handling",
@@ -3417,6 +3505,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "revalidation",
@@ -3425,6 +3514,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "conditional-fetching",
@@ -3433,6 +3523,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "arguments",
@@ -3441,6 +3532,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "mutation",
@@ -3449,6 +3541,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "pagination",
@@ -3457,6 +3550,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "prefetching",
@@ -3465,6 +3559,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "with-nextjs",
@@ -3473,6 +3568,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "typescript",
@@ -3481,6 +3577,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "suspense",
@@ -3489,6 +3586,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "middleware",
@@ -3497,6 +3595,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "cache",
@@ -3505,6 +3604,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "performance",
@@ -3513,6 +3613,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "react-native",
@@ -3521,6 +3622,7 @@ exports[`normalize-page > zh-CN home 1`] = `
       "type": "doc",
     },
     {
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "change-log",
@@ -3533,6 +3635,7 @@ exports[`normalize-page > zh-CN home 1`] = `
         "full": true,
         "title": "基本用法",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "basic",
@@ -3545,6 +3648,7 @@ exports[`normalize-page > zh-CN home 1`] = `
         "full": true,
         "title": "身份验证",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "auth",
@@ -3557,6 +3661,7 @@ exports[`normalize-page > zh-CN home 1`] = `
         "full": true,
         "title": "无限加载",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "infinite-loading",
@@ -3569,6 +3674,7 @@ exports[`normalize-page > zh-CN home 1`] = `
         "full": true,
         "title": "错误处理",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "error-handling",
@@ -3581,6 +3687,7 @@ exports[`normalize-page > zh-CN home 1`] = `
         "full": true,
         "title": "Next.js SSR",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "en-US",
       "name": "ssr",
@@ -3593,6 +3700,7 @@ exports[`normalize-page > zh-CN home 1`] = `
         "description": "大约两年前，我们开源了 SWR，大家喜爱的小型数据请求 React 库。今天，我们迎来了另一个里程碑：SWR 1.0 版本发布。",
         "image": "https://assets.vercel.com/image/upload/v1630059453/swr/v1.png",
       },
+      "isUnderCurrentDocsTree": true,
       "kind": "MdxPage",
       "locale": "zh-CN",
       "name": "swr-v1",

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -195,7 +195,10 @@ function File({
 }): ReactElement {
   const { asPath, locale = DEFAULT_LOCALE } = useRouter()
   const route = getFSRoute(asPath, locale)
-  const active = [route, route + '/'].includes(item.route + '/')
+
+  // It is possible that the item doesn't have any route - for example an extermal link.
+  const active = item.route && [route, route + '/'].includes(item.route + '/')
+
   const slugger = new Slugger()
   const activeAnchor = useActiveAnchor()
   const { setMenu } = useMenu()
@@ -261,18 +264,26 @@ interface MenuProps {
   anchors: string[]
   base?: string
   className?: string
+  onlyCurrentDocs?: boolean
 }
 
-function Menu({ directories, anchors, className }: MenuProps): ReactElement {
+function Menu({
+  directories,
+  anchors,
+  className,
+  onlyCurrentDocs
+}: MenuProps): ReactElement {
   return (
     <ul className={cn(classes.list, className)}>
       {directories.map(item =>
-        item.type === 'menu' ||
-        (item.children && (item.children.length || !item.withIndexPage)) ? (
-          <Folder key={item.name} item={item} anchors={anchors} />
-        ) : (
-          <File key={item.name} item={item} anchors={anchors} />
-        )
+        !onlyCurrentDocs || item.isUnderCurrentDocsTree ? (
+          item.type === 'menu' ||
+          (item.children && (item.children.length || !item.withIndexPage)) ? (
+            <Folder key={item.name} item={item} anchors={anchors} />
+          ) : (
+            <File key={item.name} item={item} anchors={anchors} />
+          )
+        ) : null
       )}
     </ul>
   )
@@ -395,6 +406,7 @@ export function Sidebar({
             // When the viewport size is larger than `md`, hide the anchors in
             // the sidebar when `floatTOC` is enabled.
             anchors={config.toc.float ? [] : anchors}
+            onlyCurrentDocs
           />
           <Menu
             className="md:nx-hidden"

--- a/packages/nextra-theme-docs/src/utils/normalize-pages.ts
+++ b/packages/nextra-theme-docs/src/utils/normalize-pages.ts
@@ -29,6 +29,7 @@ export interface Item extends MdxFile {
   display?: Display
   withIndexPage?: boolean
   theme?: PageTheme
+  isUnderCurrentDocsTree?: boolean
 }
 
 export interface PageItem extends MdxFile {
@@ -40,6 +41,7 @@ export interface PageItem extends MdxFile {
   firstChildRoute?: string
   display?: Display
   withIndexPage?: boolean
+  isUnderCurrentDocsTree?: boolean
 }
 
 export interface MenuItem extends MdxFile {
@@ -63,6 +65,7 @@ interface DocsItem extends MdxFile {
   children?: DocsItem[]
   firstChildRoute?: string
   withIndexPage?: boolean
+  isUnderCurrentDocsTree?: boolean
 }
 
 function findFirstRoute(items: DocsItem[]): string | undefined {
@@ -245,6 +248,8 @@ export function normalizePages({
     const docsItem: DocsItem = getItem()
     const pageItem: PageItem = getItem()
 
+    docsItem.isUnderCurrentDocsTree = isCurrentDocsTree
+
     // This item is currently active, we collect the active path etc.
     if (a.route === route) {
       activePath = [item]
@@ -262,9 +267,7 @@ export function normalizePages({
           break
         case 'doc':
           // Active in the docs tree
-          if (isCurrentDocsTree) {
-            activeIndex = flatDocsDirectories.length
-          }
+          activeIndex = flatDocsDirectories.length
       }
     }
     if (display === 'hidden' || CUSTOM_ERROR_PAGES.includes(a.route)) continue
@@ -316,15 +319,13 @@ export function normalizePages({
 
           break
         case 'doc':
-          if (isCurrentDocsTree) {
-            if (Array.isArray(docsItem.children)) {
-              docsItem.children.push(...normalizedChildren.docsDirectories)
-            }
-            // Itself is a doc page.
-            if (item.withIndexPage) {
-              if (display !== 'children') {
-                flatDocsDirectories.push(docsItem)
-              }
+          if (Array.isArray(docsItem.children)) {
+            docsItem.children.push(...normalizedChildren.docsDirectories)
+          }
+          // Itself is a doc page.
+          if (item.withIndexPage) {
+            if (display !== 'children') {
+              flatDocsDirectories.push(docsItem)
             }
           }
       }
@@ -342,9 +343,7 @@ export function normalizePages({
           topLevelNavbarItems.push(pageItem)
           break
         case 'doc':
-          if (isCurrentDocsTree) {
-            flatDocsDirectories.push(docsItem)
-          }
+          flatDocsDirectories.push(docsItem)
       }
     }
 
@@ -361,15 +360,11 @@ export function normalizePages({
     switch (type) {
       case 'page':
       case 'menu':
-        if (isCurrentDocsTree && underCurrentDocsRoot) {
-          docsDirectories.push(pageItem)
-        }
+        docsDirectories.push(pageItem)
         break
       case 'doc':
-        if (isCurrentDocsTree) {
-          if (display !== 'children') {
-            docsDirectories.push(docsItem)
-          }
+        if (display !== 'children') {
+          docsDirectories.push(docsItem)
         }
         break
       case 'separator':


### PR DESCRIPTION
If there are multiple docs trees, for the mobile menu we should display the full list (contains all docs trees) and for the sidebar we need to show only the current active one. To make the implementation easier, we always include the doc item in the list, but mark it with `isUnderCurrentDocsTree`. And when displaying it in the sidebar or mobile menu, we conditionally filter these out.

Another fix is to not show external items as active.