### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple, powerful and flexible site generation framework with everything you love
 
 ### Installation
 
-The Nextra repository uses [PNPM Workspaces](https://pnpm.io/workspaces) and [Turborepo](https://github.com/vercel/turborepo). To install dependencies, just simply run `pnpm` in the project root directory.
+The Nextra repository uses [PNPM Workspaces](https://pnpm.io/workspaces) and [Turborepo](https://github.com/vercel/turborepo). To install dependencies, run `pnpm install` in the project root directory.
 
 ### Build Nextra Core
 


### PR DESCRIPTION
Running nextra for the first time locally. 

The installation command is incorrect. Running `pnpm` itself presents the help text for pnpm.

![image](https://user-images.githubusercontent.com/298435/236599242-9067134d-c2e3-47b7-bc99-6aa1884a2120.png)

----

I also removed `just simply` as not inclusive words. See https://bradfrost.com/blog/post/just/ for some more thoughts on this