### PR TITLE
Use config.useOptions text as the Select `selected` name on Theme Switch

### DIFF
--- a/.changeset/blue-games-pretend.md
+++ b/.changeset/blue-games-pretend.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Use config.useOptions text as the Select selected name on Theme Switch

--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -35,6 +35,12 @@ export function ThemeSwitch({
       ? config.useOptions()
       : config.useOptions
 
+  const optionsMap = {
+    light: options.light,
+    dark: options.dark,
+    system: options.system
+  }
+
   return (
     <Select
       className={className}
@@ -53,7 +59,9 @@ export function ThemeSwitch({
           <div className="nx-flex nx-items-center nx-gap-2 nx-capitalize">
             <IconToUse />
             <span className={lite ? 'md:nx-hidden' : ''}>
-              {mounted ? theme : 'light'}
+              {mounted
+                ? optionsMap[theme as keyof typeof optionsMap]
+                : optionsMap.light}
             </span>
           </div>
         )

--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -35,12 +35,6 @@ export function ThemeSwitch({
       ? config.useOptions()
       : config.useOptions
 
-  const optionsMap = {
-    light: options.light,
-    dark: options.dark,
-    system: options.system
-  }
-
   return (
     <Select
       className={className}
@@ -59,9 +53,7 @@ export function ThemeSwitch({
           <div className="nx-flex nx-items-center nx-gap-2 nx-capitalize">
             <IconToUse />
             <span className={lite ? 'md:nx-hidden' : ''}>
-              {mounted
-                ? optionsMap[theme as keyof typeof optionsMap]
-                : optionsMap.light}
+              {mounted ? options[theme as keyof typeof options] : options.light}
             </span>
           </div>
         )


### PR DESCRIPTION
## Description

Here I'm using the themeSwitch `useOptions` custom hook to change the default language to portuguese (pt-BR) on my docs site but the selected option text does not replicate the options I'm returning.

```jsx
// ./theme.config.js
export default {
  themeSwitch: {
    useOptions() {
      return {
        light: 'Claro',
        dark: 'Escuro',
        system: 'Sistema',
      }
    }
  }
}
```

## Output

<img width="291" alt="CleanShot 2023-04-17 at 13 59 13@2x" src="https://user-images.githubusercontent.com/54036572/232558087-c32ce0b1-8f1a-4f8b-b5b7-0f20d3e565f7.png">

<img width="291" alt="CleanShot 2023-04-17 at 14 03 40@2x" src="https://user-images.githubusercontent.com/54036572/232558231-a4dfb9f7-9be3-4066-9d0a-a44270315b9b.png">

## Solution

To fix the issue I'm using the `useOptions().config` object and grabbing the text using the `theme` string from next-themes `useTheme()` hook