### PR TITLE
fix project/chat icon could appear without provided link

### DIFF
--- a/.changeset/metal-laws-joke.md
+++ b/.changeset/metal-laws-joke.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix project/chat icon could appear without provided link

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -177,10 +177,6 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           >
             {renderComponent(config.project.icon)}
           </Anchor>
-        ) : config.project.icon ? (
-          // if no project link is provided, but a component exists, render it
-          // to allow the client to render their own link
-          renderComponent(config.project.icon)
         ) : null}
 
         {config.chat.link ? (
@@ -191,10 +187,6 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           >
             {renderComponent(config.chat.icon)}
           </Anchor>
-        ) : config.chat.icon ? (
-          // if no chat link is provided, but a component exists, render it
-          // to allow the client to render their own link
-          renderComponent(config.chat.icon)
         ) : null}
 
         <button


### PR DESCRIPTION
I was discouraged by the appearance of the discord icon without specifying the discord link in `theme.config` 

Custom elements in NavBar should be added by this new option https://github.com/shuding/nextra/pull/907, current behaviour changed by @tknickman is confused

![image](https://user-images.githubusercontent.com/7361780/198419581-5cd670b6-3fa3-419e-8bdc-a744319b2c03.png)