### PR TITLE
Add transformPageOpts option for advanced use cases

### DIFF
--- a/.changeset/sharp-flowers-roll.md
+++ b/.changeset/sharp-flowers-roll.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+add transformPageOpts option for advanced use cases

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -70,6 +70,7 @@ async function loader(
     pageMapCache,
     newNextLinkBehavior,
     transform,
+    transformPageOpts,
     codeHighlight
   } = context.getOptions()
 
@@ -228,7 +229,7 @@ export default MDXContent`
     ? `import __nextra_themeConfig from '${slash(path.resolve(themeConfig))}'`
     : ''
 
-  const pageOpts: PageOpts = {
+  let pageOpts: PageOpts = {
     filePath: slash(path.relative(CWD, mdxPath)),
     route,
     frontMatter,
@@ -240,6 +241,13 @@ export default MDXContent`
     newNextLinkBehavior,
     readingTime,
     title: fallbackTitle
+  }
+  if (transformPageOpts) {
+    // It is possible that a theme wants to attach customized data, or modify
+    // some fields of `pageOpts`. One example is that the theme doesn't need
+    // to access the full pageMap or frontMatter of other pages, and it's not
+    // necessary to include them in the bundle.
+    pageOpts = transformPageOpts(pageOpts)
   }
 
   const finalResult = transform

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -130,11 +130,17 @@ export type NextraConfig = {
   readingTime?: boolean
   latex?: boolean
   codeHighlight?: boolean
+  /**
+   * A function to modify the code of compiled MDX pages.
+   * @experimental
+   */
   transform?: Transform
-  mdxOptions?: Pick<
-    ProcessorOptions,
-    'rehypePlugins' | 'remarkPlugins'
-  > & {
+  /**
+   * A function to modify the `pageOpts` prop passed to theme layouts.
+   * @experimental
+   */
+  transformPageOpts?: (pageOpts: PageOpts) => PageOpts
+  mdxOptions?: Pick<ProcessorOptions, 'rehypePlugins' | 'remarkPlugins'> & {
     format?: 'detect' | 'mdx' | 'md'
     rehypePrettyCodeOptions?: Partial<RehypePrettyCodeOptions>
   }

--- a/packages/nextra/src/use-internals.ts
+++ b/packages/nextra/src/use-internals.ts
@@ -19,6 +19,7 @@ export function useInternals() {
   // should be removed after compilation and it's fine to put the effect under
   // if, because hooks' order is still stable.
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       const trigger = () => rerender({})
 


### PR DESCRIPTION
This is an option that mostly helps custom themes. For example if the site has 1000 pages, every page will bundle the meta information (such as front matter) for all other pages and that's 1000x1000 copies. If the theme doesn't show a global sidebar for everything (unlike our `nextra-theme-docs`), that's totally unnecessary.
