### PR TITLE
Support dynamic markdown import

### DIFF
--- a/.changeset/fast-grapes-shop.md
+++ b/.changeset/fast-grapes-shop.md
@@ -2,4 +2,4 @@
 'nextra': patch
 ---
 
-support dynamic import
+support dynamic markdown import

--- a/.changeset/fast-grapes-shop.md
+++ b/.changeset/fast-grapes-shop.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+support dynamic import

--- a/examples/swr-site/pages/docs/advanced/dynamic-markdown-import.en-US.mdx
+++ b/examples/swr-site/pages/docs/advanced/dynamic-markdown-import.en-US.mdx
@@ -1,0 +1,22 @@
+# Dynamic Markdown Import!
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+
+export function Renderer() {
+  const [pageOne, setPageOne] = useState(true)
+  const Page = dynamic(
+    () => {
+      if (pageOne) {
+        return import(`./more/tree/one.en-US.mdx`)
+      }
+      return import(`./more/tree/two.en-US.mdx`)
+    }
+  );
+  return <>
+    <Page />
+    <button onClick={() => setPageOne(!pageOne)}>Toggle Content</button>
+  </>
+}
+
+<Renderer/>

--- a/packages/nextra/src/index.js
+++ b/packages/nextra/src/index.js
@@ -82,8 +82,10 @@ const nextra = (themeOrNextraConfig, themeConfig) =>
           {
             // Match Markdown imports from non-pages. These imports have an
             // issuer, which can be anything as long as it's not empty.
+            // When the issuer is null, it means that it can be imported via a
+            // runtime import call such as `import('...')`.
             test: MARKDOWN_EXTENSION_REGEX,
-            issuer: request => !!request,
+            issuer: request => !!request || request === null,
             use: [
               options.defaultLoaders.babel,
               {
@@ -93,9 +95,9 @@ const nextra = (themeOrNextraConfig, themeConfig) =>
             ]
           },
           {
-            // Match pages (imports without an issuer).
+            // Match pages (imports without an issuer request).
             test: MARKDOWN_EXTENSION_REGEX,
-            issuer: request => !request,
+            issuer: request => request === '',
             use: [
               options.defaultLoaders.babel,
               {

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -263,15 +263,23 @@ setupNextraPage({
   themeConfig: ${themeConfigImport ? '__nextra_themeConfig' : 'null'},
   Content: MDXContent,
   hot: module.hot,
-  pageOptsChecksum: ${JSON.stringify(hashFnv32a(stringifiedPageOpts))},
-  dynamicMetaModules: typeof window !== 'undefined' ? [] : [${dynamicMetaItems
-    .map(
-      descriptor =>
-        `[import(${JSON.stringify(descriptor.metaFilePath)}), ${JSON.stringify(
-          descriptor
-        )}]`
-    )
-    .join(',')}]
+  pageOptsChecksum: ${
+    IS_PRODUCTION
+      ? 'undefined'
+      : JSON.stringify(hashFnv32a(stringifiedPageOpts))
+  },
+  dynamicMetaModules: [${
+    typeof window !== 'undefined'
+      ? ''
+      : dynamicMetaItems
+          .map(
+            descriptor =>
+              `[import(${JSON.stringify(
+                descriptor.metaFilePath
+              )}), ${JSON.stringify(descriptor)}]`
+          )
+          .join(',')
+  }]
 })
 
 export { default } from 'nextra/layout'`


### PR DESCRIPTION
This PR adds support for dynamic Markdown imports, that are executed during the runtime, such as:

```js
cond ? import(`./a.mdx`) : import(`./b.mdx`)
```

These imports can't be determined during the compilation, so their `issuer` will be `null` (for page imports their `issuer` will be `""`). And they will be compiled as standalone chunks and dynamically loaded when executing.
