### PR TITLE
fix: force main div to w-full

### DIFF
--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -191,7 +191,7 @@ const InnerLayout = ({
       <div
         className={cn(
           'nx-mx-auto nx-flex',
-          themeContext.layout !== 'raw' && 'nx-max-w-[90rem]'
+          themeContext.layout !== 'raw' && 'nx-max-w-[90rem] nx-w-full'
         )}
       >
         <ActiveAnchorProvider>


### PR DESCRIPTION
Force the primary `div` in the `nextra-theme-blog` content area to `nx-w-full`.

See following issue for details: https://github.com/shuding/nextra/issues/1523