### PR TITLE
prefer `asPath` over `route` in `useNextSeoProps` docs, allow `void` as return type of `useNextSeoProps`

### DIFF
--- a/.changeset/many-plants-add.md
+++ b/.changeset/many-plants-add.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+prefer `asPath` over `route` in `useNextSeoProps` docs, allow `void` as return type of `useNextSeoProps`

--- a/docs/components/card/index.tsx
+++ b/docs/components/card/index.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps, ReactNode } from 'react'
 import cn from 'clsx'
 import Link from 'next/link'
 
@@ -11,6 +12,13 @@ export function Card({
   arrow,
   href,
   ...props
+}: {
+  children: ReactNode
+  title: string,
+  icon: ReactNode,
+  image?: boolean,
+  arrow?: boolean,
+  href: string
 }) {
   const animatedArrow = arrow ? (
     <span
@@ -79,12 +87,17 @@ export function Card({
   )
 }
 
-export function Cards({ children, num, ...props }) {
+export function Cards({
+  children,
+  num,
+  ...props
+}: { num?: number } & ComponentProps<'div'>) {
   return (
     <div
       className={cn(styles.cards, 'mt-4 gap-4')}
       {...props}
       style={{
+        // @ts-expect-error -- todo: enhance style prop to accept css variables
         '--rows': num || 3,
         ...props.style
       }}

--- a/docs/components/features/index.tsx
+++ b/docs/components/features/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import Link from 'next/link'
 import cn from 'clsx'
 import { motion } from 'framer-motion'
@@ -50,6 +51,6 @@ export function Feature({
   )
 }
 
-export function Features({ children }) {
+export function Features({ children }: { children: ReactNode }) {
   return <div className={styles.features}>{children}</div>
 }

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -55,13 +55,13 @@ import titleSuffixImage from '../../../public/assets/docs/title-suffix.png'
 
 <Screenshot src={titleSuffixImage} alt="Title suffix" />
 
-```jsx
+```js
 export default {
   useNextSeoProps() {
     return {
       titleTemplate: '%s – SWR'
     }
-  },
+  }
 }
 ```
 
@@ -69,16 +69,16 @@ The `%s` is a [placeholder](https://github.com/garmeeh/next-seo#title-template) 
 
 You can also return it conditionally to avoid adding the suffix to the homepage:
 
-```jsx
+```js
 export default {
   useNextSeoProps() {
-    const { route } = useRouter()
-    if (route !== '/') {
+    const { asPath } = useRouter()
+    if (asPath !== '/') {
       return {
         titleTemplate: '%s – SWR'
       }
     }
-  },
+  }
 }
 ```
 

--- a/docs/pages/docs/guide/syntax-highlighting.mdx
+++ b/docs/pages/docs/guide/syntax-highlighting.mdx
@@ -16,12 +16,6 @@ And it renders:
 console.log('hello, world')
 ```
 
-You can opt out of syntax highlighting for using one of your own. You can disable syntax highlighting globally by setting ```codeHighlight: false``` in your Nextra configuration (next.config.js file)
-
-<OptionTable options={[
-  ['codeHighlight', 'boolean' , 'Enable or Disable syntax highlighting. Defaults to `true`.'],
-]} />
-
 ## Features
 
 ### Inlined Code
@@ -221,3 +215,11 @@ function hello () {
 This workaround has a limitation that updated content won't be re-highlighted. For example if we update the number to `1 + 1`, it will be highlighted wrongly.
 
 Check out the [code](https://github.com/shuding/nextra/blob/main/docs/pages/docs/guide/syntax-highlighting.mdx) to see how it works.
+
+## Disable Syntax Highlighting
+
+You can opt out of syntax highlighting for using one of your own. You can disable syntax highlighting globally by setting `codeHighlight: false` in your Nextra configuration (`next.config.js` file)
+
+<OptionTable options={[
+  ['codeHighlight', 'boolean' , 'Enable or disable syntax highlighting. Defaults to `true`.'],
+]} />

--- a/docs/pages/docs/guide/syntax-highlighting.mdx
+++ b/docs/pages/docs/guide/syntax-highlighting.mdx
@@ -218,7 +218,7 @@ Check out the [code](https://github.com/shuding/nextra/blob/main/docs/pages/docs
 
 ## Disable Syntax Highlighting
 
-You can opt out of syntax highlighting for using one of your own. You can disable syntax highlighting globally by setting `codeHighlight: false` in your Nextra configuration (`next.config.js` file)
+You can opt out of syntax highlighting for using one of your own. You can disable syntax highlighting globally by setting `codeHighlight: false` in your Nextra configuration (`next.config.js` file).
 
 <OptionTable options={[
   ['codeHighlight', 'boolean' , 'Enable or disable syntax highlighting. Defaults to `true`.'],

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -47,8 +47,8 @@ const config: DocsThemeConfig = {
   },
   docsRepositoryBase: 'https://github.com/shuding/nextra/tree/main/docs',
   useNextSeoProps() {
-    const { route } = useRouter()
-    if (route !== '/') {
+    const { asPath } = useRouter()
+    if (asPath !== '/') {
       return {
         titleTemplate: '%s – Nextra'
       }

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -144,7 +144,7 @@ export const themeSchema = z.strictObject({
     float: z.boolean(),
     title: z.custom<ReactNode | FC>(...reactNode)
   }),
-  useNextSeoProps: z.custom<() => NextSeoProps>(isFunction)
+  useNextSeoProps: z.custom<() => NextSeoProps | void>(isFunction)
 })
 
 const publicThemeSchema = themeSchema.deepPartial().extend({


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/pull/1406