### PR TITLE
Hide footer menu if there's nothing to display

### DIFF
--- a/packages/nextra-theme-docs/src/components/footer.tsx
+++ b/packages/nextra-theme-docs/src/components/footer.tsx
@@ -12,7 +12,9 @@ export function Footer({ menu }: { menu?: boolean }): ReactElement {
       <div
         className={cn(
           'nx-mx-auto nx-flex nx-max-w-[90rem] nx-gap-2 nx-py-2 nx-px-4',
-          menu ? 'nx-flex' : 'nx-hidden'
+          menu && (config.i18n.length > 0 || config.darkMode)
+            ? 'nx-flex'
+            : 'nx-hidden'
         )}
       >
         {config.i18n.length > 0 && <LocaleSwitch options={config.i18n} />}


### PR DESCRIPTION
### 🔴 Issue
The menu in `Footer` isn't hidden, if `darkMode` is disabled and `i18n` isn't set or is empty.

<img width="1210" alt="nextra-before" src="https://user-images.githubusercontent.com/43032218/215394315-955427ab-fc86-4a66-a3c1-9f7831885f4e.png">

### ✅ Solution
Hide the menu if the above statement is true.

<img width="1208" alt="nextra-after" src="https://user-images.githubusercontent.com/43032218/215395585-25b4ffe1-a3d9-45ca-9a53-e6e763c8cc46.png">
