### PR TITLE
fix: update href to docs page

### DIFF
--- a/docs/pages/docs/guide/organize-files.mdx
+++ b/docs/pages/docs/guide/organize-files.mdx
@@ -112,6 +112,6 @@ Check the corresponding pages for more information:
   <Card
     icon={<FileIcon />}
     title="Blog Theme →"
-    href="/docs/blog-theme/page-configuration"
+    href="/docs/blog-theme/start"
   />
 </Cards>


### PR DESCRIPTION
<img width="1025" alt="image" src="https://github.com/shuding/nextra/assets/57122180/53f47533-4d11-49d4-a219-00e857e9081c">

This page isn't exist.
Check this page https://nextra.site/docs/guide/organize-files

So I update href