### PR TITLE
fix: darkMode themes

### DIFF
--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -66,7 +66,6 @@ const config: DocsThemeConfig = {
     key: 'swr-2',
     text: 'SWR 2.0 is out! Read more →'
   },
-  darkMode: true,
   docsRepositoryBase:
     'https://github.com/shuding/nextra/blob/core/examples/swr-site',
   editLink: {

--- a/packages/nextra-theme-docs/src/components/footer.tsx
+++ b/packages/nextra-theme-docs/src/components/footer.tsx
@@ -7,18 +7,23 @@ import { renderComponent } from '../utils'
 
 export function Footer({ menu }: { menu?: boolean }): ReactElement {
   const config = useConfig()
+
   return (
     <footer className="nx-bg-gray-100 nx-pb-[env(safe-area-inset-bottom)] dark:nx-bg-neutral-900 print:nx-bg-transparent">
       <div
         className={cn(
           'nx-mx-auto nx-flex nx-max-w-[90rem] nx-gap-2 nx-py-2 nx-px-4',
-          menu && (config.i18n.length > 0 || config.darkMode)
+          menu &&
+            (config.i18n.length > 0 ||
+              (config.darkMode === undefined && !config.nextThemes.forcedTheme))
             ? 'nx-flex'
             : 'nx-hidden'
         )}
       >
         {config.i18n.length > 0 && <LocaleSwitch options={config.i18n} />}
-        {config.darkMode && <ThemeSwitch />}
+        {config.darkMode === undefined && !config.nextThemes.forcedTheme && (
+          <ThemeSwitch />
+        )}
       </div>
       <hr className="dark:nx-border-neutral-800" />
       <div

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -466,12 +466,13 @@ export function Sidebar({
                 className={cn(showSidebar ? 'nx-grow' : 'max-md:nx-grow')}
               />
             )}
-            {config.darkMode && (
-              <ThemeSwitch
-                lite={!showSidebar || hasI18n}
-                className={showSidebar && !hasI18n ? 'nx-grow' : ''}
-              />
-            )}
+            {config.darkMode === undefined &&
+              !config.nextThemes.forcedTheme && (
+                <ThemeSwitch
+                  lite={!showSidebar || hasI18n}
+                  className={showSidebar && !hasI18n ? 'nx-grow' : ''}
+                />
+              )}
             {config.sidebar.toggleButton && (
               <button
                 title={showSidebar ? 'Hide sidebar' : 'Show sidebar'}

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -1,12 +1,12 @@
 /* eslint sort-keys: error */
-import type { FC, ReactNode } from 'react';
+import type { FC, ReactNode } from 'react'
 import { isValidElement } from 'react'
 import { useRouter } from 'next/router'
 import { Anchor, Flexsearch, Footer, Navbar, TOC } from './components'
 import { DiscordIcon, GitHubIcon } from 'nextra/icons'
 import { MatchSorterSearch } from './components/match-sorter-search'
 import { useConfig } from './contexts'
-import type { Item } from './utils';
+import type { Item } from './utils'
 import { useGitEditUrl, getGitIssueUrl } from './utils'
 import { z } from 'zod'
 import type { NavBarProps } from './components/navbar'
@@ -59,7 +59,7 @@ export const themeSchema = z.strictObject({
     link: z.string().startsWith('https://').optional()
   }),
   components: z.record(z.custom<FC>(...fc)).optional(),
-  darkMode: z.boolean(),
+  darkMode: z.boolean().optional(),
   direction: z.enum(['ltr', 'rtl']),
   docsRepositoryBase: z.string().startsWith('https://'),
   editLink: z.strictObject({
@@ -168,7 +168,6 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       </>
     )
   },
-  darkMode: true,
   direction: 'ltr',
   docsRepositoryBase: 'https://github.com/shuding/nextra',
   editLink: {

--- a/packages/nextra-theme-docs/src/contexts/config.tsx
+++ b/packages/nextra-theme-docs/src/contexts/config.tsx
@@ -118,9 +118,15 @@ export const ConfigProvider = ({
     <ThemeProvider
       attribute="class"
       disableTransitionOnChange
-      defaultTheme={nextThemes.defaultTheme}
+      defaultTheme={
+        theme.darkMode === undefined
+          ? nextThemes.defaultTheme
+          : theme.darkMode
+          ? 'dark'
+          : 'light'
+      }
       storageKey={nextThemes.storageKey}
-      forcedTheme={theme.darkMode ? nextThemes.forcedTheme : 'light'}
+      forcedTheme={nextThemes.forcedTheme}
     >
       <ConfigContext.Provider value={extendedConfig}>
         <MenuProvider value={{ menu, setMenu }}>{children}</MenuProvider>


### PR DESCRIPTION
Solves issue #1538

**Changes:**
- Make darkMode optional [`aebe019`](https://github.com/shuding/nextra/commit/aebe01912e44f3f823e25cfc04ac36a3d5bfe14d#diff-e78a51266b9aa9a8b728bf9afd6040727400c645c456bbb8750e72d4e4684af8R62)
- `darkMode: undefined` enables `ThemeSwitch` and uses `nextThemes.defaultTheme` by default
- `darkMode: false` hides the `ThemeSwitch` and uses `light mode`
- `darkMode: true` hides the `ThemeSwitch` and uses `dark mode`
- `nextThemes.forcedTheme` hides the `ThemeSwitch`

**Todos:**
- [ ] Update nextra-theme-blog
- [ ] Update docs
- [ ] Rather introduce a new prop?