### PR TITLE
fix: add mp4 to shoudlHandleLocale exception

### DIFF
--- a/.changeset/pretty-rings-smile.md
+++ b/.changeset/pretty-rings-smile.md
@@ -1,0 +1,6 @@
+---
+'nextra': patch
+'nextra-theme-docs': patch
+---
+
+do not redirect .mp4 in locales middleware

--- a/packages/nextra/src/locales.ts
+++ b/packages/nextra/src/locales.ts
@@ -38,7 +38,7 @@ export function locales(request: NextRequest) {
 
   const shouldHandleLocale =
     !/^\/(api|_next)\//.test(nextUrl.pathname) &&
-    !/\.(jpe?g|svg|png|webmanifest|xml|ico|txt)$/.test(nextUrl.pathname) &&
+    !/\.(jpe?g|svg|png|webmanifest|xml|ico|txt|mp4)$/.test(nextUrl.pathname) &&
     nextUrl.locale !== '' &&
     // not Server-Side Error page
     nextUrl.pathname !== '/500'


### PR DESCRIPTION
Currently `nextra` tries "handle" the pathname conversion for mp4 files.