### PR TITLE
some major updates

### DIFF
--- a/.changeset/poor-carrots-raise.md
+++ b/.changeset/poor-carrots-raise.md
@@ -1,0 +1,9 @@
+---
+'nextra-theme-docs': major
+---
+
+- remove `Steps`, `Callout`, `Tabs`, `Tab`, `Cards`, `Card`, `FileTree` exports, export them now from `nextra/components`
+
+- remove `useMDXComponents` export, export it now from `nextra/mdx`
+
+- set by default `sidebar.toggleButton` to true

--- a/docs/pages/docs/docs-theme.mdx
+++ b/docs/pages/docs/docs-theme.mdx
@@ -6,25 +6,25 @@ import {
   GearIcon,
   RowsIcon
 } from '@components/icons'
-import { Card, Cards } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<ChevronRightIcon />}
     title="Get Started"
     href="/docs/docs-theme/start"
   />
-  <Card
+  <Cards.Card
     icon={<RowsIcon />}
     title="Page Configuration"
     href="/docs/docs-theme/page-configuration"
   />
-  <Card
+  <Cards.Card
     icon={<GearIcon />}
     title="Theme Configuration"
     href="/docs/docs-theme/theme-configuration"
   />
-  <Card
+  <Cards.Card
     icon={<BoxIcon />}
     title="Built-in Components"
     href="/docs/docs-theme/built-ins"

--- a/docs/pages/docs/docs-theme/built-ins.mdx
+++ b/docs/pages/docs/docs-theme/built-ins.mdx
@@ -1,13 +1,13 @@
 # Built-ins
 
 import { CardsIcon } from '@components/icons'
-import { Card, Cards } from 'nextra-theme-docs'
+import { Cards } from 'nextra/components'
 
 The Nextra Docs Theme includes a couple of built-in components that you can use
 to better style your documentation:
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<CardsIcon />}
     title="Bleed"
     href="/docs/docs-theme/built-ins/bleed"

--- a/docs/pages/docs/docs-theme/start.mdx
+++ b/docs/pages/docs/docs-theme/start.mdx
@@ -1,5 +1,5 @@
 import { BoxIcon, GearIcon, RowsIcon } from '@components/icons'
-import { Callout, Card, Cards, Steps } from 'nextra/components'
+import { Callout, Cards, Steps } from 'nextra/components'
 
 # Docs Theme
 
@@ -109,17 +109,17 @@ Next, check out the next section to learn about organizing the documentation
 structure and configuring the website theme:
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<RowsIcon />}
     title="Page Structure"
     href="/docs/docs-theme/page-configuration"
   />
-  <Card
+  <Cards.Card
     icon={<GearIcon />}
     title="Theme Configuration"
     href="/docs/docs-theme/theme-configuration"
   />
-  <Card
+  <Cards.Card
     icon={<BoxIcon />}
     title="Built-in Components"
     href="/docs/docs-theme/built-ins"

--- a/docs/pages/docs/guide.mdx
+++ b/docs/pages/docs/guide.mdx
@@ -10,7 +10,7 @@ import {
   PictureIcon,
   StarsIcon
 } from '@components/icons'
-import { Card, Cards } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 # Guide
 
@@ -18,24 +18,52 @@ The following features are configured via the Next.js configuration and are
 available in all themes.
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<FilesIcon />}
     title="Organize Files"
     href="/docs/guide/organize-files"
   />
-  <Card icon={<MarkdownIcon />} title="Markdown" href="/docs/guide/markdown" />
-  <Card
+  <Cards.Card
+    icon={<MarkdownIcon />}
+    title="Markdown"
+    href="/docs/guide/markdown"
+  />
+  <Cards.Card
     icon={<StarsIcon />}
     title="Syntax Highlighting"
     href="/docs/guide/syntax-highlighting"
   />
-  <Card icon={<LinkIcon />} title="Next.js Link" href="/docs/guide/link" />
-  <Card icon={<PictureIcon />} title="Next.js Image" href="/docs/guide/image" />
-  <Card icon={<LightningIcon />} title="Next.js SSG" href="/docs/guide/ssg" />
-  <Card icon={<GlobeIcon />} title="Next.js I18n" href="/docs/guide/i18n" />
-  <Card icon={<BrushIcon />} title="Custom CSS" href="/docs/guide/custom-css" />
-  <Card icon={<DropperIcon />} title="Advanced" href="/docs/guide/advanced" />
-  <Card
+  <Cards.Card
+    icon={<LinkIcon />}
+    title="Next.js Link"
+    href="/docs/guide/link"
+  />
+  <Cards.Card
+    icon={<PictureIcon />}
+    title="Next.js Image"
+    href="/docs/guide/image"
+  />
+  <Cards.Card
+    icon={<LightningIcon />}
+    title="Next.js SSG"
+    href="/docs/guide/ssg"
+  />
+  <Cards.Card
+    icon={<GlobeIcon />}
+    title="Next.js I18n"
+    href="/docs/guide/i18n"
+  />
+  <Cards.Card
+    icon={<BrushIcon />}
+    title="Custom CSS"
+    href="/docs/guide/custom-css"
+  />
+  <Cards.Card
+    icon={<DropperIcon />}
+    title="Advanced"
+    href="/docs/guide/advanced"
+  />
+  <Cards.Card
     icon={<BoxIcon />}
     title="Built-in Components"
     href="/docs/guide/built-ins"

