### PR TITLE
Allow to use MD (instead of MDX) syntax

### DIFF
--- a/.changeset/late-bears-explode.md
+++ b/.changeset/late-bears-explode.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+feat: allow to use plain md syntax

--- a/examples/swr-site/pages/test.en-US.md
+++ b/examples/swr-site/pages/test.en-US.md
@@ -1,0 +1,11 @@
+---
+mdxOptions: { format: "md" }
+---
+
+# Hello!
+
+This is a MD file instead of MDX, which means you can use syntax like this:
+
+<!-- this is a comment -->
+
+However, no JSX is allowed here.

--- a/packages/nextra/__test__/__snapshots__/context.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/context.test.ts.snap
@@ -1959,6 +1959,20 @@ exports[`context > getAllPages() > should work 1`] = `
     "name": "blog",
     "route": "/blog",
   },
+  {
+    "frontMatter": {
+      "mdxOptions": {
+        "format": "md",
+      },
+    },
+    "kind": "MdxPage",
+    "locale": "en-US",
+    "meta": {
+      "title": "Test",
+    },
+    "name": "test",
+    "route": "/test",
+  },
 ]
 `;
 

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -85,6 +85,7 @@ exports[`Page Process > pageMap en-US 1`] = `
           "title": "Nextra ↗",
           "type": "page",
         },
+        "test": "Test",
       },
       "kind": "Meta",
       "locale": "en-US",
@@ -610,6 +611,17 @@ exports[`Page Process > pageMap en-US 1`] = `
       "route": "/",
     },
     {
+      "frontMatter": {
+        "mdxOptions": {
+          "format": "md",
+        },
+      },
+      "kind": "MdxPage",
+      "locale": "en-US",
+      "name": "test",
+      "route": "/test",
+    },
+    {
       "data": {
         "404": "404",
         "500": "500",
@@ -1125,6 +1137,17 @@ exports[`Page Process > pageMap zh-CN 1`] = `
       "locale": "en-US",
       "name": "blog",
       "route": "/blog",
+    },
+    {
+      "frontMatter": {
+        "mdxOptions": {
+          "format": "md",
+        },
+      },
+      "kind": "MdxPage",
+      "locale": "en-US",
+      "name": "test",
+      "route": "/test",
     },
   ],
   "/docs/data-fetching",

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -92,10 +92,14 @@ export async function compileMdx(
     ]
   })
   try {
-    const vFile = await compiler.process({
-      value: source,
-      path: filePath
-    })
+    const vFile = await compiler.process(
+      filePath
+        ? {
+            value: source,
+            path: filePath
+          }
+        : source
+    )
     const result = String(vFile)
       .replace('export const __nextra_title__', 'const __nextra_title__')
       .replace('export default MDXContent;', '')

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -54,7 +54,7 @@ export async function compileMdx(
     | 'latex'
   > & {
     mdxOptions?: LoaderOptions['mdxOptions'] &
-      Pick<ProcessorOptions, 'jsx' | 'outputFormat'>
+      Pick<ProcessorOptions, 'jsx' | 'outputFormat' | 'format'>
   } = {},
   filePath = ''
 ) {
@@ -66,6 +66,7 @@ export async function compileMdx(
     jsx: mdxOptions.jsx || false,
     outputFormat: mdxOptions.outputFormat || 'function-body',
     providerImportSource: '@mdx-js/react',
+    format: mdxOptions.format || 'mdx',
     // https://github.com/hashicorp/next-mdx-remote/issues/307#issuecomment-1363415249
     development: false,
     remarkPlugins: [
@@ -91,7 +92,10 @@ export async function compileMdx(
     ]
   })
   try {
-    const vFile = await compiler.process(source)
+    const vFile = await compiler.process({
+      value: source,
+      path: filePath
+    })
     const result = String(vFile)
       .replace('export const __nextra_title__', 'const __nextra_title__')
       .replace('export default MDXContent;', '')

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -143,6 +143,8 @@ async function loader(
       {
         mdxOptions: {
           ...mdxOptions,
+          // You can override MDX options in the frontMatter too.
+          ...frontMatter.mdxOptions,
           jsx: true,
           outputFormat: 'program'
         },


### PR DESCRIPTION
Sometimes people want to only use standard Markdown files to build a simple page, if they don't need JSX at all. One difference between MD and MDX is that `<!-- comment -->` will be invalid in MDX.

Hence we are now accepting the `format` option for `mdxOptions`. It can be defined via both `next.config.js` globally or front matter on a per file basis.