### PR TITLE
fix `Error: ENOENT: no such file or directory` in Nx-managed monorepos

### DIFF
--- a/.changeset/blue-apricots-hammer.md
+++ b/.changeset/blue-apricots-hammer.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+fix `Error: ENOENT: no such file or directory` in Nx-managed monorepos

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -100,10 +100,11 @@ async function loader(
   const mdxPath = (
     context._module?.resourceResolveData
       ? // to make it work with symlinks, resolve the mdx path based on the relative path
-        path.join(
-          context.rootContext,
-          context._module.resourceResolveData.relativePath
-        )
+        /*
+         * `context._module.resourceResolveData.relativePath` could include path chunk of
+         * `context.rootContext` use `context._module.rawRequest` instead
+         */
+        path.join(context.rootContext, context._module.rawRequest)
       : context.resourcePath
   ) as MdxPath
 

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -101,10 +101,14 @@ async function loader(
     context._module?.resourceResolveData
       ? // to make it work with symlinks, resolve the mdx path based on the relative path
         /*
-         * `context._module.resourceResolveData.relativePath` could include path chunk of
-         * `context.rootContext` use `context._module.rawRequest` instead
+         * `context.rootContext` could include path chunk of
+         * `context._module.resourceResolveData.relativePath` use
+         * `context._module.resourceResolveData.descriptionFileRoot` instead
          */
-        path.join(context.rootContext, context._module.rawRequest)
+      path.join(
+        context._module.resourceResolveData.descriptionFileRoot,
+        context._module.resourceResolveData.relativePath
+      )
       : context.resourcePath
   ) as MdxPath
 


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/1762