### PR TITLE
Remove `development: false` for mdx remote

### DIFF
--- a/.changeset/brown-falcons-call.md
+++ b/.changeset/brown-falcons-call.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+remove development: false

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -100,8 +100,9 @@ export async function compileMdx(
     // You can override MDX options in the frontMatter too.
     ...(frontMatter.mdxOptions as Record<string, unknown>)
   }
-  
-  const format = _format === "detect" ? filePath.endsWith(".mdx") ? "mdx" : "md" : _format
+
+  const format =
+    _format === 'detect' ? (filePath.endsWith('.mdx') ? 'mdx' : 'md') : _format
 
   const compiler =
     (useCachedCompiler && cachedCompilerForFormat[format]) ||
@@ -110,8 +111,6 @@ export async function compileMdx(
       format,
       outputFormat,
       providerImportSource: 'nextra/mdx',
-      // https://github.com/hashicorp/next-mdx-remote/issues/307#issuecomment-1363415249
-      development: false,
       remarkPlugins: [
         ...remarkPlugins,
         remarkGfm,


### PR DESCRIPTION
This is no longer needed because the problem was fixed in latest `next-mdx-remote`.