### PR TITLE
fix: move intersection observe and slugs into ActiveAnchorProvider

### DIFF
--- a/.changeset/wet-doors-flow.md
+++ b/.changeset/wet-doors-flow.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix: move intersection observe and slugs into ActiveAnchorProvider

--- a/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
+++ b/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
@@ -3,7 +3,6 @@ import type {
   ReactElement,
   ReactNode,
   SetStateAction,
-  MutableRefObject
 } from 'react';
 import 'intersection-observer'
 import {
@@ -11,7 +10,6 @@ import {
   useContext,
   useState,
   useRef,
-  createRef
 } from 'react';
 import { IS_BROWSER } from '../constants';
 
@@ -30,7 +28,7 @@ const SetActiveAnchorContext = createContext<
   Dispatch<SetStateAction<ActiveAnchor>>
 >(v => v)
 
-const IntersectionObserverContext = createContext<MutableRefObject<IntersectionObserver | null>>(createRef())
+const IntersectionObserverContext = createContext<IntersectionObserver | null>(null)
 const slugs = new WeakMap()
 const SlugsContext = createContext<WeakMap<any, any>>(slugs)
 // Separate the state as 2 contexts here to avoid
@@ -105,7 +103,7 @@ export const ActiveAnchorProvider = ({
     <ActiveAnchorContext.Provider value={activeAnchor}>
       <SetActiveAnchorContext.Provider value={setActiveAnchor}>
         <SlugsContext.Provider value={slugs}>
-          <IntersectionObserverContext.Provider value={observerRef}>
+          <IntersectionObserverContext.Provider value={observerRef.current}>
             {children}
           </IntersectionObserverContext.Provider>
         </SlugsContext.Provider>

--- a/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
+++ b/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
@@ -2,13 +2,16 @@ import type {
   Dispatch,
   ReactElement,
   ReactNode,
-  SetStateAction
+  SetStateAction,
+  MutableRefObject
 } from 'react';
 import 'intersection-observer'
 import {
   createContext,
   useContext,
-  useState
+  useState,
+  useRef,
+  createRef
 } from 'react';
 import { IS_BROWSER } from '../constants';
 
@@ -27,7 +30,7 @@ const SetActiveAnchorContext = createContext<
   Dispatch<SetStateAction<ActiveAnchor>>
 >(v => v)
 
-const IntersectionObserverContext = createContext<IntersectionObserver | null>(null)
+const IntersectionObserverContext = createContext<MutableRefObject<IntersectionObserver | null>>(createRef())
 const slugs = new WeakMap()
 const SlugsContext = createContext<WeakMap<any, any>>(slugs)
 // Separate the state as 2 contexts here to avoid
@@ -44,69 +47,65 @@ export const ActiveAnchorProvider = ({
   children: ReactNode
 }): ReactElement => {
   const [activeAnchor, setActiveAnchor] = useState<ActiveAnchor>({})
-  const [observer] = useState<IntersectionObserver | null>(() => {
-    if (IS_BROWSER) {
-      const observer = new IntersectionObserver(
-        entries => {
-          setActiveAnchor(f => {
-            const ret = { ...f }
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  if (IS_BROWSER && !observerRef.current) {
+    observerRef.current = new IntersectionObserver(
+      entries => {
+        setActiveAnchor(f => {
+          const ret = { ...f }
 
-            for (const entry of entries) {
-              if (entry?.rootBounds && slugs.has(entry.target)) {
-                const [slug, index] = slugs.get(entry.target)
-                const aboveHalfViewport =
-                  entry.boundingClientRect.y + entry.boundingClientRect.height <=
-                  entry.rootBounds.y + entry.rootBounds.height
-                const insideHalfViewport = entry.intersectionRatio > 0
-                ret[slug] = {
-                  index,
-                  aboveHalfViewport,
-                  insideHalfViewport
-                }
+          for (const entry of entries) {
+            if (entry?.rootBounds && slugs.has(entry.target)) {
+              const [slug, index] = slugs.get(entry.target)
+              const aboveHalfViewport =
+                entry.boundingClientRect.y + entry.boundingClientRect.height <=
+                entry.rootBounds.y + entry.rootBounds.height
+              const insideHalfViewport = entry.intersectionRatio > 0
+              ret[slug] = {
+                index,
+                aboveHalfViewport,
+                insideHalfViewport
               }
             }
+          }
 
-            let activeSlug = ''
-            let smallestIndexInViewport = Infinity
-            let largestIndexAboveViewport = -1
-            for (const s in ret) {
-              ret[s].isActive = false
-              if (
-                ret[s].insideHalfViewport &&
-                ret[s].index < smallestIndexInViewport
-              ) {
-                smallestIndexInViewport = ret[s].index
-                activeSlug = s
-              }
-              if (
-                smallestIndexInViewport === Infinity &&
-                ret[s].aboveHalfViewport &&
-                ret[s].index > largestIndexAboveViewport
-              ) {
-                largestIndexAboveViewport = ret[s].index
-                activeSlug = s
-              }
+          let activeSlug = ''
+          let smallestIndexInViewport = Infinity
+          let largestIndexAboveViewport = -1
+          for (const s in ret) {
+            ret[s].isActive = false
+            if (
+              ret[s].insideHalfViewport &&
+              ret[s].index < smallestIndexInViewport
+            ) {
+              smallestIndexInViewport = ret[s].index
+              activeSlug = s
             }
+            if (
+              smallestIndexInViewport === Infinity &&
+              ret[s].aboveHalfViewport &&
+              ret[s].index > largestIndexAboveViewport
+            ) {
+              largestIndexAboveViewport = ret[s].index
+              activeSlug = s
+            }
+          }
 
-            if (ret[activeSlug]) ret[activeSlug].isActive = true
-            return ret
-          })
-        },
-        {
-          rootMargin: '0px 0px -50%',
-          threshold: [0, 1]
-        }
-      )
-      return observer
-    }
-    return null
-  })
-
+          if (ret[activeSlug]) ret[activeSlug].isActive = true
+          return ret
+        })
+      },
+      {
+        rootMargin: '0px 0px -50%',
+        threshold: [0, 1]
+      }
+    )
+  }
   return (
     <ActiveAnchorContext.Provider value={activeAnchor}>
       <SetActiveAnchorContext.Provider value={setActiveAnchor}>
         <SlugsContext.Provider value={slugs}>
-          <IntersectionObserverContext.Provider value={observer}>
+          <IntersectionObserverContext.Provider value={observerRef}>
             {children}
           </IntersectionObserverContext.Provider>
         </SlugsContext.Provider>

--- a/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
+++ b/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
@@ -2,12 +2,15 @@ import type {
   Dispatch,
   ReactElement,
   ReactNode,
-  SetStateAction} from 'react';
+  SetStateAction
+} from 'react';
+import 'intersection-observer'
 import {
   createContext,
   useContext,
   useState
-} from 'react'
+} from 'react';
+import { IS_BROWSER } from '../constants';
 
 type ActiveAnchor = Record<
   string,
@@ -24,10 +27,16 @@ const SetActiveAnchorContext = createContext<
   Dispatch<SetStateAction<ActiveAnchor>>
 >(v => v)
 
+const IntersectionObserverContext = createContext<IntersectionObserver | null>(null)
+const slugs = new WeakMap()
+const SlugsContext = createContext<WeakMap<any, any>>(slugs)
 // Separate the state as 2 contexts here to avoid
 // re-renders of the content triggered by the state update.
 export const useActiveAnchor = () => useContext(ActiveAnchorContext)
 export const useSetActiveAnchor = () => useContext(SetActiveAnchorContext)
+
+export const useIntersectionObserver = () => useContext(IntersectionObserverContext)
+export const useSlugs = () => useContext(SlugsContext)
 
 export const ActiveAnchorProvider = ({
   children
@@ -35,11 +44,72 @@ export const ActiveAnchorProvider = ({
   children: ReactNode
 }): ReactElement => {
   const [activeAnchor, setActiveAnchor] = useState<ActiveAnchor>({})
+  const [observer] = useState<IntersectionObserver | null>(() => {
+    if (IS_BROWSER) {
+      const observer = new IntersectionObserver(
+        entries => {
+          setActiveAnchor(f => {
+            const ret = { ...f }
+
+            for (const entry of entries) {
+              if (entry?.rootBounds && slugs.has(entry.target)) {
+                const [slug, index] = slugs.get(entry.target)
+                const aboveHalfViewport =
+                  entry.boundingClientRect.y + entry.boundingClientRect.height <=
+                  entry.rootBounds.y + entry.rootBounds.height
+                const insideHalfViewport = entry.intersectionRatio > 0
+                ret[slug] = {
+                  index,
+                  aboveHalfViewport,
+                  insideHalfViewport
+                }
+              }
+            }
+
+            let activeSlug = ''
+            let smallestIndexInViewport = Infinity
+            let largestIndexAboveViewport = -1
+            for (const s in ret) {
+              ret[s].isActive = false
+              if (
+                ret[s].insideHalfViewport &&
+                ret[s].index < smallestIndexInViewport
+              ) {
+                smallestIndexInViewport = ret[s].index
+                activeSlug = s
+              }
+              if (
+                smallestIndexInViewport === Infinity &&
+                ret[s].aboveHalfViewport &&
+                ret[s].index > largestIndexAboveViewport
+              ) {
+                largestIndexAboveViewport = ret[s].index
+                activeSlug = s
+              }
+            }
+
+            if (ret[activeSlug]) ret[activeSlug].isActive = true
+            return ret
+          })
+        },
+        {
+          rootMargin: '0px 0px -50%',
+          threshold: [0, 1]
+        }
+      )
+      return observer
+    }
+    return null
+  })
 
   return (
     <ActiveAnchorContext.Provider value={activeAnchor}>
       <SetActiveAnchorContext.Provider value={setActiveAnchor}>
-        {children}
+        <SlugsContext.Provider value={slugs}>
+          <IntersectionObserverContext.Provider value={observer}>
+            {children}
+          </IntersectionObserverContext.Provider>
+        </SlugsContext.Provider>
       </SetActiveAnchorContext.Provider>
     </ActiveAnchorContext.Provider>
   )

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -21,14 +21,13 @@ function HeadingLink({
 }): ReactElement {
   const setActiveAnchor = useSetActiveAnchor()
   const slugs = useSlugs()
-  const observer = useIntersectionObserver()
+  const observer = useIntersectionObserver().current
   const obRef = useRef<HTMLAnchorElement>(null)
 
   useEffect(() => {
     if (!id) return
     const heading = obRef.current
     if (!heading) return
-
     slugs.set(heading, [id, (context.index += 1)])
     observer?.observe(heading)
 

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -21,7 +21,7 @@ function HeadingLink({
 }): ReactElement {
   const setActiveAnchor = useSetActiveAnchor()
   const slugs = useSlugs()
-  const observer = useIntersectionObserver().current
+  const observer = useIntersectionObserver()
   const obRef = useRef<HTMLAnchorElement>(null)
 
   useEffect(() => {


### PR DESCRIPTION
In this way,  React Hook "useSetActiveAnchor" would not be called conditionally.

fixes https://github.com/shuding/nextra/issues/1207