### PR TITLE
Fix build error of resolving subpath imports

### DIFF
--- a/.changeset/three-boats-learn.md
+++ b/.changeset/three-boats-learn.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+fix subpath import failed

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -70,6 +70,18 @@
       "import": "./dist/hooks/index.mjs",
       "types": "./dist/hooks/index.d.ts"
     },
+    "./setup-page": {
+      "import": "./dist/setup-page.mjs",
+      "types": "./dist/setup-page.d.ts"
+    },
+    "./mdx": {
+      "import": "./dist/mdx.mjs",
+      "types": "./dist/mdx.d.ts"
+    },
+    "./layout": {
+      "import": "./dist/layout.mjs",
+      "types": "./dist/layout.d.ts"
+    },
     "./*": {
       "import": "./dist/*.mjs",
       "types": "./dist/*.d.ts"

--- a/packages/nextra/src/index.js
+++ b/packages/nextra/src/index.js
@@ -60,6 +60,11 @@ const nextra = (themeOrNextraConfig, themeConfig) =>
       newNextLinkBehavior: nextConfig.experimental?.newNextLinkBehavior
     }
 
+    // Check if there's a theme provided
+    if (!nextraLoaderOptions.theme) {
+      throw new Error('No Nextra theme found!')
+    }
+
     return {
       ...nextConfig,
       rewrites,

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -81,11 +81,6 @@ async function loader(
     return 'export default () => null'
   }
 
-  // Check if there's a theme provided
-  if (!theme) {
-    throw new Error('No Nextra theme found!')
-  }
-
   const mdxPath = context.resourcePath as MdxPath
 
   if (mdxPath.includes('/pages/api/')) {


### PR DESCRIPTION
I'm not 100% sure why there's this error, but it seems that some times the webpack resolver doesn't handle `./*` correctly:

<img width="1360" alt="CleanShot 2023-01-19 at 23 51 33@2x" src="https://user-images.githubusercontent.com/3676859/213581900-1f9815fd-b67b-4403-8454-e6962ec9c8a6.png">
