### PR TITLE
fix `Module not found: Can't resolve 'nextra-theme-docs/style.css'` for imported markdown files that located outside of CWD

### DIFF
--- a/.changeset/modern-rings-melt.md
+++ b/.changeset/modern-rings-melt.md
@@ -1,0 +1,6 @@
+---
+'nextra': patch
+'nextra-theme-docs': patch
+---
+
+fix `Module not found: Can't resolve 'nextra-theme-docs/style.css'` for imported markdown files that located outside of CWD

--- a/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
@@ -23,7 +23,7 @@ function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
   return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
 }
-
+export default MDXContent;
 ",
   "searchIndexKey": null,
   "structurizedData": {},
@@ -54,7 +54,7 @@ function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
   return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
 }
-
+export default MDXContent;
 ",
   "searchIndexKey": null,
   "structurizedData": {},
@@ -90,7 +90,7 @@ function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
   return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
 }
-
+export default MDXContent;
 ",
   "searchIndexKey": null,
   "structurizedData": {},
@@ -120,7 +120,7 @@ function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
   return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
 }
-
+export default MDXContent;
 ",
   "searchIndexKey": null,
   "structurizedData": {},
@@ -149,7 +149,7 @@ function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
   return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
 }
-
+export default MDXContent;
 ",
   "searchIndexKey": null,
   "structurizedData": {},

--- a/packages/nextra/src/compile.ts
+++ b/packages/nextra/src/compile.ts
@@ -109,7 +109,7 @@ export async function compileMdx(
 
   // https://github.com/shuding/nextra/issues/1303
   const isFileOutsideCWD =
-    !isPageImport && path.relative(CWD, filePath).startsWith('../')
+    !isPageImport && path.relative(CWD, filePath).startsWith('..')
 
   const compiler =
     (useCachedCompiler && cachedCompilerForFormat[format]) ||

--- a/packages/nextra/src/index.js
+++ b/packages/nextra/src/index.js
@@ -109,7 +109,7 @@ const nextra = (themeOrNextraConfig, themeConfig) =>
                 loader: 'nextra/loader',
                 options: {
                   ...nextraLoaderOptions,
-                  pageImport: true
+                  isPageImport: true
                 }
               }
             ]
