### PR TITLE
use github-slugger for custom heading ids to prevent duplicated headings

### DIFF
--- a/.changeset/curvy-pigs-ring.md
+++ b/.changeset/curvy-pigs-ring.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-docs': patch
+'nextra': patch
+'nextra-theme-blog': patch
+---
+
+use github-slugger for custom heading ids to prevent duplicated headings

--- a/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
@@ -17,7 +17,7 @@ function _createMdxContent(props) {
     h1: \\"h1\\",
     code: \\"code\\"
   }, _provideComponents(), props.components);
-  return <_components.h1><_components.code>{\\"codegen.yml\\"}</_components.code></_components.h1>;
+  return <_components.h1 id=\\"codegenyml\\"><_components.code>{\\"codegen.yml\\"}</_components.code></_components.h1>;
 }
 function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
@@ -48,7 +48,7 @@ function _createMdxContent(props) {
     h1: \\"h1\\",
     code: \\"code\\"
   }, _provideComponents(), props.components);
-  return <_components.h1><_components.code>{\\"codegen.yml\\"}</_components.code>{\\" file\\"}</_components.h1>;
+  return <_components.h1 id=\\"codegenyml-file\\"><_components.code>{\\"codegen.yml\\"}</_components.code>{\\" file\\"}</_components.h1>;
 }
 function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
@@ -84,7 +84,7 @@ function _createMdxContent(props) {
   const _components = Object.assign({
     h1: \\"h1\\"
   }, _provideComponents(), props.components);
-  return <_components.h1>{\\"Posts Tagged with “\\"}<TagName />{\\"”\\"}</_components.h1>;
+  return <_components.h1 id=\\"posts-tagged-with-\\">{\\"Posts Tagged with “\\"}<TagName />{\\"”\\"}</_components.h1>;
 }
 function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);
@@ -143,7 +143,7 @@ function _createMdxContent(props) {
   const _components = Object.assign({
     h1: \\"h1\\"
   }, _provideComponents(), props.components);
-  return <_components.h1>{\\"Hello World\\"}</_components.h1>;
+  return <_components.h1 id=\\"hello-world\\">{\\"Hello World\\"}</_components.h1>;
 }
 function MDXContent(props = {}) {
   const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);

--- a/packages/nextra/__test__/compile.test.ts
+++ b/packages/nextra/__test__/compile.test.ts
@@ -69,7 +69,7 @@ describe('Process heading', () => {
     expect(result).toMatch(
       `<_components.h3 id="without-space">{"nospace"}</_components.h3>`
     )
-    expect(result).toMatch(`<_components.h4 id="другой язык">{"foo"}`)
+    expect(result).toMatch(`<_components.h4 id="другой-язык">{"foo"}`)
     expect(result).toMatch(`<_components.h5 id="bar-baz-">{"bar Baz []"}`)
     expect(result).toMatch(`<_components.h6 id="bar-qux-">{"bar Qux [#]"}`)
   })

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -150,7 +150,6 @@
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",
-    "@types/github-slugger": "^2.0.0",
     "@types/graceful-fs": "^4.1.6",
     "@types/lodash.get": "^4.4.7",
     "@types/mdast": "^4.0.0",

--- a/packages/nextra/src/mdx-plugins/rehype.ts
+++ b/packages/nextra/src/mdx-plugins/rehype.ts
@@ -1,8 +1,5 @@
 // @ts-nocheck
-
-import Slugger from 'github-slugger'
 import { CODE_BLOCK_FILENAME_REGEX } from '../constants'
