### PR TITLE
fix(nav-links.tsx): fix word breaks and alignment in Safari

### DIFF
--- a/packages/nextra-theme-docs/src/components/nav-links.tsx
+++ b/packages/nextra-theme-docs/src/components/nav-links.tsx
@@ -13,7 +13,7 @@ interface NavLinkProps {
 
 const classes = {
   link: cn(
-    'nx-flex nx-grow nx-max-w-[50%] nx-items-center nx-gap-1 nx-py-4 nx-text-base nx-font-medium nx-text-gray-600 nx-transition-colors [word-break:break-word] hover:nx-text-primary-600 dark:nx-text-gray-300 md:nx-text-lg'
+    'nx-flex nx-max-w-[50%] nx-grow nx-items-center nx-gap-1 nx-py-4 nx-text-base nx-font-medium nx-text-gray-600 nx-transition-colors [word-break:break-word] hover:nx-text-primary-600 dark:nx-text-gray-300 md:nx-text-lg'
   ),
   icon: cn('nx-inline nx-h-5 nx-shrink-0')
 }
@@ -54,7 +54,7 @@ export const NavLinks = ({
           title={next.title}
           className={cn(
             classes.link,
-            'ltr:nx-ml-auto ltr:nx-pl-4 ltr:nx-justify-end rtl:nx-mr-auto rtl:nx-pr-4 rtl:nx-justify-start'
+            'ltr:nx-ml-auto ltr:nx-justify-end ltr:nx-pl-4 rtl:nx-mr-auto rtl:nx-justify-start rtl:nx-pr-4'
           )}
         >
           {next.title}

--- a/packages/nextra-theme-docs/src/components/nav-links.tsx
+++ b/packages/nextra-theme-docs/src/components/nav-links.tsx
@@ -13,7 +13,7 @@ interface NavLinkProps {
 
 const classes = {
   link: cn(
-    'nx-flex nx-flex-grow nx-max-w-[50%] nx-items-center nx-gap-1 nx-py-4 nx-text-base nx-font-medium nx-text-gray-600 nx-transition-colors [word-break:break-word] hover:nx-text-primary-600 dark:nx-text-gray-300 md:nx-text-lg'
+    'nx-flex nx-grow nx-max-w-[50%] nx-items-center nx-gap-1 nx-py-4 nx-text-base nx-font-medium nx-text-gray-600 nx-transition-colors [word-break:break-word] hover:nx-text-primary-600 dark:nx-text-gray-300 md:nx-text-lg'
   ),
   icon: cn('nx-inline nx-h-5 nx-shrink-0')
 }

--- a/packages/nextra-theme-docs/src/components/nav-links.tsx
+++ b/packages/nextra-theme-docs/src/components/nav-links.tsx
@@ -13,7 +13,7 @@ interface NavLinkProps {
 
 const classes = {
   link: cn(
-    'nx-flex nx-max-w-[50%] nx-items-center nx-gap-1 nx-py-4 nx-text-base nx-font-medium nx-text-gray-600 nx-transition-colors [word-break:break-word] hover:nx-text-primary-600 dark:nx-text-gray-300 md:nx-text-lg'
+    'nx-flex nx-flex-grow nx-max-w-[50%] nx-items-center nx-gap-1 nx-py-4 nx-text-base nx-font-medium nx-text-gray-600 nx-transition-colors [word-break:break-word] hover:nx-text-primary-600 dark:nx-text-gray-300 md:nx-text-lg'
   ),
   icon: cn('nx-inline nx-h-5 nx-shrink-0')
 }
@@ -54,7 +54,7 @@ export const NavLinks = ({
           title={next.title}
           className={cn(
             classes.link,
-            'ltr:nx-ml-auto ltr:nx-pl-4 ltr:nx-text-right rtl:nx-mr-auto rtl:nx-pr-4 rtl:nx-text-left'
+            'ltr:nx-ml-auto ltr:nx-pl-4 ltr:nx-justify-end rtl:nx-mr-auto rtl:nx-pr-4 rtl:nx-justify-start'
           )}
         >
           {next.title}


### PR DESCRIPTION
I might need some clarity on the intent of the ltr/rtl selectors, but this fixes an issue where the flex children do not grow in Safari, causing words to break in odd places.

Additionally, because the `<a>` elements have a `flex` display, `text-align` has no effect.

### Before

<img width="573" alt="Screen Shot 2022-12-19 at 9 39 42 AM" src="https://user-images.githubusercontent.com/86995/208451144-3818066b-430a-4f52-b87f-b8fd331e6d5d.png">

### After

<img width="573" alt="Screen Shot 2022-12-19 at 9 41 41 AM" src="https://user-images.githubusercontent.com/86995/208451113-073c9709-5834-47c6-b682-c2fba07e5fa6.png">
