### PR TITLE
fix(blog): Use tailwind prose for small screens

### DIFF
--- a/.changeset/happy-pianos-fail.md
+++ b/.changeset/happy-pianos-fail.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-blog': patch
+---
+
+Fix prose styles for small breakpoints

--- a/packages/nextra-theme-blog/src/basic-layout.tsx
+++ b/packages/nextra-theme-blog/src/basic-layout.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react'
 import { useRef } from 'react'
 import { useBlogContext } from './blog-context'
 import { HeadingContext } from './mdx-theme'
@@ -10,7 +10,7 @@ export const BasicLayout = ({ children }: { children: ReactNode }) => {
   const ref = useRef<HTMLHeadingElement>(null)
   return (
     <article
-      className="nx-container nx-prose-sm dark:nx-prose-dark md:nx-prose"
+      className="nx-container nx-prose nx-prose-sm dark:nx-prose-dark md:nx-prose"
       dir="ltr"
     >
       <Head>

--- a/packages/nextra-theme-blog/src/basic-layout.tsx
+++ b/packages/nextra-theme-blog/src/basic-layout.tsx
@@ -9,7 +9,7 @@ export const BasicLayout = ({ children }: { children: ReactNode }) => {
   const title = `${opts.title}${config.titleSuffix || ''}`
   const ref = useRef<HTMLHeadingElement>(null)
   return (
-    <article className="nx-container nx-prose dark:nx-prose-dark" dir="ltr">
+    <article className="nx-container nx-prose max-md:nx-prose-sm dark:nx-prose-dark" dir="ltr">
       <Head>
         <title>{title}</title>
         {config.head?.({ title, meta: opts.frontMatter })}

--- a/packages/nextra-theme-blog/src/basic-layout.tsx
+++ b/packages/nextra-theme-blog/src/basic-layout.tsx
@@ -9,10 +9,7 @@ export const BasicLayout = ({ children }: { children: ReactNode }) => {
   const title = `${opts.title}${config.titleSuffix || ''}`
   const ref = useRef<HTMLHeadingElement>(null)
   return (
-    <article
-      className="nx-container nx-prose nx-prose-sm dark:nx-prose-dark md:nx-prose"
-      dir="ltr"
-    >
+    <article className="nx-container nx-prose dark:nx-prose-dark" dir="ltr">
       <Head>
         <title>{title}</title>
         {config.head?.({ title, meta: opts.frontMatter })}

--- a/packages/nextra-theme-blog/src/styles.css
+++ b/packages/nextra-theme-blog/src/styles.css
@@ -21,7 +21,7 @@ h1 {
   letter-spacing: -0.03em;
 }
 
-.nx-prose-sm code {
+.nx-prose code {
   &:before,
   &:after {
     @apply nx-hidden;


### PR DESCRIPTION
I started using the blog theme and noticed that some styles were missing on smaller screens. Things like `blockquote`, headings and `a` elements weren't properly styled. After digging into it a bit I found that the `prose` class wasn't applied to all breakpoints, just `sm`. Adding the `nx-prose` class to the basic layout fixed things.

I walked through the blog example after the change and confirmed that the styles were applied and nothing else was affected. If necessary I can add some before and after screenshots.