### PR TITLE
fixed accessability issue in light mode for nav bar

### DIFF
--- a/packages/nextra-theme-blog/src/nav.tsx
+++ b/packages/nextra-theme-blog/src/nav.tsx
@@ -15,7 +15,7 @@ export default function Nav(): ReactElement {
             return (
               <span
                 key={page.route}
-                className="nx-cursor-default nx-text-gray-400"
+                className={`nx-cursor-default ${config.darkMode ? 'nx-text-gray-400' : 'nx-text-gray-600'}`}
               >
                 {page.frontMatter?.title || page.name}
               </span>


### PR DESCRIPTION
The current blog theme nav bars contrast is insufficient between the background and foreground colors for the `<span>` element in light mode. It now passes WCAG standards according to AA and AAA.