### PR TITLE
fix: break words in TOC titles for proper wrapping

### DIFF
--- a/.changeset/fix-toc-word-wrap.md
+++ b/.changeset/fix-toc-word-wrap.md
@@ -1,5 +1,0 @@
----
-'nextra-theme-docs': patch
----
-
-Wrap long section headers in TOC properly

--- a/.changeset/fix-toc-word-wrap.md
+++ b/.changeset/fix-toc-word-wrap.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Wrap long section headers in TOC properly

--- a/.changeset/twenty-chefs-switch.md
+++ b/.changeset/twenty-chefs-switch.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Wrap long section headers in TOC properly

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -77,16 +77,16 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
                   className={cn(
                     {
                       2: 'nx-font-semibold',
-                      3: 'ltr:nx-ml-4 rtl:nx-mr-4',
-                      4: 'ltr:nx-ml-8 rtl:nx-mr-8',
-                      5: 'ltr:nx-ml-12 rtl:nx-mr-12',
-                      6: 'ltr:nx-ml-16 rtl:nx-mr-16'
+                      3: 'ltr:nx-pl-4 rtl:nx-pr-4',
+                      4: 'ltr:nx-pl-8 rtl:nx-pr-8',
+                      5: 'ltr:nx-pl-12 rtl:nx-pr-12',
+                      6: 'ltr:nx-pl-16 rtl:nx-pr-16'
                     }[depth as Exclude<typeof depth, 1>],
                     'nx-inline-block',
                     activeAnchor[id]?.isActive
                       ? 'nx-text-primary-600 nx-subpixel-antialiased contrast-more:!nx-text-primary-600'
                       : 'nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-300',
-                    'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50'
+                    'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words'
                   )}
                 >
                   {value}


### PR DESCRIPTION
Fixed wrapping issue in TOC section for long single-word headers (e.g. env variables)

### Before:

https://user-images.githubusercontent.com/827338/230904093-f9de9564-9b73-4c63-9224-46ceb2c3ee07.mp4

### After:

https://user-images.githubusercontent.com/827338/230904132-55bcacfa-c3e8-4795-9e14-cfedc4b636d2.mp4
