### PR TITLE
feat: Add `search.useResultModifier` support

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -251,6 +251,7 @@ Check out [Page Configuration](/docs/docs-theme/page-configuration#navbar-items)
   ['search.emptyResult', 'React.ReactNode | React.FC', 'Not found text'],
   ['search.loading', 'string | (() => string)', 'Loading text'],
   ['search.placeholder', 'string | (() => string)', 'Placeholder text'],
+  ['search.useResultModifier', '() => (r: SearchResult[]) => SearchResult[]', 'Custom function to sort or filter the search results']
 ]}/>
 
 ### Banner

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -60,6 +60,12 @@ const FOOTER_LINK_TEXT = {
   ),
 };
 
+// A custom ranking implementation, that "options" will always be before "getting started".
+const rank = {
+  "/docs/options": 2,
+  "/docs/getting-started": 1,
+};
+
 const config: DocsThemeConfig = {
   banner: {
     key: "swr-2",
@@ -72,6 +78,20 @@ const config: DocsThemeConfig = {
     text: function useText() {
       const { locale } = useRouter();
       return EDIT_TEXT[locale];
+    },
+  },
+  search: {
+    useResultModifier: () => {
+      return (results) => {
+        results.sort((a, b) => {
+          const [route1] = a.url.split("#");
+          const [route2] = b.url.split("#");
+          const rank1 = rank[route1] || 0;
+          const rank2 = rank[route2] || 0;
+          return rank1 - rank2;
+        });
+        return results;
+      };
     },
   },
   feedback: {

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -30,6 +30,9 @@ type SearchProps = {
 
 const INPUTS = ['input', 'select', 'button', 'textarea']
 
+const isMac =
+  typeof navigator !== 'undefined' && navigator.userAgent.includes('Macintosh')
+
 export function Search({
   className,
   overlayClassName,
@@ -125,7 +128,7 @@ export function Search({
         case 'Enter': {
           const result = results[active]
           if (result) {
-            void router.push(result.route)
+            void router.push(result.url)
             finishSearch()
           }
           break
@@ -173,7 +176,7 @@ export function Search({
         {value
           ? 'ESC'
           : mounted &&
-            (navigator.userAgent.includes('Macintosh') ? (
+            (isMac ? (
               <>
                 <span className="nx-text-xs">⌘</span>K
               </>
@@ -238,7 +241,7 @@ export function Search({
               {renderString(config.search.loading)}
             </span>
           ) : results.length > 0 ? (
-            results.map(({ route, prefix, children, id }, i) => (
+            results.map(({ url, prefix, children, id }, i) => (
               <Fragment key={id}>
                 {prefix}
                 <li
@@ -252,7 +255,7 @@ export function Search({
                 >
                   <Anchor
                     className="nx-block nx-scroll-m-12 nx-px-2.5 nx-py-2"
-                    href={route}
+                    href={url}
                     data-index={i}
                     onFocus={handleActive}
                     onMouseMove={handleActive}

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -1,6 +1,6 @@
 /* eslint sort-keys: error */
 import { isValidElement, FC, ReactNode } from 'react'
-import { PageTheme } from './types'
+import { PageTheme, SearchResult } from './types'
 import { useRouter } from 'next/router'
 import { Anchor, Flexsearch, Footer, Navbar, TOC } from './components'
 import { DiscordIcon, GitHubIcon } from 'nextra/icons'
@@ -124,7 +124,10 @@ export const themeSchema = z
       emptyResult: z.custom<ReactNode | FC>(...reactNode),
       loading: z.string().or(z.function().returns(z.string())),
       // Can't be React component
-      placeholder: z.string().or(z.function().returns(z.string()))
+      placeholder: z.string().or(z.function().returns(z.string())),
+      useResultModifier: z
+        .function()
+        .returns(z.custom<(v: SearchResult[]) => SearchResult[]>())
     }),
     serverSideError: z.object({
       content: z.custom<ReactNode | FC>(...reactNode),
@@ -289,6 +292,9 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       if (locale === 'ru') return 'Поиск документации…'
       if (locale === 'fr') return 'Rechercher de la documentation…'
       return 'Search documentation…'
+    },
+    useResultModifier: function useResultModifier() {
+      return (v: SearchResult[]) => v
     }
   },
   serverSideError: {

--- a/packages/nextra-theme-docs/src/types.ts
+++ b/packages/nextra-theme-docs/src/types.ts
@@ -25,5 +25,5 @@ export type SearchResult = {
   children: ReactNode
   id: string
   prefix?: ReactNode
-  route: string
+  url: string
 }

--- a/packages/nextra/src/constants.ts
+++ b/packages/nextra/src/constants.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { NextraConfig } from './types'
+import type { NextraConfig } from './types'
 
 export const MARKDOWN_EXTENSION_REGEX = /\.mdx?$/
 

--- a/packages/nextra/src/setup-page.ts
+++ b/packages/nextra/src/setup-page.ts
@@ -3,15 +3,16 @@
  * This file should be never used directly, only in loader.ts
  */
 
-import { FC } from 'react'
-import get from 'lodash.get'
-import { NEXTRA_INTERNAL } from './constants'
-import {
+import type { FC } from 'react'
+import type {
   DynamicMetaDescriptor,
   NextraInternalGlobal,
   PageOpts,
   ThemeConfig
 } from './types'
+
+import get from 'lodash.get'
+import { NEXTRA_INTERNAL } from './constants'
 
 /**
  * Calculate a 32 bit FNV-1a hash


### PR DESCRIPTION
Although we can improve our search algorithm, it might still be helpful to make it customizable. Keeping this a draft as I'm not convinced yet...

It's interesting that due to our multi-index implementation and the natural of doc sites, we can just collect the full content and then do search on either a server or on the client completely (will make it configurable in the future, or automatically). I don't see a bottleneck in the near future (1mb gzipped index is a lot, probably can fit 5,000~10,000 pages). And if that becomes the bottleneck some day, we can find a way to convert them into vectors instead.

Ref: list of libraries that we can take a look:
- https://github.com/lithammer/fuzzysearch
- https://github.com/facebookresearch/faiss 
- https://github.com/leeoniya/uFuzzy
- https://github.com/nextapps-de/flexsearch
- https://github.com/EthanRutherford/fast-fuzzy
- https://github.com/LyraSearch/lyra