### PR TITLE
Simplify the theme layout interface

### DIFF
--- a/.changeset/pink-bears-smoke.md
+++ b/.changeset/pink-bears-smoke.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+simplify the custom theme layout api

--- a/packages/nextra-theme-blog/src/index.tsx
+++ b/packages/nextra-theme-blog/src/index.tsx
@@ -1,3 +1,5 @@
+import type { NextraThemeLayoutProps } from 'nextra'
+
 import React, { ReactElement, ReactNode } from 'react'
 import { ThemeProvider } from 'next-themes'
 import type { LayoutProps } from './types'
@@ -6,7 +8,6 @@ import { ArticleLayout } from './article-layout'
 import { PostsLayout } from './posts-layout'
 import { PageLayout } from './page-layout'
 import { DEFAULT_THEME } from './constants'
-import { usePageContext } from 'nextra/hooks'
 
 const layoutMap = {
   post: ArticleLayout,
@@ -34,14 +35,16 @@ const BlogLayout = ({
   )
 }
 
-export default function Layout(props: any) {
-  const context = usePageContext()
+export default function Layout({
+  children,
+  ...context
+}: NextraThemeLayoutProps) {
   const extendedConfig = { ...DEFAULT_THEME, ...context.themeConfig }
 
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <BlogLayout config={extendedConfig} opts={context.pageOpts}>
-        <context.Content {...props} />
+        {children}
       </BlogLayout>
     </ThemeProvider>
   )

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -1,4 +1,4 @@
-import type { PageMapItem, PageOpts } from 'nextra'
+import type { NextraThemeLayoutProps, PageMapItem, PageOpts } from 'nextra'
 import type { ReactElement, ReactNode } from 'react'
 
 import React, { useMemo } from 'react'
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import 'focus-visible'
 import cn from 'clsx'
 import { MDXProvider } from '@mdx-js/react'
-import { useMounted, usePageContext } from 'nextra/hooks'
+import { useMounted } from 'nextra/hooks'
 
 import './polyfill'
 import {
@@ -236,14 +236,13 @@ const InnerLayout = ({
   )
 }
 
-export default function Layout(props: any): ReactElement {
-  const context = usePageContext()
-  const { pageOpts, Content } = context
+export default function Layout({
+  children,
+  ...context
+}: NextraThemeLayoutProps): ReactElement {
   return (
     <ConfigProvider value={context}>
-      <InnerLayout {...pageOpts}>
-        <Content {...props} />
-      </InnerLayout>
+      <InnerLayout {...context.pageOpts}>{children}</InnerLayout>
     </ConfigProvider>
   )
 }

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -126,7 +126,6 @@ export type PageTheme = {
 }
 
 export type Context = {
-  Content: FC
   pageOpts: PageOpts
   themeConfig: DocsThemeConfig
 }

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -35,6 +35,9 @@
       ],
       "hooks": [
         "./dist/hooks/index.d.ts"
+      ],
+      "layout": [
+        "./dist/layout.d.ts"
       ]
     }
   },

--- a/packages/nextra/src/hooks/index.ts
+++ b/packages/nextra/src/hooks/index.ts
@@ -1,2 +1,1 @@
 export * from './use-mounted'
-export * from './use-page-context'

--- a/packages/nextra/src/layout.ts
+++ b/packages/nextra/src/layout.ts
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { SSGContext } from './ssg'
+import { useInternals } from './use-internals'
+
+export default function Nextra(props: any): React.ReactElement {
+  const { context, Layout } = useInternals()
+  const { Content } = context
+
+  return React.createElement(
+    Layout,
+    context,
+    React.createElement(
+      SSGContext.Provider,
+      {
+        value: props
+      },
+      React.createElement(Content, props)
+    )
+  )
+}

--- a/packages/nextra/src/layout.ts
+++ b/packages/nextra/src/layout.ts
@@ -5,11 +5,11 @@ import { useInternals } from './use-internals'
 
 export default function Nextra(props: any): React.ReactElement {
   const { context, Layout } = useInternals()
-  const { Content } = context
+  const { Content, ...restContext } = context
 
   return React.createElement(
     Layout,
-    context,
+    restContext,
     React.createElement(
       SSGContext.Provider,
       {

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -238,9 +238,9 @@ export default MDXContent`
   const stringifiedPageOpts = JSON.stringify(pageOpts)
   const pageOptsChecksum = !IS_PRODUCTION && hashFnv32a(stringifiedPageOpts)
 
-  return `import { SSGContext as __nextra_SSGContext__ } from 'nextra/ssg'
-${themeConfigImport}
+  return `${themeConfigImport}
 ${cssImport}
+import __nextra_layout__ from '${layout}'
 
 const __nextra_pageOpts__ = ${stringifiedPageOpts}
 
@@ -253,14 +253,9 @@ __nextra_internal__.pageMap = __nextra_pageOpts__.pageMap
 __nextra_internal__.route = __nextra_pageOpts__.route
 __nextra_internal__.context ||= Object.create(null)
 __nextra_internal__.refreshListeners ||= Object.create(null)
+__nextra_internal__.Layout = __nextra_layout__
 
 ${result}
-
-const Content = props => (
-  <__nextra_SSGContext__.Provider value={props}>
-    <MDXContent />
-  </__nextra_SSGContext__.Provider>
-)
 
 __nextra_pageOpts__.title =
   ${JSON.stringify(frontMatter.title)} ||
@@ -268,7 +263,7 @@ __nextra_pageOpts__.title =
   ${JSON.stringify(title /* Fallback as sidebar link name */)}
 
 __nextra_internal__.context[${stringifiedPageNextRoute}] = {
-  Content,
+  Content: MDXContent,
   pageOpts: __nextra_pageOpts__,
   themeConfig: ${themeConfigImport ? '__nextra_themeConfig__' : 'null'}
 }
@@ -284,7 +279,7 @@ if (${!IS_PRODUCTION} && module.hot) {
   })
 }
 
-export { default } from '${layout}'`
+export { default } from 'nextra/layout'`
 }
 
 export default function syncLoader(

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -109,7 +109,6 @@ const nextra: Nextra = () => () => ({})
 export default nextra
 
 export type NextraThemeLayoutProps = {
-  Content: React.FC
   pageOpts: PageOpts
   themeConfig: any | null
   children: React.ReactNode

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -107,3 +107,10 @@ export type Nextra = (
 const nextra: Nextra = () => () => ({})
 
 export default nextra
+
+export type NextraThemeLayoutProps = {
+  Content: React.FC
+  pageOpts: PageOpts
+  themeConfig: any | null
+  children: React.ReactNode
+}

--- a/packages/nextra/src/use-internals.ts
+++ b/packages/nextra/src/use-internals.ts
@@ -1,12 +1,16 @@
 import { useRouter } from 'next/router.js'
 import { useEffect, useState } from 'react'
 
-import { PageMapItem, PageOpts } from '../types'
-import { IS_PRODUCTION } from '../constants'
+import { PageMapItem, PageOpts } from './types'
+import { IS_PRODUCTION } from './constants'
 
 const NEXTRA_INTERNAL = Symbol.for('__nextra_internal__')
 
-export function usePageContext() {
+/**
+ * This hook is used to access the internal state of Nextra, you should never
+ * use this hook in your application.
+ */
+export function useInternals() {
   const __nextra_internal__ = (globalThis as any)[NEXTRA_INTERNAL] as {
     pageMap: PageMapItem[]
     route: string
@@ -19,6 +23,7 @@ export function usePageContext() {
       }
     >
     refreshListeners: Record<string, (() => void)[]>
+    Layout: React.FC<any>
   }
 
   const { route } = useRouter()
@@ -47,5 +52,8 @@ export function usePageContext() {
     )
   }
 
-  return context
+  return {
+    context,
+    Layout: __nextra_internal__.Layout
+  }
 }

--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -21,7 +21,8 @@ export default defineConfig([
       'src/components/index.ts',
       'src/ssg.ts',
       'src/locales.ts',
-      'src/context.ts'
+      'src/context.ts',
+      'src/layout.ts'
     ],
     format: 'esm',
     dts: true,


### PR DESCRIPTION
After #1144, I realized that we can simplify the theme layout component even further and get rid of the `usePageContext()` call (so it can be a 100% internal implementation detail).

With this change, the theme layout is just a component that receives the following props:
- `children`: The page content
- `pageOpts`: Related meta information for the current page
- `themeConfig`: The global theme configuration

Which is very straightforward and easy to understand. This will make custom theme easier to create too.

Another reason for this change is, in https://github.com/shuding/nextra/pull/1168/files#diff-8310a54b1ec9da38ed7c74e8c1328e33f07848d25bd9779811614642e3268747R247-R249 we are manipulating the page's props (received from SSG/SSR) and the `pageOpts` object. It would be great to move all these to an internal layer as we can have more changes like that in the future.