### PR TITLE
fix: improve warning when missing `.git` directory

### DIFF
--- a/.changeset/curly-rings-sip.md
+++ b/.changeset/curly-rings-sip.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+Prints the warning inline instead of the current behavior which includes a stack trace.

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -57,8 +57,10 @@ const initGitRepo = (async () => {
       // repository.path() returns the `/path/to/repo/.git`, we need the parent directory of it
       const gitRoot = path.join(repository.path(), '..')
       return { repository, gitRoot }
-    } catch (e: any) {
-      console.warn(`[nextra] Init git repository failed ${e.message || e}`)
+    } catch (error) {
+      console.warn(
+        `[nextra] Init git repository failed ${(error as Error).message}`
+      )
     }
   }
   return {}

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -57,8 +57,8 @@ const initGitRepo = (async () => {
       // repository.path() returns the `/path/to/repo/.git`, we need the parent directory of it
       const gitRoot = path.join(repository.path(), '..')
       return { repository, gitRoot }
-    } catch (e) {
-      console.warn('[nextra] Init git repository failed', e)
+    } catch (e: any) {
+      console.warn(`[nextra] Init git repository failed ${e.message || e}`)
     }
   }
   return {}


### PR DESCRIPTION
This PR prints the warning inline instead of the current behavior which includes a stack trace.

### Before
```
$ next build
info  - Linting and checking validity of types
[nextra] Init git repository failed Error: Discover git repo from [/Users/styfle/Code/foo] failed: could not find repository from '/Users/styfle/Code/foo'; class=Repository (6); code=NotFound (-3)
    at file:///Users/styfle/Code/foo/node_modules/nextra/dist/loader.mjs:29:37 {
  code: 'GenericFailure'
}
```

### After

```
$ next build
info  - Linting and checking validity of types
[nextra] Init git repository failed Discover git repo from [/Users/styfle/Code/foo] failed: could not find repository from '/Users/styfle/Code/foo'; class=Repository (6); code=NotFound (-3)
```