-import { getFlattenedValue } from './remark-headings'
 
 function visit(node, tagNames, handler) {
   if (tagNames.includes(node.tagName)) {
@@ -30,17 +27,7 @@ export const parseMeta =
   }
 
 export const attachMeta = () => tree => {
-  const slugger = new Slugger()
-
-  const headingsWithSlug = new Set(['h2', 'h3', 'h4', 'h5', 'h6'])
-
-  visit(tree, [...headingsWithSlug, 'div', 'pre'], node => {
-    if (headingsWithSlug.has(node.tagName)) {
-      // Attach slug
-      node.properties.id ||= slugger.slug(getFlattenedValue(node))
-      return
-    }
-
+  visit(tree, ['div', 'pre'], node => {
     if ('data-rehype-pretty-code-fragment' in node.properties) {
       // remove <div data-rehype-pretty-code-fragment /> element that wraps <pre /> element
       // because we'll wrap with our own <div />

--- a/packages/nextra/src/mdx-plugins/remark-custom-heading-id.ts
+++ b/packages/nextra/src/mdx-plugins/remark-custom-heading-id.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'unified'
 import { visit } from 'unist-util-visit'
 
 export type HProperties = {
-  id?: string
+  id: string
 }
 
 export const remarkCustomHeadingId: Plugin<[], Root> =
@@ -17,8 +17,8 @@ export const remarkCustomHeadingId: Plugin<[], Root> =
 
       if (!matched) return
       node.data ||= {}
-      node.data.hProperties ||= {} as HProperties
-      ;(node.data.hProperties as HProperties).id = matched[1]
+      const headingProps = (node.data.hProperties ||= {}) as HProperties
+      headingProps.id = matched[1]
 
       lastChild.value = heading.slice(0, matched.index)
     })

--- a/packages/nextra/src/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/mdx-plugins/remark-headings.ts
@@ -46,6 +46,23 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
             id:
               (node.data?.hProperties as HProperties)?.id || slugger.slug(value)
           }
+
+          // check if heading.id already exists in headings list
+          const sameHeadingIdIndex = data.headingMeta.headings.findIndex(h => h.id == heading.id);
+
+          // no need to iterate on depth 1 headings
+          if(sameHeadingIdIndex !== -1 && heading.depth > 1) {
+            const oldHeading = data.headingMeta.headings[sameHeadingIdIndex]
+            // findLastIndex workaround: clone, rotate, findLastIndex (todo: refactor)
+            const lowerDepthHeadingIndex = data.headingMeta.headings
+              .slice(0)
+              .reverse()
+              .findIndex((heading) => heading.depth == oldHeading.depth - 1);
+
+            // append lower heading id
+            if(lowerDepthHeadingIndex) heading.id = slugger.slug(`${data.headingMeta.headings[lowerDepthHeadingIndex].id}-${heading.id}`);
+          }
+
           data.headingMeta.headings.push(heading)
           if (hasJsxInH1) {
             data.headingMeta.hasJsxInH1 = true

--- a/packages/nextra/src/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/mdx-plugins/remark-headings.ts
@@ -64,7 +64,6 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
         }
       }
     )
-    console.log(data.headingMeta.headings)
     done()
   }
 }

--- a/packages/nextra/src/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/mdx-plugins/remark-headings.ts
@@ -51,19 +51,22 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
           const sameHeadingIdIndex = data.headingMeta.headings.findIndex(h => h.id == heading.id);
 
           // no need to iterate on depth 1 headings
-          if(sameHeadingIdIndex !== -1 && heading.depth > 1) {
-            const oldHeading = data.headingMeta.headings[sameHeadingIdIndex]
-            // findLastIndex workaround: clone, rotate, findLastIndex (todo: refactor)
-            const lowerDepthHeadingIndex = data.headingMeta.headings
-              .slice(0)
-              .reverse()
-              .findIndex((heading) => heading.depth == oldHeading.depth - 1);
-
-            // append lower heading id
-            if(lowerDepthHeadingIndex) heading.id = slugger.slug(`${data.headingMeta.headings[lowerDepthHeadingIndex].id}-${heading.id}`);
+          if (sameHeadingIdIndex !== -1 && heading.depth > 1) {
+            const oldHeading = data.headingMeta.headings[sameHeadingIdIndex];
+            let lowerDepthHeadingIndex = -1;
+          
+            for (let i = data.headingMeta.headings.length - 1; i >= 0; i--) {
+              if (data.headingMeta.headings[i].depth === oldHeading.depth - 1) {
+                lowerDepthHeadingIndex = i;
+                break;
+              }
+            }
+          
+            // prepend lower heading id
+            if (lowerDepthHeadingIndex) {
+              heading.id = slugger.slug(`${data.headingMeta.headings[lowerDepthHeadingIndex].id}-${heading.id}`);
+            }
           }
-
-          data.headingMeta.headings.push(heading)
           if (hasJsxInH1) {
             data.headingMeta.hasJsxInH1 = true
           }

--- a/packages/nextra/src/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/mdx-plugins/remark-headings.ts
@@ -48,27 +48,31 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
           }
 
           // check if heading.id already exists in headings list
