### PR TITLE
add support for remote [...catchAll] routes 

### DIFF
--- a/.changeset/stupid-glasses-serve.md
+++ b/.changeset/stupid-glasses-serve.md
@@ -1,0 +1,10 @@
+---
+'nextra': patch
+'nextra-theme-docs': patch
+---
+
+add support for remote `[...catchAll]` routes
+
+support meta keys with `/`
+
+sanitize remote mdx by removing `import` statements

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,7 @@ module.exports = {
         '@typescript-eslint/prefer-optional-chain': 'error',
         'no-else-return': ['error', { allowElseIf: false }],
         'no-lonely-if': 'error',
+        'prefer-destructuring': ['error', { VariableDeclarator: { object: true } }],
         // todo: enable
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',

--- a/examples/swr-site/components/remote-utils.js
+++ b/examples/swr-site/components/remote-utils.js
@@ -1,0 +1,51 @@
+/* eslint-disable */
+const path = require('path')
+const fs = require('fs')
+const git = require('isomorphic-git')
+const http = require('isomorphic-git/http/node')
+
+const CACHE_DIR = '.next/cache/nextra-remote/'
+
+async function listFiles({ repo, rootDir }) {
+  const dir = path.join(CACHE_DIR, repo.split('/').pop())
+  await git.clone({ fs, http, dir, url: repo })
+
+  const filenames = await git.listFiles({ fs, http, dir })
+  return filenames
+    .filter(filename => filename.startsWith(rootDir))
+    .map(filename => filename.replace(rootDir, ''))
+}
+
+async function findPathWithExtension({ repo, rootDir, slug }) {
+  if (slug === undefined) {
+    slug = ['index']
+  }
+  const dirs = slug.slice(0, -1)
+  const dirPath = path.join(CACHE_DIR, repo.split('/').pop(), rootDir, ...dirs)
+
+  const files = await fs.promises.readdir(dirPath, {
+    withFileTypes: true
+  })
+  const filename = slug.at(-1)
+  const matched = files.find(file => {
+    const { name, ext } = path.parse(file.name)
+    return file.isFile() && name === filename && /\.mdx?$/.test(ext)
+  })
+  return path.join(dirPath, matched?.name)
+}
+
+async function findStaticPaths({ repo, rootDir }) {
+  const filePaths = await listFiles({ repo, rootDir })
+  return filePaths
+    .filter(filename => /\.mdx?$/.test(filename))
+    .map(filename => ({
+      params: {
+        slug: filename
+          .replace(/\.mdx?$/, '')
+          // .replace(/(\/|^)index$/, '')
+          .split('/')
+      }
+    }))
+}
+
+module.exports = { listFiles, findPathWithExtension, findStaticPaths }

--- a/examples/swr-site/package.json
+++ b/examples/swr-site/package.json
@@ -14,9 +14,9 @@
   "dependencies": {
     "focus-visible": "^5.1.0",
     "intersection-observer": "^0.10.0",
+    "isomorphic-git": "1.21.0",
     "markdown-to-jsx": "^6.11.4",
     "next": ">=13",
-    "next-mdx-remote": "^4.2.0",
     "nextra": "workspace:*",
     "nextra-theme-docs": "workspace:*",
     "react": "*",
@@ -35,10 +35,6 @@
     "autoprefixer": "*",
     "postcss": "*",
     "tailwindcss": "*"
-  },
-  "prettier": {
-    "embeddedLanguageFormatting": "off",
-    "htmlWhitespaceSensitivity": "strict"
   },
   "version": null
 }

--- a/examples/swr-site/pages/remote/[slug].mdx
+++ b/examples/swr-site/pages/remote/[slug].mdx
@@ -4,44 +4,50 @@ import { RemoteContent } from 'nextra/data'
 export const getStaticProps = async ({ params }) => {
   const token = process.env.GITHUB_TEST_REMOTE_MDX
   const res = await fetch(
-    'https://api.github.com/gists/c204a2da82cd3ed8e676f35c493ab59f/comments/' + params.slug,
+    'https://api.github.com/gists/c204a2da82cd3ed8e676f35c493ab59f/comments/' +
+      params.slug,
     {
       headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
         ...(token && { Authorization: `Bearer ${token}` })
-      },
+      }
     }
-  );
-  const comment = await res.json();
+  )
+  const comment = await res.json()
   if (!comment.body) {
-    throw new Error(`Error while fetch data from GitHub.\n${JSON.stringify(comment, null, 4)}`)
+    throw new Error(
+      `Error while fetch data from GitHub.\n${JSON.stringify(comment, null, 4)}`
+    )
   }
   return {
     props: {
-      ...(await buildDynamicMDX(comment.body)),
+      ...(await buildDynamicMDX(comment.body, {
+        codeHighlight: true,
+        defaultShowCopyCode: true
+      })),
       ...(await buildDynamicMeta())
     },
-    revalidate: 10,
+    revalidate: 10
   }
 }
 
 export const getStaticPaths = async () => {
   const token = process.env.GITHUB_TEST_REMOTE_MDX
   const res = await fetch(
-    "https://api.github.com/gists/c204a2da82cd3ed8e676f35c493ab59f/comments",
+    'https://api.github.com/gists/c204a2da82cd3ed8e676f35c493ab59f/comments',
     {
       headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
         ...(token && { Authorization: `Bearer ${token}` })
-      },
+      }
     }
