### PR TITLE
Fix: Navbar item use href instead of route

### DIFF
--- a/.changeset/quick-cherries-check.md
+++ b/.changeset/quick-cherries-check.md
@@ -1,0 +1,7 @@
+---
+"nextra-theme-docs": patch
+"nextra": patch
+"docs": patch
+---
+
+Fix unexpected behaviour when having multiple navbar items that point to the same folder (shuding/nextra#1857)

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -147,9 +147,10 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
               (page.withIndexPage ? page.route : page.firstChildRoute) || href
           }
 
+          const route = page.href || page.route
           const isActive =
-            page.route === activeRoute ||
-            activeRoute.startsWith(page.route + '/')
+            route === activeRoute ||
+            activeRoute.startsWith(route + '/')
 
           return (
             <Anchor


### PR DESCRIPTION
If defined, use `page.href` instead of `page.route` to determine weither the item is actived or not (#1857)