### PR TITLE
fix(theme-blog): `•` separator is missing if tags are empty

### DIFF
--- a/.changeset/spotty-planes-kick.md
+++ b/.changeset/spotty-planes-kick.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-blog': patch
+---
+
+`•` separator is missing if tags are empty

--- a/packages/nextra-theme-blog/src/meta.tsx
+++ b/packages/nextra-theme-blog/src/meta.tsx
@@ -53,7 +53,9 @@ export default function Meta(): ReactElement {
               {new Date(date).toDateString()}
             </time>
           )}
-          {(author || date) && tags.length > 0 && '  •  '}
+          {(author || date) && (readingTime || tags.length > 0) && (
+            <span className="nx-px-1">•</span>
+          )}
           {readingTime || tagsEl}
         </div>
         {readingTime && (


### PR DESCRIPTION
This PR fixes the missing `•` separator in meta heading when `readingTime` is enabled and tags are empty.

- Before
![image](https://user-images.githubusercontent.com/24727447/210556063-c85a2b30-1078-4475-8223-f78b8517549a.png)

- After
![image](https://user-images.githubusercontent.com/24727447/210556355-2b8a4b5f-9387-4a74-98a5-dc1ba0162238.png)

---

Also wrapped the separator in `<span className="nx-px-1">` to prevent uneven spacing when using monospace font like Fira Code.

- Before
![image](https://user-images.githubusercontent.com/24727447/210557734-ee972954-f6d4-42a8-ad9f-8e717c37e70e.png)

- After
![image](https://user-images.githubusercontent.com/24727447/210557889-73461e82-7f7f-4790-92d4-c5df595a5744.png)
