### PR TITLE
[Docs] Fixing key name for footer content

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -467,7 +467,7 @@ You can add some simple content, such as copyright information to the default fo
 export default {
   footer: {
     text: <span>
-      MIT ${new Date().getFullYear()} © <a href="https://nextra.site" target="_blank">Nextra</a>.
+      MIT {new Date().getFullYear()} © <a href="https://nextra.site" target="_blank">Nextra</a>.
     </span>,
   }
 }

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -455,7 +455,7 @@ Show the last updated date of each page. It’s useful for showing the freshness
 The footer area of the website. You can either specify some content for the default footer, or fully customize it with a custom component.
 
 <OptionTable options={[
-  ['footer.content', 'React.ReactNode | React.FC', 'Content of the default footer component.'],
+  ['footer.text', 'React.ReactNode | React.FC', 'Content of the default footer component.'],
   ['footer.component', 'React.ReactNode | React.FC<{ menu: boolean }>', 'Customized footer component.'],
 ]}/>
 
@@ -466,7 +466,7 @@ You can add some simple content, such as copyright information to the default fo
 ```jsx
 export default {
   footer: {
-    content: <span>
+    text: <span>
       MIT ${new Date().getFullYear()} © <a href="https://nextra.site" target="_blank">Nextra</a>.
     </span>,
   }


### PR DESCRIPTION
The documentation uses `footer.content` while the actual code is using `footer.text`.

Here is the code reference:
https://github.com/shuding/nextra/blob/e1fc506a0bdf73fe9fcf679e3de39918697aa352/packages/nextra-theme-docs/src/components/footer.tsx#L28

---

I also noticed an extra `$` in the code example and I removed it, here is the code reference:
https://github.com/shuding/nextra/blob/73241b3fee58f0318e9349a5eb7650a7cd55a4e3/docs/pages/docs/docs-theme/theme-configuration.mdx?plain=1#L470