### PR TITLE
fix select+copy for code blocks with line numbers

### DIFF
--- a/.changeset/neat-kings-approve.md
+++ b/.changeset/neat-kings-approve.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+fix broken code format while selecting and copying code with `showLineNumbers` option enabled

--- a/packages/nextra/styles/code-block.css
+++ b/packages/nextra/styles/code-block.css
@@ -3,7 +3,7 @@ code {
   font-feature-settings: 'rlig' 1, 'calt' 1, 'ss01' 1;
 
   &[data-line-numbers] > .line {
-    @apply nx-inline-flex nx-pl-2;
+    @apply nx-pl-2;
     &::before {
       counter-increment: line;
       content: counter(line);


### PR DESCRIPTION
Selecting and copying code/lines from code blocks with line numbers is currently broken.

Try it with the docs site here: https://nextra.site/docs/guide/syntax-highlighting

<img width="514" alt="image" src="https://github.com/shuding/nextra/assets/508855/4da09bec-8af0-4802-9861-94a4057011ad">

Result:
```
function
 
Counter
() {
  
const
 [
count
,
 
setCount
] 
=
 
useState
(
0
)
  
return
 <
button
 
onClick
=
{() 
=>
 
setCount
(count 
+
 
1
)}>{count}</
button
>
}
```

By removing `display: inline-flex`, I see no visual differences except that copying code works again:

<img width="452" alt="image" src="https://github.com/shuding/nextra/assets/508855/9a654b8f-ab1c-45ae-9372-8bbd5ed39866">

Result:
```
function Counter() {
  const [count, setCount] = useState(0)
  return <button onClick={() => setCount(count + 1)}>{count}</button>
}
```