### PR TITLE
Make http links external (not just https ones)

### DIFF
--- a/.changeset/dirty-donuts-look.md
+++ b/.changeset/dirty-donuts-look.md
@@ -1,0 +1,6 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+open http:// links in new window

--- a/packages/nextra-theme-blog/src/mdx-theme.tsx
+++ b/packages/nextra-theme-blog/src/mdx-theme.tsx
@@ -1,8 +1,4 @@
-import type {
-  RefObject,
-  ComponentProps,
-  ReactElement,
-  ReactNode} from 'react';
+import type { RefObject, ComponentProps, ReactElement, ReactNode } from 'react'
 import {
   createRef,
   createContext,
@@ -53,7 +49,8 @@ function HeadingLink({
 }
 
 const A = ({ children, ...props }: ComponentProps<'a'>) => {
-  const isExternal = props.href?.startsWith('https://')
+  const isExternal =
+    props.href?.startsWith('https://') || props.href?.startsWith('http://')
   if (isExternal) {
     return (
       <a target="_blank" rel="noreferrer" {...props}>

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -151,7 +151,11 @@ const Summary = (props: ComponentProps<'summary'>): ReactElement => {
 }
 
 const A = ({ href = '', ...props }) => (
-  <Anchor href={href} newWindow={href.startsWith('https://')} {...props} />
+  <Anchor
+    href={href}
+    newWindow={href.startsWith('https://') || href.startsWith('http://')}
+    {...props}
+  />
 )
 
 export const getComponents = ({


### PR DESCRIPTION
Currently, only `https://` links open in a new tab. With this change,`http://` links also open in a new tab.

Plus, a tiny Prettier reformatting.

fixes https://github.com/shuding/nextra/issues/1375