### PR TITLE
feat(core): Add description field to card component

### DIFF
--- a/.changeset/tender-bikes-mix.md
+++ b/.changeset/tender-bikes-mix.md
@@ -1,0 +1,5 @@
+---
+'nextra': minor
+---
+
+Added `description` attribute for the built-in `<Card />` component

--- a/docs/pages/docs/docs-theme.mdx
+++ b/docs/pages/docs/docs-theme.mdx
@@ -12,21 +12,25 @@ import { Card, Cards } from 'nextra/components'
   <Card
     icon={<ChevronRightIcon />}
     title="Get Started"
+    description="Learn how to setup your first project quickly"
     href="/docs/docs-theme/start"
   />
   <Card
     icon={<RowsIcon />}
     title="Page Configuration"
+    description="Check how to tweak configurations to use your own styles"
     href="/docs/docs-theme/page-configuration"
   />
   <Card
     icon={<GearIcon />}
     title="Theme Configuration"
+    description="Want to do something different? Learn how to extend Nextra."
     href="/docs/docs-theme/theme-configuration"
   />
   <Card
     icon={<BoxIcon />}
     title="Built-in Components"
+    description="Hand-crafted components for common use cases"
     href="/docs/docs-theme/built-ins"
   />
 </Cards>

--- a/docs/pages/docs/guide/built-ins/cards.mdx
+++ b/docs/pages/docs/guide/built-ins/cards.mdx
@@ -1,4 +1,9 @@
-import { CardsIcon, OneIcon, WarningIcon, FolderTreeIcon } from '@components/icons'
+import {
+  CardsIcon,
+  FolderTreeIcon,
+  OneIcon,
+  WarningIcon
+} from '@components/icons'
 import { Card, Cards } from 'nextra/components'
 
 # Cards Component
@@ -16,8 +21,14 @@ import { Card, Cards } from 'nextra/components'
 </Cards>
 
 ### With Description
+
 <Cards>
-  <Card icon={<FolderTreeIcon />} title="FileTree" description="Display beautiful File trees alongside your content" href="/docs/guide/built-ins/filetree" />
+  <Card
+    icon={<FolderTreeIcon />}
+    title="FileTree"
+    description="Display beautiful File trees alongside your content"
+    href="/docs/guide/built-ins/filetree"
+  />
 </Cards>
 
 ## Usage

--- a/docs/pages/docs/guide/built-ins/cards.mdx
+++ b/docs/pages/docs/guide/built-ins/cards.mdx
@@ -1,4 +1,4 @@
-import { CardsIcon, OneIcon, WarningIcon } from '@components/icons'
+import { CardsIcon, OneIcon, WarningIcon, FolderTreeIcon } from '@components/icons'
 import { Card, Cards } from 'nextra/components'
 
 # Cards Component
@@ -15,16 +15,23 @@ import { Card, Cards } from 'nextra/components'
   <Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
 </Cards>
 
+### With Description
+<Cards>
+  <Card icon={<FolderTreeIcon />} title="FileTree" description="Display beautiful File trees alongside your content" href="/docs/guide/built-ins/filetree" />
+</Cards>
+
 ## Usage
 
 {/* prettier-ignore */}
 ```mdx filename="Markdown"
 import { Cards, Card } from 'nextra/components'
-import { CardsIcon, OneIcon, WarningIcon } from '../../icons'
+import { CardsIcon, OneIcon, WarningIcon, FolderTreeIcon } from '../../icons'
 
 <Cards>
   <Card icon={<WarningIcon />} title="Callout" href="/docs/guide/built-ins/callout" />
   <Card icon={<CardsIcon />} title="Tabs" href="/docs/guide/built-ins/tabs" />
   <Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
+
+  <Card icon={<FolderTreeIcon />} title="FileTree" description="Display beautiful File trees alongside your content" href="/docs/guide/built-ins/filetree" />
 </Cards>
 ```

--- a/packages/nextra/src/components/cards.tsx
+++ b/packages/nextra/src/components/cards.tsx
@@ -64,7 +64,7 @@ export function Card({
             classes.title,
             'dark:nx-text-gray-300 dark:hover:nx-text-gray-100',
             {
-              "nx-pb-0": description,
+              'nx-pb-0': description
             }
           )}
         >