-          const sameHeadingIdIndex = data.headingMeta.headings.findIndex(h => h.id == heading.id);
+          const sameHeadingIdIndex = data.headingMeta.headings.findIndex(
+            h => h.id == heading.id
+          )
 
           // no need to iterate on depth 1 headings
           if (sameHeadingIdIndex !== -1 && heading.depth > 1) {
-            const oldHeading = data.headingMeta.headings[sameHeadingIdIndex];
-            let lowerDepthHeadingIndex = -1;
-          
+            const oldHeading = data.headingMeta.headings[sameHeadingIdIndex]
+            let lowerDepthHeadingIndex = -1
+
             for (let i = data.headingMeta.headings.length - 1; i >= 0; i--) {
               if (data.headingMeta.headings[i].depth === oldHeading.depth - 1) {
-                lowerDepthHeadingIndex = i;
-                break;
+                lowerDepthHeadingIndex = i
+                break
               }
             }
-          
+
             // prepend lower heading id
             if (lowerDepthHeadingIndex) {
-              heading.id = slugger.slug(`${data.headingMeta.headings[lowerDepthHeadingIndex].id}-${heading.id}`);
+              heading.id = slugger.slug(
+                `${data.headingMeta.headings[lowerDepthHeadingIndex].id}-${heading.id}`
+              )
             }
           }
           data.headingMeta.headings.push(heading)
-          
+
           if (hasJsxInH1) {
             data.headingMeta.hasJsxInH1 = true
           }

--- a/packages/nextra/src/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/mdx-plugins/remark-headings.ts
@@ -43,36 +43,11 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
           const heading = {
             depth: node.depth,
             value,
-            id:
-              (node.data?.hProperties as HProperties)?.id || slugger.slug(value)
-          }
-
-          // check if heading.id already exists in headings list
-          const sameHeadingIdIndex = data.headingMeta.headings.findIndex(
-            h => h.id == heading.id
-          )
-
-          // no need to iterate on depth 1 headings
-          if (sameHeadingIdIndex !== -1 && heading.depth > 1) {
-            const oldHeading = data.headingMeta.headings[sameHeadingIdIndex]
-            let lowerDepthHeadingIndex = -1
-
-            for (let i = data.headingMeta.headings.length - 1; i >= 0; i--) {
-              if (data.headingMeta.headings[i].depth === oldHeading.depth - 1) {
-                lowerDepthHeadingIndex = i
-                break
-              }
-            }
-
-            // prepend lower heading id
-            if (lowerDepthHeadingIndex) {
-              heading.id = slugger.slug(
-                `${data.headingMeta.headings[lowerDepthHeadingIndex].id}-${heading.id}`
-              )
-            }
+            id: slugger.slug(
+              (node.data?.hProperties as HProperties)?.id || value
+            )
           }
           data.headingMeta.headings.push(heading)
-
           if (hasJsxInH1) {
             data.headingMeta.hasJsxInH1 = true
           }
@@ -89,6 +64,7 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
         }
       }
     )
+    console.log(data.headingMeta.headings)
     done()
   }
 }

