### PR TITLE
create new docs page about `useConfig`

### DIFF
--- a/docs/pages/docs/docs-theme/_meta.json
+++ b/docs/pages/docs/docs-theme/_meta.json
@@ -2,5 +2,6 @@
   "start": "Get Started",
   "page-configuration": "",
   "theme-configuration": "",
-  "built-ins": "Built-ins"
+  "built-ins": "Built-ins",
+  "api": "API"
 }

--- a/docs/pages/docs/docs-theme/api/_meta.json
+++ b/docs/pages/docs/docs-theme/api/_meta.json
@@ -1,0 +1,3 @@
+{
+    "use-config": "useConfig"
+}

--- a/docs/pages/docs/docs-theme/api/_meta.json
+++ b/docs/pages/docs/docs-theme/api/_meta.json
@@ -1,3 +1,3 @@
 {
-    "use-config": "useConfig"
+  "use-config": "useConfig"
 }

--- a/docs/pages/docs/docs-theme/api/use-config.mdx
+++ b/docs/pages/docs/docs-theme/api/use-config.mdx
@@ -6,19 +6,20 @@ import { Callout } from "nextra/components"
 **The `useConfig` hook is made to dynamically configure your project**. See [Theme Configuration](/docs/docs-theme/theme-configuration) for more information about each customizable feature.
 </Callout>
 