@@ -75,10 +75,12 @@ export function Card({
           </span>
 
           {description && (
-            <p className={cn(
-              classes.description,
-              'dark:nx-text-neutral-400 dark:group-hover:nx-text-neutral-100 nx-flex nx-items-center'
-            )}>
+            <p
+              className={cn(
+                classes.description,
+                'dark:nx-text-neutral-400 dark:group-hover:nx-text-neutral-100 nx-flex nx-items-center'
+              )}
+            >
               {description}
             </p>
           )}
@@ -101,7 +103,7 @@ export function Card({
           classes.title,
           'dark:nx-text-neutral-200 dark:hover:nx-text-neutral-50',
           {
-            "nx-pb-0": description,
+            'nx-pb-0': description
           }
         )}
       >
@@ -111,10 +113,12 @@ export function Card({
       </span>
 
       {description && (
-        <p className={cn(
-          classes.description,
-          'dark:nx-text-neutral-400 dark:group-hover:nx-text-neutral-100 nx-flex nx-items-center'
-        )}>
+        <p
+          className={cn(
+            classes.description,
+            'dark:nx-text-neutral-400 dark:group-hover:nx-text-neutral-100 nx-flex nx-items-center'
+          )}
+        >
           {description}
         </p>
       )}

--- a/packages/nextra/src/components/cards.tsx
+++ b/packages/nextra/src/components/cards.tsx
@@ -16,6 +16,9 @@ const classes = {
   ),
   title: cn(
     'nx-flex nx-font-semibold nx-items-start nx-gap-2 nx-p-4 nx-text-gray-700 hover:nx-text-gray-900'
+  ),
+  description: cn(
+    'nx-flex nx-items-start nx-gap-2 nx-pb-4 nx-px-4 nx-text-sm nx-text-gray-600 group-hover:nx-text-gray-600 nx-duration-75 nx-transition-colors'
   )
 }
 
@@ -28,6 +31,7 @@ const arrowEl = (
 export function Card({
   children,
   title,
+  description,
   icon,
   image,
   arrow,
@@ -36,6 +40,7 @@ export function Card({
 }: {
   children: ReactNode
   title: string
+  description?: string
   icon: ReactNode
   image?: boolean
   arrow?: boolean
@@ -57,7 +62,10 @@ export function Card({
         <span
           className={cn(
             classes.title,
-            'dark:nx-text-gray-300 dark:hover:nx-text-gray-100'
+            'dark:nx-text-gray-300 dark:hover:nx-text-gray-100',
+            {
+              "nx-pb-0": description,
+            }
           )}
         >
           {icon}
@@ -65,6 +73,15 @@ export function Card({
             {title}
             {animatedArrow}
           </span>
+
+          {description && (
+            <p className={cn(
+              classes.description,
+              'dark:nx-text-neutral-400 dark:group-hover:nx-text-neutral-100 nx-flex nx-items-center'
+            )}>
+              {description}
+            </p>
+          )}
         </span>
       </NextLink>
     )
@@ -82,13 +99,25 @@ export function Card({
       <span
         className={cn(
           classes.title,
-          'dark:nx-text-neutral-200 dark:hover:nx-text-neutral-50 nx-flex nx-items-center'
+          'dark:nx-text-neutral-200 dark:hover:nx-text-neutral-50',
+          {
+            "nx-pb-0": description,
+          }
         )}
       >
         {icon}
         {title}
         {animatedArrow}
       </span>
+
+      {description && (
+        <p className={cn(
+          classes.description,
+          'dark:nx-text-neutral-400 dark:group-hover:nx-text-neutral-100 nx-flex nx-items-center'
+        )}>
+          {description}
+        </p>
+      )}
     </NextLink>
   )
 }


### PR DESCRIPTION
This PR closes #2149.

As mentioned in the issue, the `<Card />` built-in component does not have a property to add context in the form of a description. Many developers that use Nextra in their projects, have to go for patching the library in order to have a full Description feature.

This PR adds the `description` prop, its styling, and also updates the built-in components section to include examples of using `<Card />` with the new prop.

## Views
Dark mode:
![image](https://github.com/guilherssousa/nextra/assets/47110995/79809ed8-ff83-441b-a979-2c9ae8c2d466)
Light mode:
![image](https://github.com/guilherssousa/nextra/assets/47110995/0d354d04-2e47-4eea-a74c-42f5f2ba8841)

## API Example
```tsx
<Card
  title="FileTree"
  description="Display beautiful File trees alongside your content"
  href="/docs/guide/built-ins/filetree"
/>
```