### PR TITLE
fix(search): always show Cmd+K when input loses focus

### DIFF
--- a/.changeset/cuddly-timers-attack.md
+++ b/.changeset/cuddly-timers-attack.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+always show `Cmd+K` when search input loses focus

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -49,6 +49,7 @@ export function Search({
   const { setMenu } = useMenu()
   const input = useRef<HTMLInputElement>(null)
   const ulRef = useRef<HTMLUListElement>(null)
+  const [focused, setFocused] = useState(false)
 
   useEffect(() => {
     setActive(0)
@@ -169,7 +170,7 @@ export function Search({
           onChange('')
         }}
       >
-        {value
+        {(value && focused)
           ? 'ESC'
           : mounted &&
             (navigator.userAgent.includes('Macintosh') ? (
@@ -202,6 +203,10 @@ export function Search({
         }}
         onFocus={() => {
           onActive?.(true)
+          setFocused(true)
+        }}
+        onBlur={() => {
+          setFocused(false)
         }}
         type="search"
         placeholder={renderString(config.search.placeholder)}


### PR DESCRIPTION
Per https://github.com/shuding/nextra/issues/1606#issuecomment-1457862874, the PR makes the search input always show `Cmd + K`/`Ctrl + K` when loses focus.

Fixes #1606.