### PR TITLE
Fix search text in French

### DIFF
--- a/.changeset/curly-bats-whisper.md
+++ b/.changeset/curly-bats-whisper.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+rename input placeholder to "Rechercher documents..." in french

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -288,7 +288,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       const { locale } = useRouter()
       if (locale === 'zh-CN') return '搜索文档…'
       if (locale === 'ru') return 'Поиск документации…'
-      if (locale === 'fr') return 'Rechercher de la documentation…'
+      if (locale === 'fr') return 'Rechercher documents…'
       return 'Search documentation…'
     }
   },


### PR DESCRIPTION
The "Search documentation..." text was originally translated in French to "Rechercher de la documentation...".  This is wrong (and is overly long).  

In this setting, it should be "Rechercher documents..." or simply "Rechercher...". 

Reference:  https://translate.google.com/?sl=fr&tl=en&text=rechercher%20documents&op=translate&hl=en

Thanks