-The `useConfig` hook returns data from your project configuration and current page context.
+The `useConfig` hook returns data from your theme configuration and current page context.
+
 ## Return Values
 
 - `banner`: data about [Banner](/docs/docs-theme/theme-configuration#banner)
-- `chat`: data about [Chat Link](/docs/docs-theme/themeconfiguration#chat-link)
+- `chat`: data about [Chat Link](/docs/docs-theme/theme-configuration#chat-link)
 - `darkMode`: a boolean whether the theme is dark or not
 - `direction`: a string that defines the current [writing direction](/docs/docs-theme/theme-configuration#writing-direction)
 - `docsRepositoryBase`: a link string to the documentation repository
-- `editLink`: data about [Edit Link](/docs-theme/theme-configuration#edit-link)
+- `editLink`: data about [Edit Link](/docs/docs-theme/theme-configuration#edit-link)
 - `feedback`: data about [Feedback Link](/docs/docs-theme/theme-configuration#feedback-link)
 - `footer`: data about [Footer](/docs/docs-theme/theme-configuration#footer)
 - `gitTimestamp`: a function that renders the [Last Updated Date](/docs/docs-theme/theme-configuration#last-updated-date)
-- `head`: an equivalent to [**Next.js Head tag**](https://nextjs.org/docs/pages/api-reference/components/head)
+- `head`: an equivalent to [Next.js Head tag](https://nextjs.org/docs/pages/api-reference/components/head)
 - `i18n`: data about [Internationalization](/docs/guide/i18n)
 - `logo`: a React component for the website's logo
 - `logoLink`: a link for the `logo` component
@@ -30,12 +31,11 @@ The `useConfig` hook returns data from your project configuration and current pa
 - `primaryHue`: data about [Theme Color](/docs/docs-theme/theme-configuration#theme-color)
 - `project`: data about [Project Link](/docs/docs-theme/theme-configuration#project-link)
 - `search`: data about [Search](/docs/docs-theme/theme-configuration#search)
-- `serverSideError`: data to display when a server side error happens
+- `serverSideError`: data to display when a server-side error happens  (requires `500.mdx` page too)
 - `sidebar`: data about [Sidebar](/docs/docs-theme/theme-configuration#sidebar)
 - `toc`: data about [Table of Contents Sidebar](/docs/docs-theme/theme-configuration#toc-sidebar)
 - `useNextSeoOptions`: a function that passes data to Next.js SEO component. (see [SEO Options](/docs/docs-theme/theme-configuration#seo-options))
 - `flexsearch`: data about search configuration
 - `title`: Title about current document
-- `frontMatter`: data about current document
-- `newNextLinkBehavior`: defines if it should use thew new `next/link` available in Next.js >=12
+- `frontMatter`: parsed [front matter](https://jekyllrb.com/docs/front-matter) data
 - `flexsearch`: data for search configuration

--- a/docs/pages/docs/docs-theme/api/use-config.mdx
+++ b/docs/pages/docs/docs-theme/api/use-config.mdx
@@ -1,41 +1,59 @@
-import { Callout } from "nextra/components"
+import { Callout } from 'nextra/components'
 
 # useConfig
 
 <Callout type="warning">
-**The `useConfig` hook is made to dynamically configure your project**. See [Theme Configuration](/docs/docs-theme/theme-configuration) for more information about each customizable feature.
+  **The `useConfig` hook is made to dynamically configure your project**. See
+  [Theme Configuration](/docs/docs-theme/theme-configuration) for more
+  information about each customizable feature.
 </Callout>
 
-The `useConfig` hook returns data from your theme configuration and current page context.
+The `useConfig` hook returns data from your theme configuration and current page
+context.
 
 ## Return Values
 
 - `banner`: data about [Banner](/docs/docs-theme/theme-configuration#banner)
 - `chat`: data about [Chat Link](/docs/docs-theme/theme-configuration#chat-link)
 - `darkMode`: a boolean whether the theme is dark or not
-- `direction`: a string that defines the current [writing direction](/docs/docs-theme/theme-configuration#writing-direction)
+- `direction`: a string that defines the current
+  [writing direction](/docs/docs-theme/theme-configuration#writing-direction)
 - `docsRepositoryBase`: a link string to the documentation repository
-- `editLink`: data about [Edit Link](/docs/docs-theme/theme-configuration#edit-link)
-- `feedback`: data about [Feedback Link](/docs/docs-theme/theme-configuration#feedback-link)
+- `editLink`: data about
+  [Edit Link](/docs/docs-theme/theme-configuration#edit-link)
+- `feedback`: data about
+  [Feedback Link](/docs/docs-theme/theme-configuration#feedback-link)
 - `footer`: data about [Footer](/docs/docs-theme/theme-configuration#footer)
-- `gitTimestamp`: a function that renders the [Last Updated Date](/docs/docs-theme/theme-configuration#last-updated-date)
-- `head`: an equivalent to [Next.js Head tag](https://nextjs.org/docs/pages/api-reference/components/head)
+- `gitTimestamp`: a function that renders the
+  [Last Updated Date](/docs/docs-theme/theme-configuration#last-updated-date)
+- `head`: an equivalent to
+  [Next.js Head tag](https://nextjs.org/docs/pages/api-reference/components/head)
 - `i18n`: data about [Internationalization](/docs/guide/i18n)
 - `logo`: a React component for the website's logo
 - `logoLink`: a link for the `logo` component
-- `navbar`: components related to [Navbar](/docs/docs-theme/theme-configuration#customize-the-navbar)
-- `navigation`: options about [Navigation](/docs/docs-theme/theme-configuration#navigation)
-- `themeSwitch`: data about [Theme Switch](/docs/docs-theme/theme-configuration#theme-switch)
-- `nextThemes`: data about theme configuration (see [pacocoursey/next-themes](https://github.com/pacocoursey/next-themes))
+- `navbar`: components related to
+  [Navbar](/docs/docs-theme/theme-configuration#customize-the-navbar)
+- `navigation`: options about
+  [Navigation](/docs/docs-theme/theme-configuration#navigation)
+- `themeSwitch`: data about
+  [Theme Switch](/docs/docs-theme/theme-configuration#theme-switch)
+- `nextThemes`: data about theme configuration (see
+  [pacocoursey/next-themes](https://github.com/pacocoursey/next-themes))
 - `notFound`: data to display when the page is not found
-- `primaryHue`: data about [Theme Color](/docs/docs-theme/theme-configuration#theme-color)
-- `project`: data about [Project Link](/docs/docs-theme/theme-configuration#project-link)
+- `primaryHue`: data about
+  [Theme Color](/docs/docs-theme/theme-configuration#theme-color)
+- `project`: data about
+  [Project Link](/docs/docs-theme/theme-configuration#project-link)
 - `search`: data about [Search](/docs/docs-theme/theme-configuration#search)
-- `serverSideError`: data to display when a server-side error happens  (requires `500.mdx` page too)
+- `serverSideError`: data to display when a server-side error happens (requires
+  `500.mdx` page too)
 - `sidebar`: data about [Sidebar](/docs/docs-theme/theme-configuration#sidebar)
-- `toc`: data about [Table of Contents Sidebar](/docs/docs-theme/theme-configuration#toc-sidebar)
-- `useNextSeoOptions`: a function that passes data to Next.js SEO component. (see [SEO Options](/docs/docs-theme/theme-configuration#seo-options))
+- `toc`: data about
+  [Table of Contents Sidebar](/docs/docs-theme/theme-configuration#toc-sidebar)
+- `useNextSeoOptions`: a function that passes data to Next.js SEO component.
+  (see [SEO Options](/docs/docs-theme/theme-configuration#seo-options))
 - `flexsearch`: data about search configuration
 - `title`: Title about current document
-- `frontMatter`: parsed [front matter](https://jekyllrb.com/docs/front-matter) data
+- `frontMatter`: parsed [front matter](https://jekyllrb.com/docs/front-matter)
+  data
 - `flexsearch`: data for search configuration

--- a/docs/pages/docs/docs-theme/api/use-config.mdx
+++ b/docs/pages/docs/docs-theme/api/use-config.mdx
@@ -3,7 +3,7 @@ import { Callout } from "nextra/components"
 # useConfig
 
 <Callout type="warning">
-**The `useConfig` hook is made to dynamically configure your project**. See [Theme Configuration](/docs/docs-theme/theme-configuration) for more informations about each customizable feature.
+**The `useConfig` hook is made to dynamically configure your project**. See [Theme Configuration](/docs/docs-theme/theme-configuration) for more information about each customizable feature.
 </Callout>
 
 The `useConfig` hook returns data from your project configuration and current page context.
@@ -30,7 +30,7 @@ The `useConfig` hook returns data from your project configuration and current pa
 - `primaryHue`: data about [Theme Color](/docs/docs-theme/theme-configuration#theme-color)
 - `project`: data about [Project Link](/docs/docs-theme/theme-configuration#project-link)
 - `search`: data about [Search](/docs/docs-theme/theme-configuration#search)
-- `serverSideErorr`: data to display when a server side error happens
+- `serverSideError`: data to display when a server side error happens
 - `sidebar`: data about [Sidebar](/docs/docs-theme/theme-configuration#sidebar)
 - `toc`: data about [Table of Contents Sidebar](/docs/docs-theme/theme-configuration#toc-sidebar)
 - `useNextSeoOptions`: a function that passes data to Next.js SEO component. (see [SEO Options](/docs/docs-theme/theme-configuration#seo-options))

--- a/docs/pages/docs/docs-theme/api/use-config.mdx
+++ b/docs/pages/docs/docs-theme/api/use-config.mdx
@@ -1,0 +1,41 @@
+import { Callout } from "nextra/components"
+
+# useConfig
+
+<Callout type="warning">
+**The `useConfig` hook is made to dynamically configure your project**. See [Theme Configuration](/docs/docs-theme/theme-configuration) for more informations about each customizable feature.
+</Callout>
+
+The `useConfig` hook returns data from your project configuration and current page context.
+## Return Values
+
+- `banner`: data about [Banner](/docs/docs-theme/theme-configuration#banner)
+- `chat`: data about [Chat Link](/docs/docs-theme/themeconfiguration#chat-link)
+- `darkMode`: a boolean whether the theme is dark or not
+- `direction`: a string that defines the current [writing direction](/docs/docs-theme/theme-configuration#writing-direction)
+- `docsRepositoryBase`: a link string to the documentation repository
+- `editLink`: data about [Edit Link](/docs-theme/theme-configuration#edit-link)
+- `feedback`: data about [Feedback Link](/docs/docs-theme/theme-configuration#feedback-link)
+- `footer`: data about [Footer](/docs/docs-theme/theme-configuration#footer)
+- `gitTimestamp`: a function that renders the [Last Updated Date](/docs/docs-theme/theme-configuration#last-updated-date)
+- `head`: an equivalent to [**Next.js Head tag**](https://nextjs.org/docs/pages/api-reference/components/head)
+- `i18n`: data about [Internationalization](/docs/guide/i18n)
+- `logo`: a React component for the website's logo
+- `logoLink`: a link for the `logo` component
+- `navbar`: components related to [Navbar](/docs/docs-theme/theme-configuration#customize-the-navbar)
+- `navigation`: options about [Navigation](/docs/docs-theme/theme-configuration#navigation)
+- `themeSwitch`: data about [Theme Switch](/docs/docs-theme/theme-configuration#theme-switch)
+- `nextThemes`: data about theme configuration (see [pacocoursey/next-themes](https://github.com/pacocoursey/next-themes))
+- `notFound`: data to display when the page is not found
+- `primaryHue`: data about [Theme Color](/docs/docs-theme/theme-configuration#theme-color)
+- `project`: data about [Project Link](/docs/docs-theme/theme-configuration#project-link)
+- `search`: data about [Search](/docs/docs-theme/theme-configuration#search)
+- `serverSideErorr`: data to display when a server side error happens
+- `sidebar`: data about [Sidebar](/docs/docs-theme/theme-configuration#sidebar)
+- `toc`: data about [Table of Contents Sidebar](/docs/docs-theme/theme-configuration#toc-sidebar)
+- `useNextSeoOptions`: a function that passes data to Next.js SEO component. (see [SEO Options](/docs/docs-theme/theme-configuration#seo-options))
+- `flexsearch`: data about search configuration
+- `title`: Title about current document
+- `frontMatter`: data about current document
+- `newNextLinkBehavior`: defines if it should use thew new `next/link` available in Next.js >=12
+- `flexsearch`: data for search configuration


### PR DESCRIPTION
This PR closes #2241.

This PR adds `/docs/docs-theme/api/use-config`, which was missing in link references and states important information about the returned values of the `useConfig` hook.

fixes https://github.com/shuding/nextra/issues/1139