### PR TITLE
Filenames and titles to syntax-highlighting

### DIFF
--- a/docs/pages/docs/guide/syntax-highlighting.mdx
+++ b/docs/pages/docs/guide/syntax-highlighting.mdx
@@ -122,6 +122,22 @@ function Counter() {
 }
 ```
 
+### Filenames and Titles
+
+You can add a filename or a title to your code blocks by adding a `filename` attribute:
+
+````md filename="Markdown"
+```js filename="example.js"
+console.log('hello, world')
+```
+````
+
+Renders:
+
+```js filename="example.js"
+console.log('hello, world')
+```
+
 ## Supported Languages
 
 Check [this list](https://github.com/shikijs/shiki/blob/main/docs/languages.md) for all supported languages.


### PR DESCRIPTION
Added a section on how to render and use the `filename` attribute (thus showing the title bar for a code section).

The attribute is frequently used throughout the Nextra documentation - but information on how to use it was missing. 

![image](https://user-images.githubusercontent.com/17752024/221379285-927d3933-66d1-45bd-9261-d6fb5625c294.png)