### PR TITLE
chore: Fix dev errors

### DIFF
--- a/.changeset/tender-plants-greet.md
+++ b/.changeset/tender-plants-greet.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+disable code splitting and fix dev errors

--- a/packages/nextra/src/__temp__.js
+++ b/packages/nextra/src/__temp__.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/ban-ts-comment */
-
 // This file has to be targeted to CJS, to keep `require.resolve` untranspiled.
 // Otherwise, the file tracing will not work.
 
@@ -8,6 +6,5 @@ const path = require('path')
 
 // https://github.com/shuding/nextra/pull/1168#issuecomment-1374960179
 // Make sure to include all languages in the bundle when tracing dependencies.
-// @ts-ignore
 const shikiPath = require.resolve('shiki/package.json')
 fs.readdir(path.join(shikiPath, '..', 'languages'), () => null)

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -20,7 +20,6 @@ import rehypeKatex from 'rehype-katex'
 import { CODE_BLOCK_FILENAME_REGEX, DEFAULT_LOCALE } from './constants'
 
 globalThis.__nextra_temp_do_not_use = () => {
-  // @ts-expect-error -- ignore error - File is not a module
   import('./__temp__')
 }
 

--- a/packages/nextra/src/mdx-plugins/rehype.ts
+++ b/packages/nextra/src/mdx-plugins/rehype.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import Slugger from 'github-slugger'
 import { getFlattenedValue } from './remark-headings'
 import { CODE_BLOCK_FILENAME_REGEX } from '../constants'

--- a/packages/nextra/src/mdx-plugins/structurize.ts
+++ b/packages/nextra/src/mdx-plugins/structurize.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import Slugger from 'github-slugger'
 
 function cleanup(content) {

--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'tsup'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
 import tsconfig from './tsconfig.json'
 
 const { target } = tsconfig.compilerOptions
@@ -13,24 +16,41 @@ export default defineConfig([
   },
   {
     name: 'nextra-esm',
-    entry: [
-      'src/hooks/index.ts',
-      'src/loader.ts',
-      'src/compile.ts',
-      'src/icons/index.ts',
-      'src/components/index.ts',
-      'src/ssg.tsx',
-      'src/locales.ts',
-      'src/context.ts',
-      'src/layout.tsx',
-      'src/setup-page.ts',
-      'src/remote.ts',
-      'src/mdx.ts'
-    ],
+    entry: ['src/**/*.ts', 'src/**/*.tsx'],
     format: 'esm',
     dts: true,
     target,
-    external: ['shiki', './__temp__']
+    bundle: true,
+    splitting: false,
+    external: ['shiki', './__temp__', 'webpack'],
+    esbuildPlugins: [
+      // https://github.com/evanw/esbuild/issues/622#issuecomment-769462611
+      {
+        name: 'add-mjs',
+        setup(build) {
+          build.onResolve({ filter: /.*/ }, async args => {
+            if (
+              args.importer &&
+              args.path.startsWith('.') &&
+              !args.path.endsWith('.json')
+            ) {
+              let isDir = false
+              try {
+                isDir = (
+                  await fs.stat(path.join(args.resolveDir, args.path))
+                ).isDirectory()
+              } catch {}
+
+              if (isDir) {
+                // it's a directory
+                return { path: args.path + '/index.mjs', external: true }
+              }
+              return { path: args.path + '.mjs', external: true }
+            }
+          })
+        }
+      }
+    ]
   },
   {
     entry: ['src/types.ts'],

--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -6,7 +6,7 @@ const { target } = tsconfig.compilerOptions
 export default defineConfig([
   {
     name: 'nextra',
-    entry: ['src/index.js', 'src/__temp__.ts'],
+    entry: ['src/index.js', 'src/__temp__.js'],
     format: 'cjs',
     dts: false,
     target


### PR DESCRIPTION
Errors like `swr-site:dev: Module not found: Can't resolve './chunk-HIDP27A7.mjs'` are extremely annoying, had to run `pnpm i` every time to copy over all the files. Not sure which part is wrong but I went with the way of transpiling everything in Nextra and disabling `splitting`.