### PR TITLE
fix: can't build package on windows

### DIFF
--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -14,6 +14,8 @@ const CLIENT_ENTRY = [
 const entries = fg.sync(CLIENT_ENTRY, { absolute: true })
 const entriesSet = new Set(entries)
 
+const winPath = (p: string) => p.replace(/\\/g, '/')
+
 const sharedConfig = defineConfig({
   // import.meta is available only from es2020
   target: 'es2020',
@@ -33,14 +35,14 @@ const sharedConfig = defineConfig({
             !args.path.endsWith('.json')
           ) {
             let isDir: boolean
-            const importPath = path.join(args.resolveDir, args.path)
+            const importPath = winPath(path.join(args.resolveDir, args.path))
             try {
               isDir = (await fs.stat(importPath)).isDirectory()
             } catch {
               isDir = false
             }
 
-            const isClientImporter = entriesSet.has(args.importer)
+            const isClientImporter = entriesSet.has(winPath(args.importer))
 
             if (isClientImporter) {
               const isClientImport = entries.some(entry =>

--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'tsup'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import fg from 'fast-glob'
+import slash from 'slash'
 
 import tsconfig from './tsconfig.json'
 
@@ -13,8 +14,6 @@ const CLIENT_ENTRY = [
 
 const entries = fg.sync(CLIENT_ENTRY, { absolute: true })
 const entriesSet = new Set(entries)
-
-const winPath = (p: string) => p.replace(/\\/g, '/')
 
 const sharedConfig = defineConfig({
   // import.meta is available only from es2020
@@ -35,14 +34,14 @@ const sharedConfig = defineConfig({
             !args.path.endsWith('.json')
           ) {
             let isDir: boolean
-            const importPath = winPath(path.join(args.resolveDir, args.path))
+            const importPath = slash(path.join(args.resolveDir, args.path))
             try {
               isDir = (await fs.stat(importPath)).isDirectory()
             } catch {
               isDir = false
             }
 
-            const isClientImporter = entriesSet.has(winPath(args.importer))
+            const isClientImporter = entriesSet.has(slash(args.importer))
 
             if (isClientImporter) {
               const isClientImport = entries.some(entry =>


### PR DESCRIPTION
On windows, `fast-glob` return path use '/' as separator, but esbuild use '\\', causing the esbuild plugin `add-mjs` can't identify client import, so the `nextra` package build output client script as `.mjs`:

![image](https://github.com/shuding/nextra/assets/85140972/77869e26-0cc9-4e26-a1d4-599d9e823efd)
