### PR TITLE
Updated SEO options for i18n

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -78,6 +78,27 @@ export default {
         titleTemplate: '%s – SWR'
       }
     }
+    return {
+      titleTemplate: undefined
+    }
+  },
+}
+```
+
+If you are using i18n, the `route` will change from `/` to `/index.[locale]` for the homepage. Modify the check to catch all translations of the homepage.
+
+```jsx
+export default {
+  useNextSeoProps() {
+    const { route } = useRouter()
+    if (!route.startsWith('/index.')) {
+      return {
+        titleTemplate: '%s – SWR'
+      }
+    }
+    return {
+      titleTemplate: undefined
+    }
   },
 }
 ```


### PR DESCRIPTION
- Changed example code to conditionally to avoid adding the suffix to the homepage to fix TypeScript error.

```
Type 'undefined' is not assignable to type 'NextSeoProps'.
```

- Added an example code to conditionally to avoid adding the suffix to the homepage when using i18n.