### PR TITLE
fix: Errors during `collectFiles` should be thrown

### DIFF
--- a/.changeset/khaki-numbers-join.md
+++ b/.changeset/khaki-numbers-join.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+fix error was swallowed silently

--- a/packages/nextra/src/plugin.ts
+++ b/packages/nextra/src/plugin.ts
@@ -183,9 +183,13 @@ export class NextraPlugin {
           restoreCache(distDir)
         }
         const PAGES_DIR = findPagesDirectory()
-        const result = await collectFiles(PAGES_DIR)
-        pageMapCache.set(result)
-        callback()
+        try {
+          const result = await collectFiles(PAGES_DIR)
+          pageMapCache.set(result)
+          callback()
+        } catch (err) {
+          callback(err as Error)
+        }
       }
     )
   }


### PR DESCRIPTION
E.g. when there's an error accessing the file system, or parsing the front matter, by default it will be swallowed and Webpack will be just stuck silently.