### PR TITLE
fix: Do not focus search when currently focusing a HTMLElement with contenteditable active

### DIFF
--- a/.changeset/lazy-cooks-wash.md
+++ b/.changeset/lazy-cooks-wash.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Do not focus search when currently focusing a HTMLElement with contenteditable active

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -57,8 +57,9 @@ export function Search({
 
   useEffect(() => {
     const down = (e: globalThis.KeyboardEvent): void => {
-      const tagName = document.activeElement?.tagName.toLowerCase()
-      if (!input.current || !tagName || INPUTS.includes(tagName)) return
+      const activeElement = document.activeElement as HTMLElement;
+      const tagName = activeElement?.tagName.toLowerCase()
+      if (!input.current || !tagName || INPUTS.includes(tagName) || activeElement?.isContentEditable) return
       if (
         e.key === '/' ||
         (e.key === 'k' &&


### PR DESCRIPTION
Fixes: #1703 

I tested this localy on my site by patching node_modules directly and it works at least with `codemirror`.