### PR TITLE
Feature Request: add `depth` prop to TOC headingComponent

### DIFF
--- a/.changeset/eleven-kids-clap.md
+++ b/.changeset/eleven-kids-clap.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+Add `depth` prop to TOC `headingComponent`

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -398,7 +398,7 @@ Show a table of contents on the right side of the page. It’s useful for naviga
   ['toc.extraContent', 'React.ReactNode | React.FC', 'Display extra content below the TOC content.'],
   ['toc.float', 'boolean', 'Float the TOC next to the content.'],
   ['toc.title', 'React.ReactNode | React.FC', 'Title of the TOC sidebar. By default it’s “On This Page”.'],
-  ['toc.headingComponent', 'React.FC<{ id: string, children: string }>', 'Custom renderer of TOC headings.'],
+  ['toc.headingComponent', 'React.FC<{ id: string, depth: number; children: string }>', 'Custom renderer of TOC headings.'],
 ]}/>
 
 #### Floating TOC

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -91,6 +91,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
                 >
                   {config.toc.headingComponent?.({
                     id,
+                    depth,
                     children: value
                   }) ?? value}
                 </a>

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -70,33 +70,69 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
             {renderComponent(config.toc.title)}
           </p>
           <ul>
-            {items.map(({ id, value, depth }) => (
-              <li className="nx-my-2 nx-scroll-my-6 nx-scroll-py-6" key={id}>
-                <a
-                  href={`#${id}`}
-                  className={cn(
-                    {
-                      2: 'nx-font-semibold',
-                      3: 'ltr:nx-pl-4 rtl:nx-pr-4',
-                      4: 'ltr:nx-pl-8 rtl:nx-pr-8',
-                      5: 'ltr:nx-pl-12 rtl:nx-pr-12',
-                      6: 'ltr:nx-pl-16 rtl:nx-pr-16'
-                    }[depth as Exclude<typeof depth, 1>],
-                    'nx-inline-block',
-                    activeAnchor[id]?.isActive
-                      ? 'nx-text-primary-600 nx-subpixel-antialiased contrast-more:!nx-text-primary-600'
-                      : 'nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-300',
-                    'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words'
-                  )}
-                >
-                  {config.toc.headingComponent?.({
-                    id,
-                    depth,
-                    children: value
-                  }) ?? value}
-                </a>
-              </li>
-            ))}
+            {items.map(({ id, value, depth }) =>
+              config.toc.headingComponent ? (
+                config.toc.headingComponent({
+                  id,
+                  depth,
+                  children: value
+                }) ? (
+                  <li
+                    className="nx-my-2 nx-scroll-my-6 nx-scroll-py-6"
+                    key={id}
+                  >
+                    <a
+                      href={`#${id}`}
+                      className={cn(
+                        {
+                          2: 'nx-font-semibold',
+                          3: 'ltr:nx-pl-4 rtl:nx-pr-4',
+                          4: 'ltr:nx-pl-8 rtl:nx-pr-8',
+                          5: 'ltr:nx-pl-12 rtl:nx-pr-12',
+                          6: 'ltr:nx-pl-16 rtl:nx-pr-16'
+                        }[depth as Exclude<typeof depth, 1>],
+                        'nx-inline-block',
+                        activeAnchor[id]?.isActive
+                          ? 'nx-text-primary-600 nx-subpixel-antialiased contrast-more:!nx-text-primary-600'
+                          : 'nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-300',
+                        'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words'
+                      )}
+                    >
+                      {config.toc.headingComponent({
+                        id,
+                        depth,
+                        children: value
+                      })}
+                    </a>
+                  </li>
+                ) : (
+                  <li
+                    className="nx-my-2 nx-scroll-my-6 nx-scroll-py-6"
+                    key={id}
+                  >
+                    <a
+                      href={`#${id}`}
+                      className={cn(
+                        {
+                          2: 'nx-font-semibold',
+                          3: 'ltr:nx-pl-4 rtl:nx-pr-4',
+                          4: 'ltr:nx-pl-8 rtl:nx-pr-8',
+                          5: 'ltr:nx-pl-12 rtl:nx-pr-12',
+                          6: 'ltr:nx-pl-16 rtl:nx-pr-16'
+                        }[depth as Exclude<typeof depth, 1>],
+                        'nx-inline-block',
+                        activeAnchor[id]?.isActive
+                          ? 'nx-text-primary-600 nx-subpixel-antialiased contrast-more:!nx-text-primary-600'
+                          : 'nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-300',
+                        'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words'
+                      )}
+                    >
+                      {value}
+                    </a>
+                  </li>
+                )
+              ) : null
+            )}
           </ul>
         </>
       )}

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -150,7 +150,7 @@ export const themeSchema = z.strictObject({
     extraContent: z.custom<ReactNode | FC>(...reactNode),
     float: z.boolean(),
     headingComponent: z
-      .custom<FC<{ id: string; children: string }>>(...fc)
+      .custom<FC<{ id: string; depth: number; children: string }>>(...fc)
       .optional(),
     title: z.custom<ReactNode | FC>(...reactNode)
   }),


### PR DESCRIPTION
# Add `depth` prop to TOC headingComponent

I would like to display only the headings from depth 1 to 4 in the TOC component.

```jsx
// ./theme.config.tsx

export default {
  toc: {
    headingComponent({ depth, children }) {
      //               ^? Property 'depth' does not exist on type '{ id: string; children: string; }'.
      return depth < 5 ? <>{children}</> : null
    },
  },
}
```

## Suggested solution

- Provide the `depth` prop to the `headingComponent`
- Renders the default `headingComponent` when `config.toc.headingComponent` is undefined
- Renders the custom `config.toc.headingComponent` when its return value is truthy
- Renders nothing when the `config.toc.headingComponent` return value is falsy
  