### PR TITLE
Fix defaultMenuCollapseLevel

### DIFF
--- a/.changeset/lucky-dogs-act.md
+++ b/.changeset/lucky-dogs-act.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix defaultMenuCollapseLevel behavior

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -203,6 +203,7 @@ const config: DocsThemeConfig = {
     link: "https://github.com/vercel/swr",
   },
   sidebar: {
+    defaultMenuCollapseLevel: 1,
     titleComponent: ({ title, type }) =>
       type === "separator" ? (
         <div className="flex items-center gap-2">

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -38,7 +38,7 @@ const OnFocuseItemContext = createContext<
 >(null)
 const FolderLevelContext = createContext(0)
 
-const Folder = memo((props: any) => {
+const Folder = memo(function FolderInner(props: any) {
   const level = useContext(FolderLevelContext)
   return (
     <FolderLevelContext.Provider value={level + 1}>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -36,8 +36,16 @@ const FocusedItemContext = createContext<null | string>(null)
 const OnFocuseItemContext = createContext<
   null | ((item: string | null) => any)
 >(null)
+const FolderLevelContext = createContext(0)
 
-const Folder = memo(FolderImpl)
+const Folder = memo((props: any) => {
+  const level = useContext(FolderLevelContext)
+  return (
+    <FolderLevelContext.Provider value={level + 1}>
+      <FolderImpl {...props} />
+    </FolderLevelContext.Provider>
+  )
+})
 
 const classes = {
   link: cn(
@@ -77,9 +85,7 @@ function FolderImpl({
 
   const focusedRoute = useContext(FocusedItemContext)
   const focusedRouteInside = !!focusedRoute?.startsWith(item.route + '/')
-
-  // TODO: This is not always correct. Might be related to docs root.
-  const folderLevel = (item.route.match(/\//g) || []).length
+  const level = useContext(FolderLevelContext)
 
   const { setMenu } = useMenu()
   const config = useConfig()
@@ -92,7 +98,7 @@ function FolderImpl({
         focusedRouteInside ||
         (theme && 'collapsed' in theme
           ? !theme.collapsed
-          : folderLevel <= config.sidebar.defaultMenuCollapseLevel)
+          : level < config.sidebar.defaultMenuCollapseLevel)
 
   const rerender = useState({})[1]
 


### PR DESCRIPTION
Currently we determine the level based on the route, however that's not reliable at all as you can put the docs inside a subpath, hide some folders (via `display: 'children'` in meta), etc. This PR changes it to use the actual displayed folder depth via a context.