### PR TITLE
feat: add custom component configuration

### DIFF
--- a/examples/blog/theme.config.jsx
+++ b/examples/blog/theme.config.jsx
@@ -1,5 +1,18 @@
 /* eslint sort-keys: error */
 export default {
+  components: {
+    h1: ({ children }) => (
+      <h1 style={{
+        backgroundClip: 'text',
+        backgroundImage: 'linear-gradient(90deg,#7928CA,#FF0080);',
+        '-webkit-background-clip': 'text',
+        '-webkit-text-fill-color': 'transparent',
+      }}
+      >
+        {children}
+      </h1>
+    )
+  },
   darkMode: true,
   footer: (
     <small style={{ display: 'block', marginTop: '8rem' }}>
@@ -15,6 +28,7 @@ export default {
         a {
           float: right;
         }
+
         @media screen and (max-width: 480px) {
           article {
             padding-top: 2rem;

--- a/packages/nextra-theme-blog/src/mdx-theme.tsx
+++ b/packages/nextra-theme-blog/src/mdx-theme.tsx
@@ -66,26 +66,30 @@ const A = ({ children, ...props }: ComponentProps<'a'>) => {
   )
 }
 
-const components = {
-  h1: H1,
-  h2: createHeaderLink('h2'),
-  h3: createHeaderLink('h3'),
-  h4: createHeaderLink('h4'),
-  h5: createHeaderLink('h5'),
-  h6: createHeaderLink('h6'),
-  a: A,
-  pre: ({ children, ...props }: ComponentProps<'pre'>) => (
-    <div className="nx-not-prose">
-      <Pre {...props}>{children}</Pre>
-    </div>
-  ),
-  tr: Tr,
-  th: Th,
-  td: Td,
-  table: (props: ComponentProps<'table'>) => (
-    <Table className="nx-not-prose" {...props} />
-  ),
-  code: Code
+const getComponents = () => {
+  const { config } = useBlogContext();
+  return {
+    h1: H1,
+    h2: createHeaderLink('h2'),
+    h3: createHeaderLink('h3'),
+    h4: createHeaderLink('h4'),
+    h5: createHeaderLink('h5'),
+    h6: createHeaderLink('h6'),
+    a: A,
+    pre: ({ children, ...props }: ComponentProps<'pre'>) => (
+      <div className="nx-not-prose">
+        <Pre {...props}>{children}</Pre>
+      </div>
+    ),
+    tr: Tr,
+    th: Th,
+    td: Td,
+    table: (props: ComponentProps<'table'>) => (
+      <Table className="nx-not-prose" {...props} />
+    ),
+    code: Code,
+    ...config.components,
+  }
 }
 
 export const MDXTheme = ({
@@ -93,5 +97,5 @@ export const MDXTheme = ({
 }: {
   children: ReactNode
 }): ReactElement => {
-  return <MDXProvider components={components}>{children}</MDXProvider>
+  return <MDXProvider components={getComponents()}>{children}</MDXProvider>
 }

--- a/packages/nextra-theme-blog/src/types.ts
+++ b/packages/nextra-theme-blog/src/types.ts
@@ -1,9 +1,11 @@
 /* eslint typescript-sort-keys/interface: error */
 import { PageOpts } from 'nextra'
 import { ReactNode } from 'react'
+import { Components } from '@mdx-js/react/lib';
 
 export interface NextraBlogTheme {
   comments?: ReactNode
+  components?: Components;
   cusdis?: {
     appId: string
     host?: string


### PR DESCRIPTION
This adds functionality to allow for overriding the default MDX component configuration which makes the theme design more flexible.

As you can see, in `examples/blog/theme.config.jsx`, the `h1` element is overridden using a custom implementation.

#### Screenshot of example overriden H1 style:
<img width="882" alt="image" src="https://user-images.githubusercontent.com/17229444/211130720-12308c67-9935-4309-91bc-9259ea054d49.png">
