### PR TITLE
Update docs for remark plugins

### DIFF
--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -186,12 +186,14 @@ import remarkMdxDisableExplicitJsx from 'remark-mdx-disable-explicit-jsx'
 const withNextra = nextra({
   theme: 'nextra-theme-docs',
   themeConfig: './theme.config.tsx',
-  remarkPlugins: [
-    [
-      remarkMdxDisableExplicitJsx,
-      { whiteList: ['table', 'thead', 'tbody', 'tr', 'th', 'td'] }
+  mdxOptions: {
+    remarkPlugins: [
+      [
+        remarkMdxDisableExplicitJsx,
+        { whiteList: ['table', 'thead', 'tbody', 'tr', 'th', 'td'] }
+      ]
     ]
-  ]
+  }
 })
 
 export default withNextra()


### PR DESCRIPTION
Possibly outdated docs? currently working with 2.5.2 and this seems to be the structure