### PR TITLE
Fix built ins components link on docs theme page

### DIFF
--- a/docs/pages/docs/docs-theme.mdx
+++ b/docs/pages/docs/docs-theme.mdx
@@ -19,6 +19,6 @@ import { Card, Cards } from '@components/card'
   <Card icon={<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
   <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
 </svg>
-  } title="Built-in Components" href="/docs/docs-theme/components">
+  } title="Built-in Components" href="/docs/docs-theme/built-ins">
   </Card>
 </Cards>


### PR DESCRIPTION
How to reproduce ?
1. Go to https://nextra.site/docs/docs-theme
2. Click on Built-In Components
3. This going to redirect you to https://nextra.site/docs/docs-theme/components

In this pull request I simply fixed the link.