### PR TITLE
fix missing border in navbar

### DIFF
--- a/.changeset/odd-pants-grow.md
+++ b/.changeset/odd-pants-grow.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix missing border in navbar

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -95,7 +95,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         className={cn(
           'nextra-nav-container-blur',
           'nx-pointer-events-none nx-absolute nx-z-[-1] nx-h-full nx-w-full nx-bg-white dark:nx-bg-dark',
-          'nx-shadow-[0_2px_4px_rgba(0,0,0,.02),0_-1px_0_rgba(0,0,0,.06)] dark:nx-shadow-[0_-1px_0_rgba(255,255,255,.1)_inset]',
+          'nx-shadow-[0_2px_4px_rgba(0,0,0,.02),0_1px_0_rgba(0,0,0,.06)] dark:nx-shadow-[0_-1px_0_rgba(255,255,255,.1)_inset]',
           'contrast-more:nx-shadow-[0_0_0_1px_#000] contrast-more:dark:nx-shadow-[0_0_0_1px_#fff]'
         )}
       />

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -95,7 +95,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         className={cn(
           'nextra-nav-container-blur',
           'nx-pointer-events-none nx-absolute nx-z-[-1] nx-h-full nx-w-full nx-bg-white dark:nx-bg-dark',
-          'nx-shadow-[0_2px_4px_rgba(0,0,0,.02),0_-1px_0_rgba(0,0,0,.06)] dark:nx-shadow-[0_-1px_0_rgba(255,255,255,.1)]',
+          'nx-shadow-[0_2px_4px_rgba(0,0,0,.02),0_-1px_0_rgba(0,0,0,.06)] dark:nx-shadow-[0_-1px_0_rgba(255,255,255,.1)_inset]',
           'contrast-more:nx-shadow-[0_0_0_1px_#000] contrast-more:dark:nx-shadow-[0_0_0_1px_#fff]'
         )}
       />


### PR DESCRIPTION
@shuding on a dark theme we no longer need a border?

as border is missing on latest preview 
<img width="1563" alt="image" src="https://user-images.githubusercontent.com/7361780/206923338-3684025f-5dc5-434e-9738-e4f4bba215d4.png">
