### PR TITLE
Fixed link from Latex page to Markdown page

### DIFF
--- a/docs/pages/docs/guide/advanced/latex.mdx
+++ b/docs/pages/docs/guide/advanced/latex.mdx
@@ -25,7 +25,7 @@ will be rendered as:
   The **Pythagorean equation**: $a=\sqrt{b^2 + c^2}$.
 </div>
 
-You can still use [Markdown and MDX syntax](markdown) in the same line as your LaTeX expression.
+You can still use [Markdown and MDX syntax](../markdown) in the same line as your LaTeX expression.
 
 import { Callout } from 'nextra/components'
 


### PR DESCRIPTION
The link from the Latex page to the Markdown page references the same parent folder, but the markdown page is one folder above. This is fixed by adding the "../" to the front of the link path.