--- a/docs/pages/docs/guide/advanced.mdx
+++ b/docs/pages/docs/guide/advanced.mdx
@@ -7,40 +7,40 @@ import {
   TailwindIcon,
   TerminalIcon
 } from '@components/icons'
-import { Card, Cards } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<TerminalIcon />}
     title="Npm2Yarn"
     href="/docs/guide/advanced/npm2yarn"
   />
-  <Card
+  <Cards.Card
     icon={<DiagramIcon />}
     title="Mermaid"
     href="/docs/guide/advanced/mermaid"
   />
-  <Card
+  <Cards.Card
     icon={<TailwindIcon className="h-6 w-6" />}
     title="Tailwind CSS"
     href="/docs/guide/advanced/tailwind-css"
   />
-  <Card
+  <Cards.Card
     icon={<FormulaIcon />}
     title="LaTeX"
     href="/docs/guide/advanced/latex"
   />
-  <Card
+  <Cards.Card
     icon={<TableIcon />}
     title="Rendering Tables"
     href="/docs/guide/advanced/table"
   />
-  <Card
+  <Cards.Card
     icon={<CodeIcon />}
     title="TypeScript"
     href="/docs/guide/advanced/typescript"
   />
-  <Card
+  <Cards.Card
     icon={<CloudIcon />}
     title="Remote Content"
     href="/docs/guide/advanced/remote"

--- a/docs/pages/docs/guide/built-ins.mdx
+++ b/docs/pages/docs/guide/built-ins.mdx
@@ -5,7 +5,7 @@ import {
   OneIcon,
   WarningIcon
 } from '@components/icons'
-import { Card, Cards } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 # Built-ins
 
@@ -13,19 +13,27 @@ Nextra includes a couple of built-in components that you can use to better style
 your content:
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<WarningIcon />}
     title="Callout"
     href="/docs/guide/built-ins/callout"
   />
-  <Card icon={<CardsIcon />} title="Tabs" href="/docs/guide/built-ins/tabs" />
-  <Card
+  <Cards.Card
+    icon={<CardsIcon />}
+    title="Tabs"
+    href="/docs/guide/built-ins/tabs"
+  />
+  <Cards.Card
     icon={<IdCardIcon />}
     title="Cards"
     href="/docs/guide/built-ins/cards"
   />
-  <Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
-  <Card
+  <Cards.Card
+    icon={<OneIcon />}
+    title="Steps"
+    href="/docs/guide/built-ins/steps"
+  />
+  <Cards.Card
     icon={<FolderTreeIcon className="h-5 w-5" />}
     title="FileTree"
     href="/docs/guide/built-ins/filetree"

--- a/docs/pages/docs/guide/built-ins/cards.mdx
+++ b/docs/pages/docs/guide/built-ins/cards.mdx
@@ -11,8 +11,16 @@ import { Cards } from 'nextra/components'
     title="Callout"
     href="/docs/guide/built-ins/callout"
   />
-  <Cards.Card icon={<CardsIcon />} title="Tabs" href="/docs/guide/built-ins/tabs" />
-  <Cards.Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
+  <Cards.Card
+    icon={<CardsIcon />}
+    title="Tabs"
+    href="/docs/guide/built-ins/tabs"
+  />
+  <Cards.Card
+    icon={<OneIcon />}
+    title="Steps"
+    href="/docs/guide/built-ins/steps"
+  />
 </Cards>
 
 ## Usage

--- a/docs/pages/docs/guide/built-ins/cards.mdx
+++ b/docs/pages/docs/guide/built-ins/cards.mdx
@@ -1,30 +1,30 @@
 import { CardsIcon, OneIcon, WarningIcon } from '@components/icons'
-import { Card, Cards } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 # Cards Component
 
 ## Example
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<WarningIcon />}
     title="Callout"
     href="/docs/guide/built-ins/callout"
   />
-  <Card icon={<CardsIcon />} title="Tabs" href="/docs/guide/built-ins/tabs" />
-  <Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
+  <Cards.Card icon={<CardsIcon />} title="Tabs" href="/docs/guide/built-ins/tabs" />
+  <Cards.Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
 </Cards>
 
 ## Usage
 
 {/* prettier-ignore */}
 ```mdx filename="Markdown"
-import { Cards, Card } from 'nextra/components'
+import { Cards } from 'nextra/components'
 import { CardsIcon, OneIcon, WarningIcon } from '../../icons'
 
 <Cards>
-  <Card icon={<WarningIcon />} title="Callout" href="/docs/guide/built-ins/callout" />
-  <Card icon={<CardsIcon />} title="Tabs" href="/docs/guide/built-ins/tabs" />
-  <Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
+  <Cards.Card icon={<WarningIcon />} title="Callout" href="/docs/guide/built-ins/callout" />
+  <Cards.Card icon={<CardsIcon />} title="Tabs" href="/docs/guide/built-ins/tabs" />
+  <Cards.Card icon={<OneIcon />} title="Steps" href="/docs/guide/built-ins/steps" />
 </Cards>
 ```

