### PR TITLE
fix: default config to exclude `ERROR_ROUTES` from search and posts

### DIFF
--- a/.changeset/happy-clocks-tease.md
+++ b/.changeset/happy-clocks-tease.md
@@ -1,0 +1,6 @@
+---
+"nextra-theme-blog": patch
+"nextra": patch
+---
+
+fix: default config to exclude /404 from search and posts

--- a/.changeset/happy-clocks-tease.md
+++ b/.changeset/happy-clocks-tease.md
@@ -3,4 +3,4 @@
 "nextra": patch
 ---
 
-fix: default config to exclude /404 from search and posts
+fix: default config to exclude /404 and /500 from search and posts

--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -62,6 +62,7 @@
     }
   },
   "dependencies": {
+    "minimatch": "^9.0.3",
     "next-themes": "^0.2.1"
   },
   "devDependencies": {

--- a/packages/nextra-theme-blog/src/constants.tsx
+++ b/packages/nextra-theme-blog/src/constants.tsx
@@ -1,4 +1,5 @@
 /* eslint sort-keys: error */
+import { ERROR_ROUTES } from 'nextra/constants'
 import type { NextraBlogTheme } from './types'
 
 export const DEFAULT_THEME: NextraBlogTheme = {
@@ -7,6 +8,6 @@ export const DEFAULT_THEME: NextraBlogTheme = {
       CC BY-NC 4.0 {new Date().getFullYear()} © Shu Ding.
     </small>
   ),
-  hiddenPages: ['/404'],
+  hiddenPages: [...ERROR_ROUTES],
   readMore: 'Read More →'
 }

--- a/packages/nextra-theme-blog/src/constants.tsx
+++ b/packages/nextra-theme-blog/src/constants.tsx
@@ -2,6 +2,7 @@
 import type { NextraBlogTheme } from './types'
 
 export const DEFAULT_THEME: NextraBlogTheme = {
+  excludePatterns: ["/404"],
   footer: (
     <small className="nx-mt-32 nx-block">
       CC BY-NC 4.0 {new Date().getFullYear()} © Shu Ding.

--- a/packages/nextra-theme-blog/src/constants.tsx
+++ b/packages/nextra-theme-blog/src/constants.tsx
@@ -2,11 +2,11 @@
 import type { NextraBlogTheme } from './types'
 
 export const DEFAULT_THEME: NextraBlogTheme = {
-  excludePatterns: ["/404"],
   footer: (
     <small className="nx-mt-32 nx-block">
       CC BY-NC 4.0 {new Date().getFullYear()} © Shu Ding.
     </small>
   ),
+  hiddenPages: ['/404'],
   readMore: 'Read More →'
 }

--- a/packages/nextra-theme-blog/src/index.tsx
+++ b/packages/nextra-theme-blog/src/index.tsx
@@ -12,7 +12,8 @@ const layoutMap = {
   post: ArticleLayout,
   page: PageLayout,
   posts: PostsLayout,
-  tag: PostsLayout
+  tag: PostsLayout,
+  ['hidden-page']: PageLayout
 }
 
 const BlogLayout = ({
@@ -23,8 +24,11 @@ const BlogLayout = ({
   const type = opts.frontMatter.type || 'post'
   const Layout = layoutMap[type]
   if (!Layout) {
+    const supported = Object.keys(layoutMap)
+      .map(type => `"${type}"`)
+      .join(', ')
     throw new Error(
-      `nextra-theme-blog does not support the layout type "${type}" It only supports "post", "page", "posts" and "tag"`
+      `nextra-theme-blog does not support the layout type "${type}" It only supports ${supported}`
     )
   }
   return (

--- a/packages/nextra-theme-blog/src/posts-layout.tsx
+++ b/packages/nextra-theme-blog/src/posts-layout.tsx
@@ -1,4 +1,3 @@
-import { minimatch } from 'minimatch'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import type { ReactElement, ReactNode } from 'react'
@@ -7,6 +6,7 @@ import { useBlogContext } from './blog-context'
 import { MDXTheme } from './mdx-theme'
 import Nav from './nav'
 import { collectPostsAndNavs } from './utils/collect'
+import { pageType } from './utils/frontmatter'
 import getTags from './utils/get-tags'
 
 export function PostsLayout({
@@ -17,13 +17,10 @@ export function PostsLayout({
   const { config, opts } = useBlogContext()
   const { posts } = collectPostsAndNavs({ config, opts })
   const router = useRouter()
-  const { type } = opts.frontMatter
+  const type = pageType(opts, config)
   const tagName = type === 'tag' ? router.query.tag : null
 
   const postList = posts.map(post => {
-    for (const excludePattern of config.excludePatterns || []) {
-      if (minimatch(post.route, excludePattern)) return null
-    }
     if (tagName) {
       const tags = getTags(post)
       if (!Array.isArray(tagName) && !tags.includes(tagName)) {

--- a/packages/nextra-theme-blog/src/posts-layout.tsx
+++ b/packages/nextra-theme-blog/src/posts-layout.tsx
@@ -1,3 +1,4 @@
+import { minimatch } from 'minimatch'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import type { ReactElement, ReactNode } from 'react'
@@ -20,6 +21,9 @@ export function PostsLayout({
   const tagName = type === 'tag' ? router.query.tag : null
 
   const postList = posts.map(post => {
+    for (const excludePattern of config.excludePatterns || []) {
+      if (minimatch(post.route, excludePattern)) return null
+    }
     if (tagName) {
       const tags = getTags(post)
       if (!Array.isArray(tagName) && !tags.includes(tagName)) {

--- a/packages/nextra-theme-blog/src/types.ts
+++ b/packages/nextra-theme-blog/src/types.ts
@@ -13,7 +13,6 @@ export interface NextraBlogTheme {
   }
   darkMode?: boolean
   dateFormatter?: (date: Date) => string
-  excludePatterns?: string[]
   footer?: ReactNode
   head?: ({
     meta,
@@ -22,6 +21,7 @@ export interface NextraBlogTheme {
     meta: Record<string, any>
     title: string
   }) => ReactNode
+  hiddenPages?: string[]
   navs?: {
     name: string
     url: string
@@ -40,7 +40,7 @@ export type BlogFrontMatter = {
   description?: string
   tag?: string | string[]
   title?: string
-  type?: 'post' | 'page' | 'posts' | 'tag'
+  type?: 'post' | 'page' | 'posts' | 'tag' | 'hidden-page'
 }
 
 export interface LayoutProps {

--- a/packages/nextra-theme-blog/src/types.ts
+++ b/packages/nextra-theme-blog/src/types.ts
@@ -13,6 +13,7 @@ export interface NextraBlogTheme {
   }
   darkMode?: boolean
   dateFormatter?: (date: Date) => string
+  excludePatterns?: string[]
   footer?: ReactNode
   head?: ({
     meta,

--- a/packages/nextra-theme-blog/src/utils/collect.ts
+++ b/packages/nextra-theme-blog/src/utils/collect.ts
@@ -1,32 +1,35 @@
 import type { MdxFile, PageMapItem } from 'nextra'
-import type { LayoutProps } from '../types'
+import type { LayoutProps, NextraBlogTheme } from '../types'
 import { sortDate } from './date'
+import { pageType } from './frontmatter'
 import traverse from './traverse'
 
-const isNav = (page: PageMapItem): page is MdxFile => {
-  const type = 'frontMatter' in page && page.frontMatter?.type
-  return type && ['page', 'posts'].includes(type)
+const isNav = (page: PageMapItem, config: NextraBlogTheme): page is MdxFile => {
+  const type = 'frontMatter' in page && pageType(page, config)
+  return type !== false && ['page', 'posts'].includes(type)
 }
-const isPost = (page: PageMapItem): page is MdxFile => {
+const isPost = (
+  page: PageMapItem,
+  config: NextraBlogTheme
+): page is MdxFile => {
   if (
     page.kind === 'Folder' ||
     page.kind === 'Meta' ||
     page.name.startsWith('_')
   )
     return false
-  const type = page.frontMatter?.type
-  return !type || type === 'post'
+  return pageType(page, config) === 'post'
 }
 
-export const collectPostsAndNavs = ({ opts }: LayoutProps) => {
+export const collectPostsAndNavs = ({ config, opts }: LayoutProps) => {
   const posts: MdxFile[] = []
   const navPages: (MdxFile & { active: boolean })[] = []
   const { route } = opts
   traverse(opts.pageMap, page => {
-    if (isNav(page)) {
+    if (isNav(page, config)) {
       navPages.push({ ...page, active: page.route === route })
     }
-    if (isPost(page)) {
+    if (isPost(page, config)) {
       posts.push(page)
     }
   })

--- a/packages/nextra-theme-blog/src/utils/frontmatter.ts
+++ b/packages/nextra-theme-blog/src/utils/frontmatter.ts
@@ -1,0 +1,17 @@
+import { minimatch } from 'minimatch'
+import type { MdxFile } from 'nextra'
+import type { NextraBlogTheme } from '../types'
+
+export function pageType(
+  page: Pick<MdxFile, 'frontMatter' | 'route'>,
+  config: NextraBlogTheme
+): string {
+  const type = page.frontMatter?.type
+  if (typeof type === 'string') return type
+
+  for (const hiddenPage of config.hiddenPages || []) {
+    if (minimatch(page.route, hiddenPage)) return 'hidden-post'
+  }
+
+  return 'post'
+}

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -12,6 +12,7 @@
     "./package.json": "./package.json",
     ".": "./dist/index.js",
     "./catch-all": "./dist/catch-all.js",
+    "./constants": "./dist/constants.mjs",
     "./data": {
       "import": "./dist/ssg.js",
       "types": "./dist/ssg.d.ts"
@@ -59,6 +60,9 @@
     "*": {
       "compile": [
         "./dist/compile.d.ts"
+      ],
+      "constants": [
+        "./dist/constants.d.ts"
       ],
       "context": [
         "./dist/context.d.ts"

--- a/packages/nextra/src/constants.ts
+++ b/packages/nextra/src/constants.ts
@@ -16,7 +16,7 @@ export const DEFAULT_CONFIG: Omit<NextraConfig, 'theme'> = {
   flexsearch: {
     codeblocks: true,
     indexKey: (_, route, locale) =>
-      route === '/404' ? null : locale || DEFAULT_LOCALE
+      ERROR_ROUTES.has(route) ? null : locale || DEFAULT_LOCALE
   },
   codeHighlight: true
 }

--- a/packages/nextra/src/constants.ts
+++ b/packages/nextra/src/constants.ts
@@ -16,7 +16,7 @@ export const DEFAULT_CONFIG: Omit<NextraConfig, 'theme'> = {
   flexsearch: {
     codeblocks: true,
     indexKey: (_, route, locale) =>
-      route === "/404" ? null : (locale || DEFAULT_LOCALE)
+      route === '/404' ? null : locale || DEFAULT_LOCALE
   },
   codeHighlight: true
 }

--- a/packages/nextra/src/constants.ts
+++ b/packages/nextra/src/constants.ts
@@ -14,7 +14,9 @@ export const DEFAULT_LOCALE = 'en-US'
 export const DEFAULT_CONFIG: Omit<NextraConfig, 'theme'> = {
   staticImage: true,
   flexsearch: {
-    codeblocks: true
+    codeblocks: true,
+    indexKey: (_, route, locale) =>
+      route === "/404" ? null : (locale || DEFAULT_LOCALE)
   },
   codeHighlight: true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
 
   packages/nextra-theme-blog:
     dependencies:
+      minimatch:
+        specifier: ^9.0.3
+        version: 9.0.3
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@13.4.8)(react-dom@18.2.0)(react@18.2.0)
@@ -4175,7 +4178,6 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
@@ -4209,7 +4211,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -7936,6 +7937,13 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
     dev: true
+
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}


### PR DESCRIPTION
resolves #2099

* sets default `indexKey` for search to exclude `ERROR_ROUTES`
* adds `type: hidden-page` to blog theme
* adds `hiddenPages` globs to blog theme; if `type` is not specified, it will be `hidden-page` if matching `hiddenPages` else `post`
* sets default `hiddenPages` for blog to exclude `ERROR_ROUTES`