### PR TITLE
fix local theme on Windows

### DIFF
--- a/nervous-tigers-camp.md
+++ b/nervous-tigers-camp.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+wrap path for local theme with `slash` for windows

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -213,7 +213,7 @@ async function loader(
   }
 
   // Relative path instead of a package name
-  const layout = isLocalTheme ? path.resolve(theme) : theme
+  const layout = isLocalTheme ? slash(path.resolve(theme)) : theme
 
   let pageOpts: PageOpts = {
     filePath: slash(path.relative(CWD, mdxPath)),


### PR DESCRIPTION
Fix the following error by adding `slash(...)`:

```
Error:
  x Bad character escape sequence, expected 2 hex characters
   ,-[C:\Users\x...\Projects\kyaru-blog\pages\blog\index.mdx:1:1]
 1 | import { setupNextraPage } from 'nextra/setup-page'
 2 | import __nextra_layout from 'C:\Users\x...\Projects\kyaru-blog\theme.tsx'
   :                                      ^^
 3 |
 4 |
   `----

Caused by:
    Syntax Error
```