### PR TITLE
fix: replace last 'export default MDXContent;'

### DIFF
--- a/.changeset/real-games-scream.md
+++ b/.changeset/real-games-scream.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+replace last match of `export default MDXContent;`

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -321,7 +321,7 @@ const __nextraPageOptions = {
         (themeConfigImport && 'themeConfig: __nextra_themeConfig')
   }
 }
-${finalResult.replace('export default MDXContent;', '')}
+${finalResult.replace(/(export default MDXContent;).*$/, '$1')}
 if (process.env.NODE_ENV !== 'production') {
   __nextraPageOptions.hot = module.hot
   __nextraPageOptions.pageOptsChecksum = ${stringifiedChecksum}

--- a/packages/nextra/src/loader.ts
+++ b/packages/nextra/src/loader.ts
@@ -321,7 +321,10 @@ const __nextraPageOptions = {
         (themeConfigImport && 'themeConfig: __nextra_themeConfig')
   }
 }
-${finalResult.replace(/(export default MDXContent;).*$/, '$1')}
+${
+  // Remove the last match of `export default MDXContent` because it can be existed in the raw MDX file
+  finalResult.slice(0, finalResult.lastIndexOf('export default MDXContent;'))
+}
 if (process.env.NODE_ENV !== 'production') {
   __nextraPageOptions.hot = module.hot
   __nextraPageOptions.pageOptsChecksum = ${stringifiedChecksum}


### PR DESCRIPTION
Fix to replace the last 'export default MDXContent;' instead of the first one.

If .mdx file contains a string that exactly matches 'export default MDXContent;', the certain export is not removed and it will result in an error.