--- a/docs/pages/docs/guide/markdown.mdx
+++ b/docs/pages/docs/guide/markdown.mdx
@@ -115,12 +115,12 @@ default `#long-heading-about-nextra`.
 ## Extended Syntax Highlighting
 
 import { StarsIcon } from '@components/icons'
-import { Card, Cards } from 'nextra/components'
+import { Cards } from 'nextra/components'
 
 Check out the Syntax Highlighting section for more information:
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<StarsIcon />}
     title="Syntax Highlighting"
     href="/docs/guide/syntax-highlighting"

--- a/docs/pages/docs/guide/organize-files.mdx
+++ b/docs/pages/docs/guide/organize-files.mdx
@@ -1,5 +1,5 @@
 import { FileIcon, NewsletterIcon } from '@components/icons'
-import { Card, Cards, FileTree } from 'nextra/components'
+import { Cards, FileTree } from 'nextra/components'
 
 # Organize Files
 
@@ -105,12 +105,12 @@ The extra configurations are passed to the **theme** as additional information.
 Check the corresponding pages for more information:
 
 <Cards>
-  <Card
+  <Cards.Card
     icon={<NewsletterIcon />}
     title="Docs Theme →"
     href="/docs/docs-theme/page-configuration"
   />
-  <Card
+  <Cards.Card
     icon={<FileIcon />}
     title="Blog Theme →"
     href="/docs/blog-theme/start"

--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
       "vitest": "^0.29.8",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",
-      "@mdx-js/react": "^2.3.0",
-      "next-themes": "^0.2.1",
       "next": "^13.4.19"
     },
     "patchedDependencies": {

--- a/packages/nextra-theme-docs/src/components/anchor.tsx
+++ b/packages/nextra-theme-docs/src/components/anchor.tsx
@@ -34,7 +34,7 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(function (
       </a>
     )
   }
-  
+
   return (
     <NextLink ref={forwardedRef} href={href} {...props}>
       {children}

--- a/packages/nextra-theme-docs/src/components/anchor.tsx
+++ b/packages/nextra-theme-docs/src/components/anchor.tsx
@@ -1,14 +1,11 @@
 // eslint-disable-next-line no-restricted-imports -- only in this file we determine either we include <a /> as child of <NextLink />
 import NextLink from 'next/link'
-import next from 'next/package.json'
 import type { ComponentProps, ReactElement } from 'react'
 import { forwardRef } from 'react'
 
 export type AnchorProps = Omit<ComponentProps<'a'>, 'ref'> & {
   newWindow?: boolean
 }
-
-const nextVersion = Number(next.version.split('.')[0])
 
 export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(function (
   { href = '', children, newWindow, ...props },
@@ -37,20 +34,10 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(function (
       </a>
     )
   }
-
-  if (nextVersion > 12) {
-    return (
-      <NextLink ref={forwardedRef} href={href} {...props}>
-        {children}
-      </NextLink>
-    )
-  }
-
+  
   return (
-    <NextLink href={href} passHref>
-      <a ref={forwardedRef} {...props}>
-        {children}
-      </a>
+    <NextLink ref={forwardedRef} href={href} {...props}>
+      {children}
     </NextLink>
   )
 })

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -309,7 +309,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   sidebar: {
     defaultMenuCollapseLevel: 2,
     titleComponent: ({ title }) => <>{title}</>,
-    toggleButton: false
+    toggleButton: true
   },
   themeSwitch: {
     component: ThemeSwitch,

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -249,16 +249,6 @@ export default function Layout({
 }
 
 export { useConfig, PartialDocsThemeConfig as DocsThemeConfig }
-export { useMDXComponents } from 'nextra/mdx'
-export {
-  Callout,
-  Steps,
-  Tabs,
-  Tab,
-  Cards,
-  Card,
-  FileTree
-} from 'nextra/components'
 export { useTheme } from 'next-themes'
 export { Link } from './mdx-components'
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,6 @@ overrides:
   vitest: ^0.29.8
   react: ^18.2.0
   react-dom: ^18.2.0
-  '@mdx-js/react': ^2.3.0
-  next-themes: ^0.2.1
   next: ^13.4.19
 
 patchedDependencies:


### PR DESCRIPTION
- remove `Steps`, `Callout`, `Tabs`, `Tab`, `Cards`, `Card`, `FileTree` exports, export them now from `nextra/components`

- remove `useMDXComponents` export, export it now from `nextra/mdx`

- set by default `sidebar.toggleButton` to true