### PR TITLE
Fix: Improve sidebar colors accessibility

### DIFF
--- a/.changeset/modern-games-bow.md
+++ b/.changeset/modern-games-bow.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+Improve sidebar colors accessibility

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -50,7 +50,7 @@ const classes = {
     'contrast-more:nx-border-transparent contrast-more:hover:nx-border-gray-900 contrast-more:dark:hover:nx-border-gray-50'
   ),
   active: cn(
-    'nx-bg-primary-50 nx-font-semibold nx-text-primary-600 dark:nx-bg-primary-500/10',
+    'nx-bg-primary-100 nx-font-semibold nx-text-primary-800 dark:nx-bg-primary-400/10 dark:nx-text-primary-600',
     'contrast-more:nx-border-primary-500 contrast-more:dark:nx-border-primary-500'
   ),
   list: cn('nx-flex nx-flex-col nx-gap-1'),


### PR DESCRIPTION
Some hue give not really accessibles sidebar actives items. 

### Some examples :
| Actual  | Fixed |
| ------------- | ------------- |
| <img width="489" alt="image" src="https://user-images.githubusercontent.com/48803115/224540227-7a753a97-a7dc-46a1-bca6-5dcd03c5be57.png">  | <img width="479" alt="image" src="https://user-images.githubusercontent.com/48803115/224540238-3f6101e8-6e98-4526-a307-e29eb14f9a1b.png">  |
| <img width="466" alt="image" src="https://user-images.githubusercontent.com/48803115/224540266-157a999a-40c9-4c06-8db9-0e43a7b39894.png">  | <img width="481" alt="image" src="https://user-images.githubusercontent.com/48803115/224540280-c3f067b5-aa4f-408d-a39a-128163a153a9.png">  |
| <img width="484" alt="image" src="https://user-images.githubusercontent.com/48803115/224540303-d3582c42-e499-4e6a-a056-d3ab561daa1e.png"> | <img width="473" alt="image" src="https://user-images.githubusercontent.com/48803115/224540317-19e89b37-c4a3-4eb0-a449-0db3fd20e656.png"> |
| <img width="478" alt="image" src="https://user-images.githubusercontent.com/48803115/224540818-c660ba37-cc0f-47c3-ae0e-47e924f65020.png"> | <img width="480" alt="image" src="https://user-images.githubusercontent.com/48803115/224540841-602589b6-718b-4bb9-b946-21caa9036e8c.png"> |

### Changes on default Nextra theme
| Actual  | Fixed |
| ------------- | ------------- |
| <img width="239" alt="image" src="https://user-images.githubusercontent.com/48803115/224541098-4d66f8a6-158e-4abd-a557-7b3545332820.png"> | <img width="234" alt="image" src="https://user-images.githubusercontent.com/48803115/224541109-31b15da7-eeec-4d83-a506-88d78cf8d58b.png"> |
| <img width="237" alt="image" src="https://user-images.githubusercontent.com/48803115/224541137-a172a580-42b4-4119-86dd-15b83de4a790.png"> | <img width="234" alt="image" src="https://user-images.githubusercontent.com/48803115/224541148-ef7208ac-9f57-4ee2-bde3-76c39b4859f5.png"> |