-  );
-  const comments = await res.json();
+  )
+  const comments = await res.json()
   return {
-    paths: comments.map((comment) => ({
-      params: { slug: String(comment.id) },
+    paths: comments.map(comment => ({
+      params: { slug: String(comment.id) }
     })),
     fallback: 'blocking'
   }

--- a/examples/swr-site/pages/remote/[slug].mdx
+++ b/examples/swr-site/pages/remote/[slug].mdx
@@ -23,7 +23,6 @@ export const getStaticProps = async ({ params }) => {
   return {
     props: {
       ...(await buildDynamicMDX(comment.body, {
-        codeHighlight: true,
         defaultShowCopyCode: true
       })),
       ...(await buildDynamicMeta())
@@ -45,6 +44,7 @@ export const getStaticPaths = async () => {
     }
   )
   const comments = await res.json()
+  console.log('getStaticPaths', comments)
   return {
     paths: comments.map(comment => ({
       params: { slug: String(comment.id) }

--- a/examples/swr-site/pages/remote/[slug].mdx
+++ b/examples/swr-site/pages/remote/[slug].mdx
@@ -44,7 +44,6 @@ export const getStaticPaths = async () => {
     }
   )
   const comments = await res.json()
-  console.log('getStaticPaths', comments)
   return {
     paths: comments.map(comment => ({
       params: { slug: String(comment.id) }

--- a/examples/swr-site/pages/remote/_meta.en-US.js
+++ b/examples/swr-site/pages/remote/_meta.en-US.js
@@ -13,7 +13,7 @@ module.exports = async () => {
     }
   );
   const comments = await res.json();
-
+  console.log('_meta.en-US.js', comments)
   return Object.fromEntries(
     comments.map((comment) => [
       comment.id,

--- a/examples/swr-site/pages/remote/_meta.en-US.js
+++ b/examples/swr-site/pages/remote/_meta.en-US.js
@@ -1,23 +1,19 @@
 /* eslint-disable */
 
 module.exports = async () => {
-  const token = process.env.GITHUB_TEST_REMOTE_MDX;
+  const token = process.env.GITHUB_TEST_REMOTE_MDX
   const res = await fetch(
-    "https://api.github.com/gists/c204a2da82cd3ed8e676f35c493ab59f/comments",
+    'https://api.github.com/gists/c204a2da82cd3ed8e676f35c493ab59f/comments',
     {
       headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        ...(token && { Authorization: `Bearer ${token}` }),
-      },
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(token && { Authorization: `Bearer ${token}` })
+      }
     }
-  );
-  const comments = await res.json();
-  console.log('_meta.en-US.js', comments)
+  )
+  const comments = await res.json()
   return Object.fromEntries(
-    comments.map((comment) => [
-      comment.id,
-      comment.user.login + "_" + comment.id,
-    ])
-  );
-};
+    comments.map(comment => [comment.id, comment.user.login + '_' + comment.id])
+  )
+}

--- a/examples/swr-site/pages/remote/graphql-eslint/[[...slug]].mdx
+++ b/examples/swr-site/pages/remote/graphql-eslint/[[...slug]].mdx
@@ -1,0 +1,44 @@
+import fs from 'fs/promises'
+import { buildDynamicMDX, buildDynamicMeta } from 'nextra/remote'
+import { RemoteContent } from 'nextra/data'
+import { Callout } from 'nextra-theme-docs'
+import {
+  findPathWithExtension,
+  findStaticPaths
+} from '@components/remote-utils'
+
+export const getStaticProps = async ({ params }) => {
+  const filePath = await findPathWithExtension({
+    repo: 'https://github.com/B2o5T/graphql-eslint',
+    rootDir: 'website/src/pages/docs/',
+    slug: params.slug
+  })
+
+  const content = await fs.readFile(filePath, 'utf8')
+  return {
+    props: {
+      ...(await buildDynamicMDX(content, {
+        codeHighlight: true,
+        defaultShowCopyCode: true,
+        remarkLinkRewriteOptions: {
+          pattern: /^\/docs(\/.*)?$/,
+          replace: '/docs/2.0.0$1'
+        }
+      })),
+      ...(await buildDynamicMeta())
+    },
+    revalidate: 10
+  }
+}
+
+export const getStaticPaths = async () => {
+  return {
+    paths: await findStaticPaths({
+      repo: 'https://github.com/B2o5T/graphql-eslint',
+      rootDir: 'website/src/pages/docs/'
+    }),
+    fallback: 'blocking'
+  }
+}
+
+<RemoteContent components={{ Callout, PackageCmd: () => null }} />

--- a/examples/swr-site/pages/remote/graphql-eslint/[[...slug]].mdx
+++ b/examples/swr-site/pages/remote/graphql-eslint/[[...slug]].mdx
@@ -18,7 +18,6 @@ export const getStaticProps = async ({ params }) => {
   return {
     props: {
       ...(await buildDynamicMDX(content, {
-        codeHighlight: true,
         defaultShowCopyCode: true,
         remarkLinkRewriteOptions: {
           pattern: /^\/docs(\/.*)?$/,

--- a/examples/swr-site/pages/remote/graphql-eslint/_meta.en-US.js
+++ b/examples/swr-site/pages/remote/graphql-eslint/_meta.en-US.js
@@ -10,7 +10,7 @@ module.exports = async () => {
   return createCatchAllMeta(
     // Ensure you didn't forget define some file by providing all paths of remote files
     files,
-    // Next you can override order of your meta files, folders should end with / and be nested
+    // Next you can override the order of your meta files, folders should have `type: 'folder'` and have `items` property
     {
       index: 'Introduction',
       'getting-started': {

--- a/examples/swr-site/pages/remote/graphql-eslint/_meta.en-US.js
+++ b/examples/swr-site/pages/remote/graphql-eslint/_meta.en-US.js
@@ -1,0 +1,25 @@
+/* eslint-env node */
+const { listFiles } = require('../../../components/remote-utils')
+const { createCatchAllMeta } = require('nextra/catch-all')
+
+module.exports = async () => {
+  const files = await listFiles({
+    repo: 'https://github.com/B2o5T/graphql-eslint',
+    rootDir: 'website/src/pages/docs/'
+  })
+  return createCatchAllMeta(
+    // Ensure you didn't forget define some file by providing all paths of remote files
+    files,
+    // Next you can override order of your meta files, folders should end with / and be nested
+    {
+      index: 'Introduction',
+      'getting-started': {
+        type: 'folder',
+        title: '🦄 GETTING Started',
+        items: {
+          parser: ''
+        }
+      }
+    }
+  )
+}

--- a/examples/swr-site/pages/remote/graphql-yoga/[[...slug]].mdx
+++ b/examples/swr-site/pages/remote/graphql-yoga/[[...slug]].mdx
@@ -1,0 +1,43 @@
+import fs from 'fs/promises'
+import { buildDynamicMDX, buildDynamicMeta } from 'nextra/remote'
+import { RemoteContent } from 'nextra/data'
+import { Callout, Tab, Tabs } from 'nextra-theme-docs'
+import {
+  findPathWithExtension,
+  findStaticPaths
+} from '@components/remote-utils'
+
+export const getStaticProps = async ({ params }) => {
+  const filePath = await findPathWithExtension({
+    repo: 'https://github.com/dotansimha/graphql-yoga',
+    rootDir: 'website/src/pages/docs/',
+    slug: params.slug
+  })
+  const content = await fs.readFile(filePath, 'utf8')
+  return {
+    props: {
+      ...(await buildDynamicMDX(content, {
+        codeHighlight: true,
+        defaultShowCopyCode: true,
+        remarkLinkRewriteOptions: {
+          pattern: /^\/docs(\/.*)?$/,
+          replace: '/docs/3.0.0$1'
+        }
+      })),
+      ...(await buildDynamicMeta())
+    },
+    revalidate: 10
+  }
+}
+
+export const getStaticPaths = async () => {
+  return {
+    paths: await findStaticPaths({
+      repo: 'https://github.com/dotansimha/graphql-yoga',
+      rootDir: 'website/src/pages/docs/'
+    }),
+    fallback: 'blocking'
+  }
+}
+
+<RemoteContent components={{ PackageCmd: () => null, Tab, Tabs, Callout }} />

--- a/examples/swr-site/pages/remote/graphql-yoga/[[...slug]].mdx
+++ b/examples/swr-site/pages/remote/graphql-yoga/[[...slug]].mdx
@@ -17,7 +17,6 @@ export const getStaticProps = async ({ params }) => {
   return {
     props: {
       ...(await buildDynamicMDX(content, {
-        codeHighlight: true,
         defaultShowCopyCode: true,
         remarkLinkRewriteOptions: {
           pattern: /^\/docs(\/.*)?$/,

--- a/examples/swr-site/pages/remote/graphql-yoga/_meta.en-US.js
+++ b/examples/swr-site/pages/remote/graphql-yoga/_meta.en-US.js
@@ -10,7 +10,7 @@ module.exports = async () => {
   return createCatchAllMeta(
     // Ensure you didn't forget define some file by providing all paths of remote files
     files,
-    // Next you can override order of your meta files, folders should end with / and be nested
+    // Next you can override the order of your meta files, folders should have `type: 'folder'` and have `items` property
     {
       index: 'Quick Start',
       features: {

--- a/examples/swr-site/pages/remote/graphql-yoga/_meta.en-US.js
+++ b/examples/swr-site/pages/remote/graphql-yoga/_meta.en-US.js
@@ -1,0 +1,50 @@
+/* eslint-env node */
+const { listFiles } = require('../../../components/remote-utils')
+const { createCatchAllMeta } = require('nextra/catch-all')
+
+module.exports = async () => {
+  const files = await listFiles({
+    repo: 'https://github.com/dotansimha/graphql-yoga',
+    rootDir: 'website/src/pages/docs/'
+  })
+  return createCatchAllMeta(
+    // Ensure you didn't forget define some file by providing all paths of remote files
+    files,
+    // Next you can override order of your meta files, folders should end with / and be nested
+    {
+      index: 'Quick Start',
+      features: {
+        title: '🚀 FeAtuReS',
+        type: 'folder',
+        items: {
+          schema: 'GraphQL Schema',
+          graphiql: 'GraphiQL',
+          context: 'GraphQL Context',
+          'error-masking': '',
+          introspection: '',
+          subscriptions: '',
+          'file-uploads': '',
+          'defer-stream': 'Defer and Stream',
+          'request-batching': '',
+          cors: 'CORS',
+          'csrf-prevention': 'CSRF Prevention',
+          'parsing-and-validation-caching': '',
+          'response-caching': '',
+          'persisted-operations': '',
+          'automatic-persisted-queries': '',
+          'logging-and-debugging': '',
+          'health-check': '',
+          'sofa-api': 'REST API',
+          'apollo-federation': '',
+          'envelop-plugins': 'Plugins'
+        }
+      },
+      integrations: {
+        type: 'folder'
+      },
+      migration: {
+        type: 'folder'
+      }
+    }
+  )
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "vitest": "^0.27.1",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
-      "@mdx-js/react": "^2.1.5",
+      "@mdx-js/react": "^2.2.1",
       "next-themes": "^0.2.1",
       "next": "^13.1.1",
       "@types/react": "^18.0.15",

--- a/packages/nextra-theme-docs/src/utils/get-fs-route.ts
+++ b/packages/nextra-theme-docs/src/utils/get-fs-route.ts
@@ -1,7 +1,7 @@
 const template = 'https://nextra.vercel.app'
 
-export const getFSRoute = (asPath: string, locale?: string | undefined) => {
-  const pathname = new URL(asPath, template).pathname
+export const getFSRoute = (asPath: string, locale?: string) => {
+  const { pathname } = new URL(asPath, template)
   const cleanedPath = locale
     ? pathname.replace(new RegExp(`\\.${locale}(\\/|$)`), '$1')
     : pathname

--- a/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`process heading > code-h1 1`] = `
+exports[`Process heading > code-h1 1`] = `
 {
   "frontMatter": {},
   "headings": [
@@ -31,7 +31,7 @@ export default MDXContent;
 }
 `;
 
-exports[`process heading > code-with-text-h1 1`] = `
+exports[`Process heading > code-with-text-h1 1`] = `
 {
   "frontMatter": {},
   "headings": [
@@ -62,7 +62,7 @@ export default MDXContent;
 }
 `;
 
-exports[`process heading > dynamic-h1 1`] = `
+exports[`Process heading > dynamic-h1 1`] = `
 {
   "frontMatter": {},
   "hasJsxInH1": true,
@@ -98,7 +98,7 @@ export default MDXContent;
 }
 `;
 
-exports[`process heading > no-h1 1`] = `
+exports[`Process heading > no-h1 1`] = `
 {
   "frontMatter": {},
   "headings": [
@@ -127,7 +127,7 @@ export default MDXContent;
 }
 `;
 
-exports[`process heading > static-h1 1`] = `
+exports[`Process heading > static-h1 1`] = `
 {
   "frontMatter": {},
   "headings": [

--- a/packages/nextra/__test__/__snapshots__/context.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/context.test.ts.snap
@@ -684,7 +684,22 @@ exports[`context > getAllPages() > should work 1`] = `
     "route": "/docs",
   },
   {
-    "children": [],
+    "children": [
+      {
+        "children": [],
+        "kind": "Folder",
+        "meta": undefined,
+        "name": "graphql-eslint",
+        "route": "/remote/graphql-eslint",
+      },
+      {
+        "children": [],
+        "kind": "Folder",
+        "meta": undefined,
+        "name": "graphql-yoga",
+        "route": "/remote/graphql-yoga",
+      },
+    ],
     "kind": "Folder",
     "meta": {
       "display": "children",

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -574,6 +574,30 @@ exports[`Page Process > pageMap en-US 1`] = `
           "kind": "Meta",
           "locale": "en-US",
         },
+        {
+          "children": [
+            {
+              "data": {},
+              "kind": "Meta",
+              "locale": "en-US",
+            },
+          ],
+          "kind": "Folder",
+          "name": "graphql-eslint",
+          "route": "/remote/graphql-eslint",
+        },
+        {
+          "children": [
+            {
+              "data": {},
+              "kind": "Meta",
+              "locale": "en-US",
+            },
+          ],
+          "kind": "Folder",
+          "name": "graphql-yoga",
+          "route": "/remote/graphql-yoga",
+        },
       ],
       "kind": "Folder",
       "name": "remote",
@@ -1042,6 +1066,30 @@ exports[`Page Process > pageMap ru 1`] = `
     },
     {
       "children": [
+        {
+          "children": [
+            {
+              "data": {},
+              "kind": "Meta",
+              "locale": "en-US",
+            },
+          ],
+          "kind": "Folder",
+          "name": "graphql-eslint",
+          "route": "/remote/graphql-eslint",
+        },
+        {
+          "children": [
+            {
+              "data": {},
+              "kind": "Meta",
+              "locale": "en-US",
+            },
+          ],
+          "kind": "Folder",
+          "name": "graphql-yoga",
+          "route": "/remote/graphql-yoga",
+        },
         {
           "data": {},
           "kind": "Meta",

--- a/packages/nextra/__test__/collect-catch-all.test.ts
+++ b/packages/nextra/__test__/collect-catch-all.test.ts
@@ -1,0 +1,140 @@
+import { collectCatchAllRoutes } from '../src/setup-page'
+import { describe, it, expect } from 'vitest'
+import { createCatchAllMeta } from '../src/catch-all'
+
+describe('collectCatchAllRoutes', () => {
+  it('should collect', () => {
+    const meta = {
+      kind: 'Meta' as const,
+      locale: 'en-US',
+      data: createCatchAllMeta([
+        'configs.md',
+        'custom-rules.md',
+        'getting-started.md',
+        'getting-started/parser-options.md',
+        'getting-started/parser.md',
+        'getting-started/third-level/foo.md',
+        'index.md'
+      ])
+    }
+    const parent = {
+      kind: 'Folder' as const,
+      name: 'nested',
+      route: '/remote/nested',
+      children: [
+        meta,
+        { kind: 'Meta', locale: 'es-ES', data: {} },
+        { kind: 'Meta', locale: 'ru', data: {} }
+      ]
+    }
+    collectCatchAllRoutes(parent, meta)
+    expect(parent).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "data": {
+              "configs": "Configs",
+              "custom-rules": "Custom Rules",
+              "getting-started": "Getting Started",
+              "index": "Index",
+            },
+            "kind": "Meta",
+            "locale": "en-US",
+          },
+          {
+            "data": {},
+            "kind": "Meta",
+            "locale": "es-ES",
+          },
+          {
+            "data": {},
+            "kind": "Meta",
+            "locale": "ru",
+          },
+          {
+            "kind": "MdxPage",
+            "locale": "en-US",
+            "name": "configs",
+            "route": "/remote/nested/configs",
+            "title": "Configs",
+          },
+          {
+            "kind": "MdxPage",
+            "locale": "en-US",
+            "name": "custom-rules",
+            "route": "/remote/nested/custom-rules",
+            "title": "Custom Rules",
+          },
+          {
+            "kind": "MdxPage",
+            "locale": "en-US",
+            "name": "getting-started",
+            "route": "/remote/nested/getting-started",
+            "title": "Getting Started",
+          },
+          {
+            "children": [
+              {
+                "data": {
+                  "parser": "Parser",
+                  "parser-options": "Parser Options",
+                  "third-level": "Third Level",
+                },
+                "kind": "Meta",
+                "locale": "en-US",
+              },
+              {
+                "kind": "MdxPage",
+                "locale": "en-US",
+                "name": "parser-options",
+                "route": "/remote/nested/getting-started/parser-options",
+                "title": "Parser Options",
+              },
+              {
+                "kind": "MdxPage",
+                "locale": "en-US",
+                "name": "parser",
+                "route": "/remote/nested/getting-started/parser",
+                "title": "Parser",
+              },
+              {
+                "children": [
+                  {
+                    "data": {
+                      "foo": "Foo",
+                    },
+                    "kind": "Meta",
+                    "locale": "en-US",
+                  },
+                  {
+                    "kind": "MdxPage",
+                    "locale": "en-US",
+                    "name": "foo",
+                    "route": "/remote/nested/getting-started/third-level/foo",
+                    "title": "Foo",
+                  },
+                ],
+                "kind": "Folder",
+                "name": "third-level",
+                "route": "/remote/nested/getting-started/third-level",
+              },
+            ],
+            "kind": "Folder",
+            "name": "getting-started",
+            "route": "/remote/nested/getting-started",
+          },
+          {
+            "kind": "MdxPage",
+            "locale": "en-US",
+            "name": "index",
+            "route": "/remote/nested",
+            "title": "Index",
+          },
+        ],
+        "kind": "Folder",
+        "name": "nested",
+        "route": "/remote/nested",
+      }
+    `)
+  })
+})

--- a/packages/nextra/__test__/compile.test.ts
+++ b/packages/nextra/__test__/compile.test.ts
@@ -21,7 +21,7 @@ const mdxOptions = {
   outputFormat: 'program' as const
 }
 
-describe('process heading', () => {
+describe('Process heading', () => {
   it('code-h1', async () => {
     const data = await loadFixture('code-h1.mdx')
     const result = await compileMdx(data, { mdxOptions })
@@ -47,93 +47,88 @@ describe('process heading', () => {
     const result = await compileMdx(data, { mdxOptions })
     expect(result).toMatchSnapshot()
   })
+})
 
-  describe('Code block', () => {
-    describe('Filename', () => {
-      it('attach with "codeHighlight: true" by default', async () => {
-        const { result } = await compileMdx('```js filename="test.js"\n```', {
-          mdxOptions
-        })
-        expect(result).toMatch(
-          '<_components.pre data-language="js" data-theme="default" filename="test.js">'
-        )
+describe('Code block', () => {
+  describe('Filename', () => {
+    it('attach with "codeHighlight: true" by default', async () => {
+      const { result } = await compileMdx('```js filename="test.js"\n```', {
+        mdxOptions
       })
-
-      it('attach with "codeHighlight: false"', async () => {
-        const { result } = await compileMdx('```js filename="test.js"\n```', {
-          mdxOptions,
-          codeHighlight: false
-        })
-        expect(result).toMatch('<_components.pre filename="test.js">')
-      })
-
-      it('not highlight filename as substring', async () => {
-        const { result } = await compileMdx(
-          '```js filename="/foo/"\nfoo\n```',
-          {
-            mdxOptions,
-            codeHighlight: true // processed only by rehype-pretty-code
-          }
-        )
-        expect(result).not.toMatch(
-          'className="highlighted">{"foo"}</_components.span>'
-        )
-        expect(result).toMatch('}}>{"foo"}</_components.span>')
-      })
+      expect(result).toMatch(
+        '<_components.pre data-language="js" data-theme="default" filename="test.js">'
+      )
     })
 
-    describe('Highlight', () => {
-      it('should support line highlights', async () => {
-        const { result } = await compileMdx(
-          '```js filename="test.js" {1}\n123\n```',
-          {
-            mdxOptions
-          }
-        )
-        expect(result).toMatch(
-          '<_components.span className="line highlighted">'
-        )
-      })
-    })
-
-    describe('Copy code button', () => {
-      for (const codeHighlight of [true, false]) {
-        describe(`codeHighlight: ${codeHighlight}`, () => {
-          it(`attach with "copy"`, async () => {
-            const { result } = await compileMdx('```js copy\n```', {
-              mdxOptions,
-              codeHighlight
-            })
-            expect(result).toMatch('hasCopyCode>')
-          })
-
-          it(`attach with "defaultShowCopyCode: true"`, async () => {
-            const { result } = await compileMdx('```js\n```', {
-              mdxOptions,
-              defaultShowCopyCode: true,
-              codeHighlight
-            })
-            expect(result).toMatch('hasCopyCode>')
-          })
-
-          it(`not attach with "defaultShowCopyCode: true" and "copy=false"`, async () => {
-            const { result } = await compileMdx('```js copy=false\n```', {
-              mdxOptions,
-              defaultShowCopyCode: true,
-              codeHighlight
-            })
-            expect(result).not.toMatch('hasCopyCode>')
-          })
-        })
-      }
-    })
-
-    it('code block without language has "text" language', async () => {
-      const { result } = await compileMdx('```\n```', {
+    it('attach with "codeHighlight: false"', async () => {
+      const { result } = await compileMdx('```js filename="test.js"\n```', {
         mdxOptions,
         codeHighlight: false
       })
-      expect(result).toMatch('<_components.code className="language-text" />')
+      expect(result).toMatch('<_components.pre filename="test.js">')
     })
+
+    it('not highlight filename as substring', async () => {
+      const { result } = await compileMdx('```js filename="/foo/"\nfoo\n```', {
+        mdxOptions,
+        codeHighlight: true // processed only by rehype-pretty-code
+      })
+      expect(result).not.toMatch(
+        'className="highlighted">{"foo"}</_components.span>'
+      )
+      expect(result).toMatch('}}>{"foo"}</_components.span>')
+    })
+  })
+
+  describe('Highlight', () => {
+    it('should support line highlights', async () => {
+      const { result } = await compileMdx(
+        '```js filename="test.js" {1}\n123\n```',
+        {
+          mdxOptions
+        }
+      )
+      expect(result).toMatch('<_components.span className="line highlighted">')
+    })
+  })
+
+  describe('Copy code button', () => {
+    for (const codeHighlight of [true, false]) {
+      describe(`codeHighlight: ${codeHighlight}`, () => {
+        it(`attach with "copy"`, async () => {
+          const { result } = await compileMdx('```js copy\n```', {
+            mdxOptions,
+            codeHighlight
+          })
+          expect(result).toMatch('hasCopyCode>')
+        })
+
+        it(`attach with "defaultShowCopyCode: true"`, async () => {
+          const { result } = await compileMdx('```js\n```', {
+            mdxOptions,
+            defaultShowCopyCode: true,
+            codeHighlight
+          })
+          expect(result).toMatch('hasCopyCode>')
+        })
+
+        it(`not attach with "defaultShowCopyCode: true" and "copy=false"`, async () => {
+          const { result } = await compileMdx('```js copy=false\n```', {
+            mdxOptions,
+            defaultShowCopyCode: true,
+            codeHighlight
+          })
+          expect(result).not.toMatch('hasCopyCode>')
+        })
+      })
+    }
+  })
+
+  it('code block without language has "text" language', async () => {
+    const { result } = await compileMdx('```\n```', {
+      mdxOptions,
+      codeHighlight: false
+    })
+    expect(result).toMatch('<_components.code className="language-text" />')
   })
 })

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -18,6 +18,9 @@
       "context": [
         "./dist/context.d.ts"
       ],
+      "catch-all": [
+        "./dist/catch-all.d.ts"
+      ],
       "data": [
         "./dist/ssg.d.ts"
       ],
@@ -53,6 +56,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": "./dist/index.js",
+    "./catch-all": "./dist/catch-all.js",
     "./data": {
       "import": "./dist/ssg.mjs",
       "types": "./dist/ssg.d.ts"
@@ -100,15 +104,15 @@
     "format": "prettier --ignore-path ../../.gitignore --write --list-different ."
   },
   "dependencies": {
-    "@mdx-js/mdx": "^2.1.5",
-    "@mdx-js/react": "^2.1.5",
+    "@mdx-js/mdx": "^2.2.1",
+    "@mdx-js/react": "^2.2.1",
     "@napi-rs/simple-git": "^0.1.8",
     "github-slugger": "^2.0.0",
     "graceful-fs": "^4.2.10",
     "gray-matter": "^4.0.3",
     "katex": "^0.16.4",
     "lodash.get": "^4.4.2",
-    "next-mdx-remote": "^4.2.0",
+    "next-mdx-remote": "^4.2.1",
     "p-limit": "^3.1.0",
     "rehype-katex": "^6.0.2",
     "rehype-pretty-code": "0.9.2",
@@ -118,6 +122,7 @@
     "shiki": "^0.12.1",
     "slash": "^3.0.0",
     "title": "^3.5.3",
+    "unist-util-remove": "^3.1.0",
     "unist-util-visit": "^4.1.1"
   },
   "peerDependencies": {

--- a/packages/nextra/src/catch-all.ts
+++ b/packages/nextra/src/catch-all.ts
@@ -1,0 +1,59 @@
+import { MARKDOWN_EXTENSION_REGEX } from './constants'
+
+type Folder = {
+  type: 'folder'
+  items: DynamicMeta
+  title?: string
+}
+
+type DynamicMeta = Record<string, string | Folder>
+
+function appendSlashForFolders(obj: DynamicMeta): DynamicMeta {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      const isFolder =
+        value && typeof value === 'object' && value.type === 'folder'
+      return isFolder ? [`${key}/`, value] : [key, value]
+    })
+  )
+}
+
+export function createCatchAllMeta(
+  filePaths: string[],
+  customMeta: DynamicMeta = Object.create(null)
+): DynamicMeta {
+  const metaMap: DynamicMeta = appendSlashForFolders(customMeta)
+
+  const paths = filePaths
+    .filter(filePath => MARKDOWN_EXTENSION_REGEX.test(filePath))
+    .map(filePath => filePath.replace(MARKDOWN_EXTENSION_REGEX, '').split('/'))
+
+  for (const path of paths) {
+    addToMap(metaMap, path)
+  }
+
+  function addToMap(meta: DynamicMeta, path: string[]) {
+    const isPage = path.length === 1
+    const [name, ...rest] = path
+    if (isPage) {
+      meta[name] ||= ''
+      return
+    }
+    meta[`${name}/`] ||= {} as Folder
+    const folder = meta[`${name}/`] as Folder
+    folder.items ||= {}
+
+    // fix conflicts when folder and folder with index page exists
+    if (Object.hasOwn(meta, name) && typeof folder.title === 'string') {
+      if (typeof meta[name] === 'string') {
+        meta[name] = folder.title
+      } else {
+        // @ts-expect-error fix Property 'title' does not exist on type 'string'.
+        meta[name].title = folder.title
+      }
+    }
+    addToMap(folder.items, rest)
+  }
+
+  return metaMap
+}

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -144,15 +144,14 @@ export async function compileMdx(
       rehypePlugins: [
         ...rehypePlugins,
         [parseMeta, { defaultShowCopyCode }],
-        codeHighlight === false
-          ? null
-          : ([
-              rehypePrettyCode,
-              {
-                ...DEFAULT_REHYPE_PRETTY_CODE_OPTIONS,
-                ...rehypePrettyCodeOptions
-              }
-            ] as any),
+        codeHighlight !== false &&
+          ([
+            rehypePrettyCode,
+            {
+              ...DEFAULT_REHYPE_PRETTY_CODE_OPTIONS,
+              ...rehypePrettyCodeOptions
+            }
+          ] as any),
         attachMeta,
         latex && rehypeKatex
       ].filter(truthy)

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -189,7 +189,7 @@ async function loader(
   if (searchIndexKey) {
     if (frontMatter.searchable !== false) {
       // Store all the things in buildInfo.
-      const buildInfo = (context._module as any).buildInfo
+      const { buildInfo } = context._module as any
       buildInfo.nextraSearch = {
         indexKey: searchIndexKey,
         title: fallbackTitle,

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -167,11 +167,6 @@ async function loader(
     }
   )
 
-  const katexCssImport = latex ? "import 'katex/dist/katex.min.css'" : ''
-  const cssImport = OFFICIAL_THEMES.includes(theme)
-    ? `import '${theme}/style.css'`
-    : ''
-
   // Imported as a normal component, no need to add the layout.
   if (!isPageImport) {
     return result
@@ -219,10 +214,6 @@ async function loader(
   // Relative path instead of a package name
   const layout = isLocalTheme ? path.resolve(theme) : theme
 
-  const themeConfigImport = themeConfig
-    ? `import __nextra_themeConfig from '${slash(path.resolve(themeConfig))}'`
-    : ''
-
   let pageOpts: PageOpts = {
     filePath: slash(path.relative(CWD, mdxPath)),
     route,
@@ -244,10 +235,16 @@ async function loader(
     pageOpts = transformPageOpts(pageOpts)
   }
 
+  const themeConfigImport = themeConfig
+    ? `import __nextra_themeConfig from '${slash(path.resolve(themeConfig))}'`
+    : ''
+  const katexCssImport = latex ? "import 'katex/dist/katex.min.css'" : ''
+  const cssImport = OFFICIAL_THEMES.includes(theme)
+    ? `import '${theme}/style.css'`
+    : ''
   const finalResult = transform
     ? await transform(result, { route: pageNextRoute })
     : result
-
   const stringifiedPageOpts = JSON.stringify(pageOpts)
 
   return `import { setupNextraPage } from 'nextra/setup-page'
@@ -262,12 +259,12 @@ ${finalResult.replace(
 )}
 
 setupNextraPage({
-  pageNextRoute: ${JSON.stringify(pageNextRoute)},
-  pageOpts: ${stringifiedPageOpts},
-  nextraLayout: __nextra_layout,
-  themeConfig: ${themeConfigImport ? '__nextra_themeConfig' : 'null'},
   Content: MDXContent,
+  nextraLayout: __nextra_layout,
   hot: module.hot,
+  pageOpts: ${stringifiedPageOpts},
+  themeConfig: ${themeConfigImport ? '__nextra_themeConfig' : 'null'},
+  pageNextRoute: ${JSON.stringify(pageNextRoute)},
   pageOptsChecksum: ${
     IS_PRODUCTION
       ? 'undefined'

--- a/packages/nextra/src/mdx-plugins/index.ts
+++ b/packages/nextra/src/mdx-plugins/index.ts
@@ -1,5 +1,10 @@
 export { parseMeta, attachMeta } from './rehype'
 export { remarkHeadings } from './remark-headings'
 export { remarkReplaceImports } from './remark-replace-imports'
+export { remarkRemoveImports } from './remark-remove-imports'
+export {
+  remarkLinkRewrite,
+  type RemarkLinkRewriteOptions
+} from './remark-link-rewrite'
 export { remarkStaticImage } from './static-image'
 export { structurize } from './structurize'

--- a/packages/nextra/src/mdx-plugins/remark-link-rewrite.ts
+++ b/packages/nextra/src/mdx-plugins/remark-link-rewrite.ts
@@ -1,0 +1,20 @@
+import { visit } from 'unist-util-visit'
+import { Plugin } from 'unified'
+import { Root } from 'mdast'
+
+export type RemarkLinkRewriteOptions = {
+  pattern: RegExp
+  replace: string
+}
+
+export const remarkLinkRewrite: Plugin<[RemarkLinkRewriteOptions], Root> = ({
+  pattern,
+  replace
+}) => {
+  return (tree, _file, done) => {
+    visit(tree, 'link', node => {
+      node.url = node.url.replace(pattern, replace)
+    })
+    done()
+  }
+}

--- a/packages/nextra/src/mdx-plugins/remark-remove-imports.ts
+++ b/packages/nextra/src/mdx-plugins/remark-remove-imports.ts
@@ -1,0 +1,10 @@
+import { remove } from 'unist-util-remove'
+import { Plugin } from 'unified'
+import { Root } from 'mdast'
+
+export const remarkRemoveImports: Plugin<[], Root> = () => {
+  return (tree, _file, done) => {
+    remove(tree, 'mdxjsEsm')
+    done()
+  }
+}

--- a/packages/nextra/src/plugin.ts
+++ b/packages/nextra/src/plugin.ts
@@ -11,9 +11,14 @@ import {
 } from './types'
 import fs from 'graceful-fs'
 import { promisify } from 'node:util'
-import { isSerializable, parseFileName, sortPages, truthy } from './utils'
+import {
+  isSerializable,
+  normalizePageRoute,
+  parseFileName,
+  sortPages,
+  truthy
+} from './utils'
 import path from 'node:path'
-import slash from 'slash'
 import grayMatter from 'gray-matter'
 import pLimit from 'p-limit'
 
@@ -62,7 +67,7 @@ export async function collectFiles(
       ? // directory couldn't have extensions
         { name: path.basename(filePath), locale: '', ext: '' }
       : parseFileName(filePath)
-    const fileRoute = slash(path.join(route, name.replace(/^index$/, '')))
+    const fileRoute = normalizePageRoute(route, name)
 
     if (isDirectory) {
       if (fileRoute === '/api') return

--- a/packages/nextra/src/setup-page.ts
+++ b/packages/nextra/src/setup-page.ts
@@ -10,7 +10,8 @@ import type {
   NextraInternalGlobal,
   PageOpts,
   ThemeConfig,
-  MetaJsonFile
+  MetaJsonFile,
+  PageMapItem
 } from './types'
 import { normalizePageRoute, pageTitleFromFilename } from './utils'
 
@@ -88,6 +89,8 @@ export function collectCatchAllRoutes(
   }
 }
 
+let cachedResolvedPageMap: PageMapItem[]
+
 export function setupNextraPage({
   pageNextRoute,
   pageOpts,
@@ -109,6 +112,9 @@ export function setupNextraPage({
 }) {
   if (typeof window === 'undefined') {
     globalThis.__nextra_resolvePageMap = async () => {
+      if (process.env.NODE_ENV === 'production' && cachedResolvedPageMap) {
+        return cachedResolvedPageMap
+      }
       const clonedPageMap = JSON.parse(JSON.stringify(pageOpts.pageMap))
 
       await Promise.all(
@@ -127,7 +133,7 @@ export function setupNextraPage({
           }
         )
       )
-      return clonedPageMap
+      return (cachedResolvedPageMap = clonedPageMap)
     }
   }
 

--- a/packages/nextra/src/ssg.tsx
+++ b/packages/nextra/src/ssg.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react'
 import { MDXRemote } from 'next-mdx-remote'
 
-import { useMDXComponents } from './mdx'
+import { useMDXComponents, Components } from './mdx'
 
 export const SSGContext = createContext<any>(false)
 export const useSSG = (key = 'ssg') => useContext(SSGContext)?.[key]
@@ -11,8 +11,13 @@ export const useSSG = (key = 'ssg') => useContext(SSGContext)?.[key]
 export const DataContext = SSGContext
 export const useData = useSSG
 
-export function RemoteContent() {
+export function RemoteContent({
+  components: dynamicComponents
+}: {
+  components: Components
+}) {
   const dynamicContext = useSSG('__nextra_dynamic_mdx')
+
   if (!dynamicContext) {
     throw new Error(
       'RemoteContent must be used together with the `buildDynamicMDX` API'
@@ -21,5 +26,10 @@ export function RemoteContent() {
 
   const components = useMDXComponents()
 
-  return <MDXRemote compiledSource={dynamicContext} components={components} />
+  return (
+    <MDXRemote
+      compiledSource={dynamicContext}
+      components={{ ...components, ...dynamicComponents }}
+    />
+  )
 }

--- a/packages/nextra/src/utils.ts
+++ b/packages/nextra/src/utils.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import title from 'title'
+import slash from 'slash'
 import { LOCALE_REGEX } from './constants'
 import { Folder, MdxFile, Meta } from './types'
 
@@ -26,6 +27,10 @@ export function truthy<T>(value: T): value is Truthy<T> {
 
 export function normalizeMeta(meta: Meta): Exclude<Meta, string> {
   return typeof meta === 'string' ? { title: meta } : meta
+}
+
+export function normalizePageRoute(parentRoute: string, route: string): string {
+  return slash(path.join(parentRoute, route.replace(/^index$/, '')))
 }
 
 export function pageTitleFromFilename(fileName: string) {

--- a/packages/nextra/tsconfig.json
+++ b/packages/nextra/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "allowJs": true,
     "jsx": "react-jsx",
+    "lib": ["es2022", "dom"],
     "moduleResolution": "node",
     "types": ["vitest/globals", "webpack-env"],
     "resolveJsonModule": true

--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -48,7 +48,7 @@ const esmOptions = defineConfig({
 export default defineConfig([
   {
     name: 'nextra',
-    entry: ['src/index.js', 'src/__temp__.js'],
+    entry: ['src/index.js', 'src/__temp__.js', 'src/catch-all.ts'],
     format: 'cjs',
     dts: false,
     target
@@ -59,7 +59,9 @@ export default defineConfig([
       'src/**/*.ts',
       'src/**/*.tsx',
       '!src/compile.ts',
-      '!src/mdx-plugins/remark-replace-imports.ts'
+      '!src/mdx-plugins/remark-replace-imports.ts',
+      '!src/**/*.d.ts',
+      '!src/catch-all.ts'
     ],
     ...esmOptions
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ overrides:
   vitest: ^0.27.1
   react: ^18.2.0
   react-dom: ^18.2.0
-  '@mdx-js/react': ^2.1.5
+  '@mdx-js/react': ^2.2.1
   next-themes: ^0.2.1
   next: ^13.1.1
   '@types/react': ^18.0.15
@@ -135,9 +135,9 @@ importers:
       autoprefixer: ^10.4.13
       focus-visible: ^5.1.0
       intersection-observer: ^0.10.0
+      isomorphic-git: 1.21.0
       markdown-to-jsx: ^6.11.4
       next: ^13.1.1
-      next-mdx-remote: ^4.2.0
       nextra: workspace:*
       nextra-theme-docs: workspace:*
       postcss: ^8.4.21
@@ -148,9 +148,9 @@ importers:
     dependencies:
       focus-visible: 5.2.0
       intersection-observer: 0.10.0
+      isomorphic-git: 1.21.0
       markdown-to-jsx: 6.11.4_react@18.2.0
       next: 13.1.1_biqbaboplfbrettd7655fr4n2y
-      next-mdx-remote: 4.2.0_biqbaboplfbrettd7655fr4n2y
       nextra: file:packages/nextra_q76c2b4vyoegvsbrcwkfvimnai
       nextra-theme-docs: file:packages/nextra-theme-docs_q76c2b4vyoegvsbrcwkfvimnai
       react: 18.2.0
@@ -168,8 +168,8 @@ importers:
 
   packages/nextra:
     specifiers:
-      '@mdx-js/mdx': ^2.1.5
-      '@mdx-js/react': ^2.1.5
+      '@mdx-js/mdx': ^2.2.1
+      '@mdx-js/react': ^2.2.1
       '@napi-rs/simple-git': ^0.1.8
       '@types/github-slugger': ^1.3.0
       '@types/graceful-fs': ^4.1.5
@@ -185,7 +185,7 @@ importers:
       katex: ^0.16.4
       lodash.get: ^4.4.2
       next: ^13.1.1
-      next-mdx-remote: ^4.2.0
+      next-mdx-remote: ^4.2.1
       p-limit: ^3.1.0
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -198,18 +198,19 @@ importers:
       slash: ^3.0.0
       title: ^3.5.3
       unified: ^10.1.2
+      unist-util-remove: ^3.1.0
       unist-util-visit: ^4.1.1
       vitest: ^0.27.1
     dependencies:
       '@mdx-js/mdx': 2.2.1
-      '@mdx-js/react': 2.1.5_react@18.2.0
+      '@mdx-js/react': 2.2.1_react@18.2.0
       '@napi-rs/simple-git': 0.1.8
       github-slugger: 2.0.0
       graceful-fs: 4.2.10
       gray-matter: 4.0.3
       katex: 0.16.4
       lodash.get: 4.4.2
-      next-mdx-remote: 4.2.0_biqbaboplfbrettd7655fr4n2y
+      next-mdx-remote: 4.2.1_biqbaboplfbrettd7655fr4n2y
       p-limit: 3.1.0
       rehype-katex: 6.0.2
       rehype-pretty-code: 0.9.2_shiki@0.12.1
@@ -219,6 +220,7 @@ importers:
       shiki: 0.12.1
       slash: 3.0.0
       title: 3.5.3
+      unist-util-remove: 3.1.0
       unist-util-visit: 4.1.1
     devDependencies:
       '@types/github-slugger': 1.3.0
@@ -535,19 +537,11 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/runtime/7.18.6:
-    resolution: {integrity: sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.9
-    dev: false
-
   /@babel/runtime/7.20.7:
     resolution: {integrity: sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: true
 
   /@babel/template/7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -1138,7 +1132,7 @@ packages:
       hast-util-to-estree: 2.0.2
       markdown-extensions: 1.1.1
       periscopic: 3.0.4
-      remark-mdx: 2.1.2
+      remark-mdx: 2.2.1
       remark-parse: 10.0.1
       remark-rehype: 10.1.0
       unified: 10.1.2
@@ -1152,6 +1146,16 @@ packages:
 
   /@mdx-js/react/2.1.5_react@18.2.0:
     resolution: {integrity: sha512-3Az1I6SAWA9R38rYjz5rXBrGKeZhq96CSSyQtqY+maPj8stBsoUH5pNcmIixuGkufYsh8F5+ka2CVPo2fycWZw==}
+    peerDependencies:
+      react: '>=16'
+    dependencies:
+      '@types/mdx': 2.0.2
+      '@types/react': 18.0.20
+      react: 18.2.0
+    dev: false
+
+  /@mdx-js/react/2.2.1_react@18.2.0:
+    resolution: {integrity: sha512-YdXcMcEnqZhzql98RNrqYo9cEhTTesBiCclEtoiQUbJwx87q9453GTapYU6kJ8ZZ2ek1Vp25SiAXEFy5O/eAPw==}
     peerDependencies:
       react: '>=16'
     dependencies:
@@ -2045,6 +2049,15 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.8.0
+    dev: true
+
+  /acorn-jsx/5.3.2_acorn@8.8.1:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.8.1
+    dev: false
 
   /acorn-node/1.8.2:
     resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
@@ -2074,12 +2087,12 @@ packages:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /acorn/8.8.1:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /ajv-keywords/3.5.2_ajv@6.12.6:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -2211,6 +2224,10 @@ packages:
   /astring/1.8.3:
     resolution: {integrity: sha512-sRpyiNrx2dEYIMmUXprS8nlpRg2Drs8m9ElX9vVEXaCB4XEAJhKfs7IcX0IwShjuOAjLR6wzIrgoptz1n19i1A==}
     hasBin: true
+    dev: false
+
+  /async-lock/1.4.0:
+    resolution: {integrity: sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==}
     dev: false
 
   /autoprefixer/10.4.13_postcss@8.4.21:
@@ -2441,6 +2458,10 @@ packages:
     resolution: {integrity: sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==}
     dev: true
 
+  /clean-git-ref/2.0.1:
+    resolution: {integrity: sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==}
+    dev: false
+
   /client-only/0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2547,6 +2568,12 @@ packages:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
     dev: true
 
+  /crc-32/1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+    dev: false
+
   /cross-spawn/5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
     dependencies:
@@ -2650,6 +2677,13 @@ packages:
       character-entities: 2.0.2
     dev: false
 
+  /decompress-response/6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      mimic-response: 3.1.0
+    dev: false
+
   /deep-eql/4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
@@ -2717,6 +2751,10 @@ packages:
   /diff/5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
+    dev: false
+
+  /diff3/0.0.3:
+    resolution: {integrity: sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==}
     dev: false
 
   /dir-glob/3.0.1:
@@ -3975,7 +4013,6 @@ packages:
   /ignore/5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
     engines: {node: '>= 4'}
-    dev: true
 
   /import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -4004,7 +4041,6 @@ packages:
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /inline-style-parser/0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
@@ -4252,6 +4288,24 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  /isomorphic-git/1.21.0:
+    resolution: {integrity: sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    dependencies:
+      async-lock: 1.4.0
+      clean-git-ref: 2.0.1
+      crc-32: 1.2.2
+      diff3: 0.0.3
+      ignore: 5.2.0
+      minimisted: 2.0.1
+      pako: 1.0.11
+      pify: 4.0.1
+      readable-stream: 3.6.0
+      sha.js: 2.4.11
+      simple-get: 4.0.1
+    dev: false
 
   /jest-worker/27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -4616,7 +4670,7 @@ packages:
   /match-sorter/6.3.1:
     resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
     dependencies:
-      '@babel/runtime': 7.18.6
+      '@babel/runtime': 7.20.7
       remove-accents: 0.4.2
     dev: false
 
@@ -4983,8 +5037,8 @@ packages:
   /micromark-extension-mdxjs/1.0.0:
     resolution: {integrity: sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==}
     dependencies:
-      acorn: 8.8.0
-      acorn-jsx: 5.3.2_acorn@8.8.0
+      acorn: 8.8.1
+      acorn-jsx: 5.3.2_acorn@8.8.1
       micromark-extension-mdx-expression: 1.0.3
       micromark-extension-mdx-jsx: 1.0.3
       micromark-extension-mdx-md: 1.0.0
@@ -5198,6 +5252,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /mimic-response/3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+    dev: false
+
   /min-indent/1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5220,7 +5279,12 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
-    dev: true
+
+  /minimisted/2.0.1:
+    resolution: {integrity: sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==}
+    dependencies:
+      minimist: 1.2.6
+    dev: false
 
   /mixme/0.5.4:
     resolution: {integrity: sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==}
@@ -5275,15 +5339,15 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next-mdx-remote/4.2.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-X5RhD7f7b78pH2abbuusObSGgII5l54OdusS/2iXljN7WN1cel6ToLlZeCZcyxx9cR4wmBGQYGongIttDYNmAA==}
+  /next-mdx-remote/4.2.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-PcVF1r5XTBjiNVXw0GyaIcOwQsklHo36+7ycfmtJb52TIkT0nM4Hzv4wgJwNg7+jvTbap99qWsMwdKUYR9WxAA==}
     engines: {node: '>=14', npm: '>=7'}
     peerDependencies:
       react: '>=16.x <=18.x'
       react-dom: '>=16.x <=18.x'
     dependencies:
       '@mdx-js/mdx': 2.2.1
-      '@mdx-js/react': 2.1.5_react@18.2.0
+      '@mdx-js/react': 2.2.1_react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       vfile: 5.3.4
@@ -5462,7 +5526,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -5540,6 +5603,10 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /pako/1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: false
 
   /parent-module/1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5655,7 +5722,6 @@ packages:
   /pify/4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
-    dev: true
 
   /pirates/4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
@@ -5988,6 +6054,15 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: false
+
   /readdirp/3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -6009,11 +6084,6 @@ packages:
 
   /regenerator-runtime/0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: true
-
-  /regenerator-runtime/0.13.9:
-    resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
-    dev: false
 
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
@@ -6094,8 +6164,8 @@ packages:
       unified: 10.1.2
     dev: false
 
-  /remark-mdx/2.1.2:
-    resolution: {integrity: sha512-npQagPdczPAv0xN9F8GSi5hJfAe/z6nBjylyfOfjLOmz086ahWrIjlk4BulRfNhA+asutqWxyuT3DFVsxiTVHA==}
+  /remark-mdx/2.2.1:
+    resolution: {integrity: sha512-R9wcN+/THRXTKyRBp6Npo/mcbGA2iT3N4G8qUqLA5pOEg7kBidHv8K2hHidCMYZ6DXmwK18umu0K4cicgA2PPQ==}
     dependencies:
       mdast-util-mdx: 2.0.0
       micromark-extension-mdxjs: 1.0.0
@@ -6219,7 +6289,6 @@ packages:
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
 
   /safe-regex-test/1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -6302,6 +6371,14 @@ packages:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: true
 
+  /sha.js/2.4.11:
+    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+    hasBin: true
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
+
   /shebang-command/1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
     engines: {node: '>=0.10.0'}
@@ -6350,6 +6427,18 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  /simple-concat/1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+    dev: false
+
+  /simple-get/4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    dev: false
 
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -6504,6 +6593,12 @@ packages:
       define-properties: 1.1.4
       es-abstract: 1.21.1
     dev: true
+
+  /string_decoder/1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /stringify-entities/4.0.3:
     resolution: {integrity: sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==}
@@ -7043,6 +7138,14 @@ packages:
       unist-util-visit: 4.1.1
     dev: false
 
+  /unist-util-remove/3.1.0:
+    resolution: {integrity: sha512-rO/sIghl13eN8irs5OBN2a4RC10MsJdiePCfwrvnzGtgIbHcDXr2REr0qi9F2r/CIb1r9FyyFmcMRIGs+EyUFw==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 5.1.1
+      unist-util-visit-parents: 5.1.1
+    dev: false
+
   /unist-util-stringify-position/3.0.2:
     resolution: {integrity: sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==}
     dependencies:
@@ -7111,7 +7214,6 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
 
   /uvu/0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -7431,7 +7533,6 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -7589,7 +7690,7 @@ packages:
       react-dom: '>=16.13.1'
     dependencies:
       '@mdx-js/mdx': 2.2.1
-      '@mdx-js/react': 2.1.5_react@18.2.0
+      '@mdx-js/react': 2.2.1_react@18.2.0
       '@napi-rs/simple-git': 0.1.8
       github-slugger: 2.0.0
       graceful-fs: 4.2.10
@@ -7597,7 +7698,7 @@ packages:
       katex: 0.16.4
       lodash.get: 4.4.2
       next: 13.1.1_biqbaboplfbrettd7655fr4n2y
-      next-mdx-remote: 4.2.0_biqbaboplfbrettd7655fr4n2y
+      next-mdx-remote: 4.2.1_biqbaboplfbrettd7655fr4n2y
       p-limit: 3.1.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -7610,6 +7711,7 @@ packages:
       shiki: 0.12.1
       slash: 3.0.0
       title: 3.5.3
+      unist-util-remove: 3.1.0
       unist-util-visit: 4.1.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
how look like catch all routes for `graphql-eslint` repository fetched from git

<img width="1563" alt="image" src="https://user-images.githubusercontent.com/7361780/213346987-a5978c0f-2f69-4d8b-8d51-666e7717c667.png">

- [x] add support for remote `[...catchAll]` routes
- [x] sanitize remote mdx by removing `import` statements 
- [x] test `collectCatchAll` that adds to pageMap meta files and mdx pages 
- [x] fix hydration error
   for some reason remote mdx wrapped with `<p/>`
<img width="704" alt="image" src="https://user-images.githubusercontent.com/7361780/213063162-a7bd1972-96a8-42b6-b639-8da772c07d67.png">

> was caused by extra semi 

![image](https://user-images.githubusercontent.com/7361780/213327620-d32975e3-9990-4a1e-8b97-864ef51ce993.png)
- [x] be capable provide missing components .`<RemoteContent />` now accept `components` props
- [x] be capable provide `codeHighlight: true` and `defaultShowCopyCode: true` while compiling remote mdx
- [x] be capable auto-generate meta links for sidebar from dynamic `_meta` file with `createCatchAllMeta()`
- [x] be capable of simple reordering above 👆 
- [x] be capable override internal URLs e.g. `[hello](/docs/foo)` => `[hello](/docs/v2/foo)` in remote mdx content
- [x] folder renaming works for both folders with/without index page
- [x] better folder structure
```json
{
  "$YOUR_FOLDER_NAME": {
    "type": "folder",
    "title":  "$YOUR_NEW_FOLDER_TITLE",
    "items": {
      "$NESTED_PAGE": "$NESTED_PAGE_TITLE"
    }
  }
}
```  

- [ ] <s>support meta keys with `/` </s> ❗️this no longer needed