### PR TITLE
fix: project root path error in nx

### DIFF
--- a/packages/nextra/src/file-system.ts
+++ b/packages/nextra/src/file-system.ts
@@ -7,7 +7,8 @@ const { findPagesDir, existsSync } = getDefault(findPagesDirImport)
 export { existsSync }
 
 export function findPagesDirectory(): string {
-  const res = findPagesDir(CWD, false)
+  const rootDir = process.env.NEXT_ROOT || CWD
+  const res = findPagesDir(rootDir, false)
   return (
     res.pagesDir || // next v13
     (res as any).pages // next v12


### PR DESCRIPTION
A simple attempt to fix the error only, without verifying that the rest of the functionality is correct.

new `next.config.js`
```ts
//@ts-check
// nextra need root dir
process.env.NEXT_ROOT = __dirname

// eslint-disable-next-line @typescript-eslint/no-var-requires
const { composePlugins, withNx } = require('@nx/next')
const withNextra = require('nextra')

/**
 * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
 **/
const nextConfig = {
  nx: {
    // Set this to true if you would like to use SVGR
    // See: https://github.com/gregberge/svgr
    svgr: false,
  },
}

const plugins = [
  // Add more Next.js plugins to this list if needed.
  withNx,
  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
  // @ts-ignore
  withNextra({
    theme: 'nextra-theme-docs',
    themeConfig: './theme.config.tsx',
    rootDir: __dirname,
  }),
]

module.exports = composePlugins(...plugins)(nextConfig)

```