### PR TITLE
fix: typo in word pnpm

### DIFF
--- a/docs/pages/docs/docs-theme/built-ins/tabs.mdx
+++ b/docs/pages/docs/docs-theme/built-ins/tabs.mdx
@@ -7,7 +7,7 @@ A built-in tab component of the Docs Theme.
 import { Tab, Tabs } from 'nextra-theme-docs'
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>**pNPM**: Fast, disk space efficient package manager.</Tab>
+  <Tab>**pnpm**: Fast, disk space efficient package manager.</Tab>
   <Tab>
     **npm** is a package manager for the JavaScript programming language.
   </Tab>
@@ -22,7 +22,7 @@ import { Tab, Tabs } from 'nextra-theme-docs'
 import { Tab, Tabs } from 'nextra-theme-docs'
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>
-  <Tab>**pNPM**: Fast, disk space efficient package manager.</Tab>
+  <Tab>**pnpm**: Fast, disk space efficient package manager.</Tab>
   <Tab>
     **npm** is a package manager for the JavaScript programming language.
   </Tab>
@@ -45,7 +45,7 @@ import { Tab, Tabs } from 'nextra-theme-docs'
 And you will have `npm` as the default tab:
 
 <Tabs items={['pnpm', 'npm', 'yarn']} defaultIndex="1">
-  <Tab>**pNPM**: Fast, disk space efficient package manager.</Tab>
+  <Tab>**pnpm**: Fast, disk space efficient package manager.</Tab>
   <Tab>
     **npm** is a package manager for the JavaScript programming language.
   </Tab>


### PR DESCRIPTION
I discovered a simple typing error in the library where "pnpm" was written as "pNPM" with the "npm" in uppercase.

I have corrected these issues in lines 10, 25, and 48.