### PR TITLE
fix(normalize-pages): findFirstRoute should ignore separator type

### DIFF
--- a/.changeset/curvy-ties-pump.md
+++ b/.changeset/curvy-ties-pump.md
@@ -1,0 +1,5 @@
+---
+'nextra': major
+---
+
+findFirstRoute should ignore separator type

--- a/packages/nextra/src/normalize-pages.ts
+++ b/packages/nextra/src/normalize-pages.ts
@@ -126,7 +126,8 @@ type DocsItem = (MdxFile | FolderWithoutChildren) & {
 
 function findFirstRoute(items: DocsItem[]): string | undefined {
   for (const item of items) {
-    if (item.route) return item.route
+    // seprator route always return `#`
+    if (item.route && item.type !== 'separator') return item.route
     if (item.children) {
       const route = findFirstRoute(item.children)
       if (route) return route


### PR DESCRIPTION
Closes #2110, #2084

Step to reproduce the bug:

## Step 1: 

Go to `examples/docs` folder to changes below: 

```js
// root _meta.json
{
  "index": "Introduction",
  "get-started": "Get Started",
  "features": "Features",
  "themes": "Themes",
  "advanced": {
    "title": "Advanced",
    "type": "page"
  }
}
```

```js
// advanded folder _meta.json
{
  "-- Guide": {
    "type": "separator",
    "title": "Guide"
  },
  "code-highlighting": "Code Highlighting"
}
```

## Step 2: 

run `pnpm --filter example-docs dev`

## Step 3: 

Click the menu, you should notice the link is `#`


<img width="416" alt="Screenshot 2023-07-26 at 9 19 57 PM" src="https://github.com/shuding/nextra/assets/11520821/1f3905d4-f421-4841-9e02-a5133eb66ded">