@@ -123,7 +123,7 @@ const nextra = (themeOrNextraConfig, themeConfig) =>
               {
                 loader: 'nextra/loader',
                 options: {
-                  metaImport: true
+                  isMetaImport: true
                 }
               }
             ]

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -55,8 +55,8 @@ async function loader(
   source: string
 ): Promise<string> {
   const {
-    metaImport,
-    pageImport,
+    isMetaImport = false,
+    isPageImport = false,
     theme,
     themeConfig,
     locales,
@@ -77,7 +77,7 @@ async function loader(
   context.cacheable(true)
 
   // _meta.js used as a page.
-  if (metaImport) {
+  if (isMetaImport) {
     return 'export default () => null'
   }
 
@@ -160,8 +160,11 @@ async function loader(
       route: pageNextRoute,
       locale
     },
-    mdxPath,
-    false // TODO: produce hydration errors or error - Create a new processor first, by calling it: use `processor()` instead of `processor`.
+    {
+      filePath: mdxPath,
+      useCachedCompiler: false, // TODO: produce hydration errors or error - Create a new processor first, by calling it: use `processor()` instead of `processor`.
+      isPageImport
+    }
   )
 
   const katexCssImport = latex ? "import 'katex/dist/katex.min.css'" : ''
@@ -172,10 +175,8 @@ async function loader(
     : ''
 
   // Imported as a normal component, no need to add the layout.
-  if (!pageImport) {
-    return `${cssImport}
-${result}
-export default MDXContent`
+  if (!isPageImport) {
+    return result
   }
 
   const { route, pageMap, dynamicMetaItems } = resolvePageMap({
@@ -257,7 +258,10 @@ ${themeConfigImport}
 ${katexCssImport}
 ${cssImport}
 
-${finalResult}
+${finalResult.replace(
+  'export default MDXContent;',
+  "export { default } from 'nextra/layout'"
+)}
 
 setupNextraPage({
   pageNextRoute: ${JSON.stringify(pageNextRoute)},
@@ -283,9 +287,7 @@ setupNextraPage({
           )
           .join(',')
   }]
-})
-
-export { default } from 'nextra/layout'`
+})`
 }
 
 export default function syncLoader(

--- a/packages/nextra/src/mdx-plugins/index.ts
+++ b/packages/nextra/src/mdx-plugins/index.ts
@@ -1,4 +1,5 @@
 export { parseMeta, attachMeta } from './rehype'
 export { remarkHeadings } from './remark-headings'
+export { remarkReplaceImports } from './remark-replace-imports'
 export { remarkStaticImage } from './static-image'
 export { structurize } from './structurize'

--- a/packages/nextra/src/mdx-plugins/remark-replace-imports.ts
+++ b/packages/nextra/src/mdx-plugins/remark-replace-imports.ts
@@ -1,0 +1,24 @@
+import { createRequire } from 'node:module'
+import { visit } from 'unist-util-visit'
+import { Plugin } from 'unified'
+import { Root } from 'mdast'
+
+const require = createRequire(import.meta.url)
+
+/**
+ * Markdown files that imported outside CWD could not find `nextra/mdx` or `next/image`
+ * to fix it we need to replace import path with absolute for them
+ * https://github.com/shuding/nextra/issues/1303
+ */
+export const remarkReplaceImports: Plugin<[], Root> = () => {
+  return (tree, _file, done) => {
+    visit(tree, 'mdxjsEsm', (node: any) => {
+      const { source } = node.data.estree.body[0]
+      const absolutePath = require.resolve(source.value)
+
+      source.value = absolutePath
+      source.raw = `"${absolutePath}"`
+    })
+    done()
+  }
+}

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -15,8 +15,8 @@ type MetaFilename = typeof META_FILENAME
 type MarkdownExtension = (typeof MARKDOWN_EXTENSIONS)[number]
 
 export interface LoaderOptions extends NextraConfig {
-  metaImport?: boolean
-  pageImport?: boolean
+  isMetaImport?: boolean
+  isPageImport?: boolean
   locales: string[]
   defaultLocale: string
   pageMapCache: PageMapCache

--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -6,6 +6,45 @@ import tsconfig from './tsconfig.json'
 
 const { target } = tsconfig.compilerOptions
 
+const esmOptions = defineConfig({
+  format: 'esm',
+  dts: true,
+  target,
+  bundle: true,
+  splitting: false,
+  external: ['shiki', './__temp__', 'webpack'],
+  esbuildPlugins: [
+    // https://github.com/evanw/esbuild/issues/622#issuecomment-769462611
+    {
+      name: 'add-mjs',
+      setup(build) {
+        build.onResolve({ filter: /.*/ }, async args => {
+          if (
+            args.importer &&
+            args.path.startsWith('.') &&
+            !args.path.endsWith('.json')
+          ) {
+            let isDir: boolean
+            try {
+              isDir = (
+                await fs.stat(path.join(args.resolveDir, args.path))
+              ).isDirectory()
+            } catch {
+              isDir = false
+            }
+
+            if (isDir) {
+              // it's a directory
+              return { path: args.path + '/index.mjs', external: true }
+            }
+            return { path: args.path + '.mjs', external: true }
+          }
+        })
+      }
+    }
+  ]
+})
+
 export default defineConfig([
   {
     name: 'nextra',
@@ -16,43 +55,20 @@ export default defineConfig([
   },
   {
     name: 'nextra-esm',
-    entry: ['src/**/*.ts', 'src/**/*.tsx'],
-    format: 'esm',
-    dts: true,
-    target,
-    bundle: true,
-    splitting: false,
-    external: ['shiki', './__temp__', 'webpack'],
-    esbuildPlugins: [
-      // https://github.com/evanw/esbuild/issues/622#issuecomment-769462611
-      {
-        name: 'add-mjs',
-        setup(build) {
-          build.onResolve({ filter: /.*/ }, async args => {
-            if (
-              args.importer &&
-              args.path.startsWith('.') &&
-              !args.path.endsWith('.json')
-            ) {
-              let isDir: boolean
-              try {
-                isDir = (
-                  await fs.stat(path.join(args.resolveDir, args.path))
-                ).isDirectory()
-              } catch {
-                isDir = false
-              }
-
-              if (isDir) {
-                // it's a directory
-                return { path: args.path + '/index.mjs', external: true }
-              }
-              return { path: args.path + '.mjs', external: true }
-            }
-          })
-        }
-      }
-    ]
+    entry: [
+      'src/**/*.ts',
+      'src/**/*.tsx',
+      '!src/compile.ts',
+      '!src/mdx-plugins/remark-replace-imports.ts'
+    ],
+    ...esmOptions
+  },
+  {
+    name: 'nextra-esm-import.meta',
+    entry: ['src/compile.ts', 'src/mdx-plugins/remark-replace-imports.ts'],
+    ...esmOptions,
+    // import.meta is available only from es2020
+    target: 'es2020'
   },
   {
     entry: ['src/types.ts'],


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/1303