### PR TITLE
Fixes dynamic head tags example

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -117,7 +117,7 @@ import { useConfig } from 'nextra-theme-docs'
 export default {
   head: () => {
     const { asPath } = useRouter()
-    const { frontMatter } = useConfig()
+    const frontMatter = useConfig()
     return <>
       <meta property="og:url" content={`https://my-app.com${asPath}`} />
       <meta property="og:title" content={frontMatter.title || 'Nextra'} />


### PR DESCRIPTION
While a key `frontMatter` does exist inside the object returned from `useConfig()`, the object is empty. The rest of the values we expect further in the example (like `frontMatter.title` and `frontMatter.description`) are present in the object returned from `useConfig()`. So we can do two things to improve this:

1. Not destructure and have `frontMatter` represent the values returned from `useConfig()` or

2. Destructure the values directly like so: `const { title, description } = useConfig()`