### PR TITLE
Close selector bracket for compat with old Safari.

### DIFF
--- a/.changeset/tall-candles-brake.md
+++ b/.changeset/tall-candles-brake.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Close selector bracket for compat with old Safari.

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -49,7 +49,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
 
   useEffect(() => {
     if (!activeSlug) return
-    const anchor = tocRef.current?.querySelector(`li > a[href="#${activeSlug}"`)
+    const anchor = tocRef.current?.querySelector(`li > a[href="#${activeSlug}"]`)
 
     if (anchor) {
       scrollIntoView(anchor, {


### PR DESCRIPTION
In old Safari accidentally omitting this bracket will throw: `SyntaxError: The string did not match the expected pattern.`