### PR TITLE
fix uncrawable links in sidebar, use button when link don't have href because it impacts on SEO

### DIFF
--- a/.changeset/lucky-eels-glow.md
+++ b/.changeset/lucky-eels-glow.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+dd

--- a/.changeset/lucky-eels-glow.md
+++ b/.changeset/lucky-eels-glow.md
@@ -4,4 +4,4 @@
 
 fix uncrawable links in sidebar, use button when link don't have href because it impacts on SEO
 
-remove useless prop children frm <FileTree.File /> component
+remove useless prop children from `<FileTree.File />` component

--- a/.changeset/lucky-eels-glow.md
+++ b/.changeset/lucky-eels-glow.md
@@ -2,4 +2,6 @@
 'nextra-theme-docs': patch
 ---
 
-dd
+fix uncrawable links in sidebar, use button when link don't have href because it impacts on SEO
+
+remove useless prop children frm <FileTree.File /> component

--- a/packages/nextra-theme-docs/src/components/file-tree.tsx
+++ b/packages/nextra-theme-docs/src/components/file-tree.tsx
@@ -21,7 +21,6 @@ interface FileProps {
   name: string
   label?: ReactElement
   active?: boolean
-  children: ReactNode
 }
 
 const Tree = ({ children }: { children: ReactNode }): ReactElement => (
@@ -91,17 +90,14 @@ const Folder = memo<FolderProps>(
 )
 Folder.displayName = 'Folder'
 
-const File = memo<FileProps>(({ label, name, active, ...props }) => (
+const File = memo<FileProps>(({ label, name, active }) => (
   <li
     className={cn(
       'nx-flex nx-list-none',
       active && 'nx-text-primary-600 contrast-more:nx-underline'
     )}
   >
-    <a
-      {...props}
-      className="nx-inline-flex nx-cursor-default nx-items-center nx-py-1"
-    >
+    <a className="nx-inline-flex nx-cursor-default nx-items-center nx-py-1">
       <Ident />
       <svg width="1em" height="1em" viewBox="0 0 24 24">
         <path

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -116,7 +116,7 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
     })
   }
 
-  const isLink = 'withIndexPage' in item && Boolean(item.withIndexPage)
+  const isLink = 'withIndexPage' in item && item.withIndexPage
   // use button when link don't have href because it impacts on SEO
   const ComponentToUse = isLink ? Anchor : 'button'
 

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -116,12 +116,16 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
     })
   }
 
+  const isLink = 'withIndexPage' in item && Boolean(item.withIndexPage)
+  // use button when link don't have href because it impacts on SEO
+  const ComponentToUse = isLink ? Anchor : 'button'
+
   return (
     <li className={cn({ open, active })}>
-      <Anchor
-        href={(item as Item).withIndexPage ? item.route : ''}
+      <ComponentToUse
+        href={isLink ? item.route : undefined}
         className={cn(
-          'nx-items-center nx-justify-between nx-gap-2',
+          'nx-items-center nx-justify-between nx-gap-2 nx-text-left',
           classes.link,
           active ? classes.active : classes.inactive
         )}
@@ -132,7 +136,7 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
           if (clickedToggleIcon) {
             e.preventDefault()
           }
-          if ((item as Item).withIndexPage) {
+          if (isLink) {
             // If it's focused, we toggle it. Otherwise, always open it.
             if (active || clickedToggleIcon) {
               TreeState[item.route] = !open
@@ -160,7 +164,7 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
             open && 'ltr:nx-rotate-90 rtl:nx-rotate-[-270deg]'
           )}
         />
-      </Anchor>
+      </ComponentToUse>
       <Collapse className="ltr:nx-pr-0 rtl:nx-pl-0 nx-pt-1" isOpen={open}>
         {Array.isArray(item.children) ? (
           <Menu


### PR DESCRIPTION
fix uncrawable links in sidebar, use button when link don't have href because it impacts on SEO

remove useless prop `children` frm <FileTree.File /> component

fixes https://github.com/shuding/nextra/issues/1635