### PR TITLE
fix: headline in firefox

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -140,7 +140,7 @@ import docsCardDark from '../public/assets/card-1.dark.png'
       border-bottom: 1px solid rgb(38,38,38);
     }
     .headline {
-      display: inline-block;
+      display: inline-flex;
       font-size: 3.125rem;
       font-size: min(4.375rem, max(8vw, 2.5rem));
       font-weight: 700;


### PR DESCRIPTION
On Firefox, the spacing between two lines of headline is too large.
![image](https://github.com/shuding/nextra/assets/85140972/dacc94f4-69b1-439f-b75a-a2fcfeaddb76)
This PR fix it.
![image](https://github.com/shuding/nextra/assets/85140972/959ac3d8-44c3-4186-96e9-fc8e2ed8ae48)
Env:
1. MacOS 13 + Firefox 111.0.1 => 113.0.1
2. Windows 11 + Firefox developer 114.0b7
