### PR TITLE
fix: cusdis display  when config cusdis in blog

### DIFF
--- a/packages/nextra-theme-blog/src/article-layout.tsx
+++ b/packages/nextra-theme-blog/src/article-layout.tsx
@@ -3,6 +3,7 @@ import Meta from './meta'
 import { MDXTheme } from './mdx-theme'
 import { useBlogContext } from './blog-context'
 import { BasicLayout } from './basic-layout'
+import Comments from './cusdis'
 
 export const ArticleLayout = ({ children }: { children: ReactNode }) => {
   const { config } = useBlogContext()
@@ -12,7 +13,7 @@ export const ArticleLayout = ({ children }: { children: ReactNode }) => {
       <MDXTheme>
         {children}
         {config.postFooter}
-        {config.comments}
+        <Comments />
       </MDXTheme>
     </BasicLayout>
   )


### PR DESCRIPTION
I noticed that the pre-existing cusdis component was directly imported here, but after the last change, it seems that the comments are now being imported with a configuration. 
This might be a mistake as it could result in the cusdis component not being used.