--- a/packages/nextra/src/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/mdx-plugins/remark-headings.ts
@@ -67,6 +67,8 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
               heading.id = slugger.slug(`${data.headingMeta.headings[lowerDepthHeadingIndex].id}-${heading.id}`);
             }
           }
+          data.headingMeta.headings.push(heading)
+          
           if (hasJsxInH1) {
             data.headingMeta.hasJsxInH1 = true
           }

--- a/packages/nextra/src/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/mdx-plugins/remark-headings.ts
@@ -6,7 +6,7 @@ import { visit } from 'unist-util-visit'
 import type { PageOpts } from '../types'
 import type { HProperties } from './remark-custom-heading-id'
 
-export const getFlattenedValue = (node: Parent): string =>
+const getFlattenedValue = (node: Parent): string =>
   node.children
     .map(child =>
       'children' in child
@@ -40,12 +40,17 @@ export const remarkHeadings: Plugin<[], Root> = function (this: Processor) {
               (child: { type: string }) => child.type === 'mdxJsxTextElement'
             )
           const value = getFlattenedValue(node)
+
+          node.data ||= {}
+          const headingProps = (node.data.hProperties ||= {}) as HProperties
+          const id = slugger.slug(headingProps.id || value)
+          // Attach flattened/custom #id to heading node
+          headingProps.id = id
+
           const heading = {
             depth: node.depth,
             value,
-            id: slugger.slug(
-              (node.data?.hProperties as HProperties)?.id || value
-            )
+            id
           }
           data.headingMeta.headings.push(heading)
           if (hasJsxInH1) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,6 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
-      '@types/github-slugger':
-        specifier: ^2.0.0
-        version: 2.0.0
       '@types/graceful-fs':
         specifier: ^4.1.6
         version: 4.1.6
@@ -3409,13 +3406,6 @@ packages:
     resolution: {integrity: sha512-Zf9mY4Mz7N3Nyi341nUkOtgVUQn4j6NS4ndqEha/lOgEbTkHzpD7wZuRagYKzrXNtvawWfsrojoC1nhsQexvNA==}
     dev: true
 
-  /@types/github-slugger@2.0.0:
-    resolution: {integrity: sha512-z/FaJhjFPk5mtrsZWeqyvaJdcZKw6CVCTuynEMrcXtgyozN3yMrtL13xWv8uQV2bWtwSXkdiNM37HEKkEj9x1Q==}
-    deprecated: This is a stub types definition. github-slugger provides its own type definitions, so you do not need this installed.
-    dependencies:
-      github-slugger: 2.0.0
-    dev: true
-
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
@@ -6254,6 +6244,7 @@ packages:
 
   /github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+    dev: false
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}


### PR DESCRIPTION
As noticed by @uonr on his issue at [vercel/swr-site#530](https://github.com/vercel/swr-site/pull/530), same headings generate the same anchor ids. This PR adds checking of existent headings before pushing, and, if necessary, adds a prefix based on the closest lower depth heading.

Here's a comparision from the SWR's Mutation and Revalidation heading tree:

```
--- BEFORE ---

mutate #mutate
  Global Mutate #global-mutate
  Bound Mutate #bound-mutate
  Revalidation #revalidation
  API #api
    Parameters #parameters
    Return Values #return-values
  useSWRMutation #useswrmutation
    API #api <-- DUPLICATED ID
      Parameters #parameters <-- DUPLICATED ID
      Return Values #return-values <-- DUPLICATED ID
    Basic Usage #basic-usage
    Defer loading data until needed #defer-loading-data-until-needed

--- AFTER ---

mutate #mutate
  Global Mutate #global-mutate
  Bound Mutate #bound-mutate
  Revalidation #revalidation
  API #api
    Parameters #parameters
    Return Values #return-values
  useSWRMutation #useswrmutation
    API #useswrmutation-api
      Parameters #useswrmutation-parameters
      Return Values #useswrmutation-return-values
    Basic Usage #basic-usage
    Defer loading data until needed #defer-loading-data-until-needed
```