### PR TITLE
[v3/docs] rename theme config options

### DIFF
--- a/.changeset/short-games-carry.md
+++ b/.changeset/short-games-carry.md
@@ -1,0 +1,13 @@
+---
+'nextra-theme-docs': major
+---
+
+- rename theme config options
+
+  `i18n.text` → `i18n.name`
+
+  `banner.text` → `banner.content`
+
+  `editLink.text` → `editLink.content`
+
+  `footer.text` → `footer.content`

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -1,4 +1,5 @@
 import { Screenshot } from 'components/screenshot'
+import { OptionTable } from 'components/table'
 
 # Theme Configuration
 
@@ -16,8 +17,6 @@ export default {
 ```
 
 Detailed information for each option is listed below.
-
-import { OptionTable } from 'components/table'
 
 ## Global
 
@@ -383,7 +382,7 @@ notice.
       'string',
       'Storage key to keep the banner state (dismissed or not).'
     ],
-    ['banner.text', 'React.ReactNode | React.FC', 'Text of the banner.']
+    ['banner.content', 'React.ReactNode | React.FC', 'Content of the banner.']
   ]}
 />
 
@@ -613,9 +612,9 @@ Show an “Edit this page” link on the page that points to the file URL on Git
 <OptionTable
   options={[
     [
-      'editLink.text',
+      'editLink.content',
       'React.ReactNode | React.FC',
-      'Content of the default edit link.'
+      'Content of the edit link.'
     ],
     [
       'editLink.component',
@@ -711,9 +710,9 @@ default footer, or fully customize it with a custom component.
 <OptionTable
   options={[
     [
-      'footer.text',
+      'footer.content',
       'React.ReactNode | React.FC',
-      'Content of the default footer component.'
+      'Content of the footer component.'
     ],
     [
       'footer.component',

--- a/docs/pages/docs/guide/i18n.mdx
+++ b/docs/pages/docs/guide/i18n.mdx
@@ -30,25 +30,6 @@ export default withNextra({
 })
 ```
 
-### Add Middleware
-
-Then, you need to add a `middleware.js` file in the root of your project
-([related Next.js docs](https://nextjs.org/docs/advanced-features/middleware)):
-
-```js
-export { locales as middleware } from 'nextra/locales'
-```
-
-If you already have the middleware defined, you can do this instead:
-
-```js
-import { withLocales } from 'nextra/locales'
-
-export const middleware = withLocales(request => {
-  // Your middleware code...
-})
-```
-
 ### Add Locale to Filenames
 
 Then, add the locale codes to your file extensions (required for the default
@@ -72,10 +53,10 @@ language dropdown:
 
 ```js filename="theme.config.jsx"
 i18n: [
-  { locale: 'en', text: 'English' },
-  { locale: 'zh', text: '中文' },
-  { locale: 'de', text: 'Deutsch' },
-  { locale: 'ar', text: 'العربية', direction: 'rtl' }
+  { locale: 'en', name: 'English' },
+  { locale: 'zh', name: '中文' },
+  { locale: 'de', name: 'Deutsch' },
+  { locale: 'ar', name: 'العربية', direction: 'rtl' }
 ]
 ```
 

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -104,7 +104,7 @@ const config: DocsThemeConfig = {
     )
   },
   editLink: {
-    text: 'Edit this page on GitHub →'
+    content: 'Edit this page on GitHub →'
   },
   feedback: {
     content: 'Question? Give us feedback →',
@@ -121,7 +121,7 @@ const config: DocsThemeConfig = {
     toggleButton: true
   },
   footer: {
-    text: (
+    content: (
       <div className="flex w-full flex-col items-center sm:items-start">
         <div>
           <a

--- a/examples/docs/src/theme.config.js
+++ b/examples/docs/src/theme.config.js
@@ -6,8 +6,8 @@ import { useConfig } from 'nextra-theme-docs'
  */
 export default {
   banner: {
-    key: 'Nextra 2',
-    text: 'Nextra 2 Alpha'
+    content: 'Nextra 2 Alpha',
+    key: 'Nextra 2'
   },
   chat: {
     link: 'https://discord.gg/hEM84NMkRv' // Next.js discord server,
@@ -15,7 +15,7 @@ export default {
   docsRepositoryBase:
     'https://github.com/shuding/nextra/blob/core/examples/docs',
   editLink: {
-    text: 'Edit this page on GitHub'
+    content: 'Edit this page on GitHub'
   },
   faviconGlyph: '✦',
   useNextSeoProps() {

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -63,14 +63,14 @@ const FOOTER_LINK_TEXT = {
 
 const config: DocsThemeConfig = {
   banner: {
-    key: 'swr-2',
-    text: 'SWR 2.0 is out! Read more →'
+    content: 'SWR 2.0 is out! Read more →',
+    key: 'swr-2'
   },
   darkMode: true,
   docsRepositoryBase:
     'https://github.com/shuding/nextra/blob/core/examples/swr-site',
   editLink: {
-    text: function useText() {
+    content: function useText() {
       const { locale } = useRouter()
       return EDIT_TEXT[locale]
     }
@@ -86,7 +86,7 @@ const config: DocsThemeConfig = {
     }
   },
   footer: {
-    text: function useText() {
+    content: function useText() {
       const { locale } = useRouter()
       return (
         <a
@@ -148,9 +148,9 @@ const config: DocsThemeConfig = {
     )
   },
   i18n: [
-    { locale: 'en', text: 'English' },
-    { direction: 'rtl', locale: 'es', text: 'Español RTL' },
-    { locale: 'ru', text: 'Русский' }
+    { locale: 'en', name: 'English' },
+    { direction: 'rtl', locale: 'es', name: 'Español RTL' },
+    { locale: 'ru', name: 'Русский' }
   ],
   logo: function Logo() {
     const { locale } = useRouter()

--- a/packages/nextra-theme-docs/src/components/banner.tsx
+++ b/packages/nextra-theme-docs/src/components/banner.tsx
@@ -6,7 +6,7 @@ import { renderComponent } from '../utils'
 
 export function Banner(): ReactElement | null {
   const { banner } = useConfig()
-  if (!banner.text) {
+  if (!banner.content) {
     return null
   }
   const hideBannerScript = `try{if(localStorage.getItem(${JSON.stringify(
@@ -25,7 +25,7 @@ export function Banner(): ReactElement | null {
         )}
       >
         <div className="nx-w-full nx-truncate nx-px-4 nx-text-center nx-font-medium nx-text-sm">
-          {renderComponent(banner.text)}
+          {renderComponent(banner.content)}
         </div>
         {banner.dismissible && (
           <button

--- a/packages/nextra-theme-docs/src/components/footer.tsx
+++ b/packages/nextra-theme-docs/src/components/footer.tsx
@@ -26,7 +26,7 @@ export function Footer({ menu }: { menu?: boolean }): ReactElement {
           'nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]'
         )}
       >
-        {renderComponent(config.footer.text)}
+        {renderComponent(config.footer.content)}
       </div>
     </footer>
   )

--- a/packages/nextra-theme-docs/src/components/locale-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/locale-switch.tsx
@@ -40,13 +40,13 @@ export function LocaleSwitch({
         name: (
           <span className="nx-flex nx-items-center nx-gap-2">
             <GlobeIcon />
-            <span className={lite ? 'nx-hidden' : ''}>{selected?.text}</span>
+            <span className={lite ? 'nx-hidden' : ''}>{selected?.name}</span>
           </span>
         )
       }}
       options={options.map(l => ({
         key: l.locale,
-        name: l.text
+        name: l.name
       }))}
     />
   )

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -122,7 +122,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
           {renderComponent(config.editLink.component, {
             filePath,
             className: linkClassName,
-            children: renderComponent(config.editLink.text)
+            children: renderComponent(config.editLink.content)
           })}
 
           {renderComponent(config.toc.extraContent)}

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -47,7 +47,7 @@ export const themeSchema = z.strictObject({
   banner: z.strictObject({
     content: z.custom<ReactNode | FC>(...reactNode).optional(),
     dismissible: z.boolean(),
-    key: z.string(),
+    key: z.string()
   }),
   chat: z.strictObject({
     icon: z.custom<ReactNode | FC>(...reactNode),
@@ -201,7 +201,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         </Anchor>
       )
     },
-    text: 'Edit this page'
+    content: 'Edit this page'
   },
   feedback: {
     content: 'Question? Give us feedback →',
@@ -217,7 +217,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   },
   footer: {
     component: Footer,
-    text: `MIT ${new Date().getFullYear()} © Nextra.`
+    content: `MIT ${new Date().getFullYear()} © Nextra.`
   },
   gitTimestamp: function GitTimestamp({ timestamp }) {
     const { locale = DEFAULT_LOCALE } = useRouter()

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -33,7 +33,7 @@ const i18nSchema = z.array(
   z.strictObject({
     direction: z.enum(['ltr', 'rtl']).optional(),
     locale: z.string(),
-    text: z.string()
+    name: z.string()
   })
 )
 
@@ -45,9 +45,9 @@ const fc = [isFunction, { message: 'Must be React.FC' }] as const
 
 export const themeSchema = z.strictObject({
   banner: z.strictObject({
+    content: z.custom<ReactNode | FC>(...reactNode).optional(),
     dismissible: z.boolean(),
     key: z.string(),
-    text: z.custom<ReactNode | FC>(...reactNode).optional()
   }),
   chat: z.strictObject({
     icon: z.custom<ReactNode | FC>(...reactNode),
@@ -65,7 +65,7 @@ export const themeSchema = z.strictObject({
         filePath?: string
       }>
     >(...fc),
-    text: z.custom<ReactNode | FC>(...reactNode)
+    content: z.custom<ReactNode | FC>(...reactNode)
   }),
   faviconGlyph: z.string().optional(),
   feedback: z.strictObject({
@@ -75,7 +75,7 @@ export const themeSchema = z.strictObject({
   }),
   footer: z.strictObject({
     component: z.custom<ReactNode | FC<{ menu: boolean }>>(...reactNode),
-    text: z.custom<ReactNode | FC>(...reactNode)
+    content: z.custom<ReactNode | FC>(...reactNode)
   }),
   gitTimestamp: z.custom<ReactNode | FC<{ timestamp: Date }>>(...reactNode),
   head: z.custom<ReactNode | FC>(...reactNode),


### PR DESCRIPTION
- rename theme config options

  `i18n.text` → `i18n.name`

  `banner.text` → `banner.content`

  `editLink.text` → `editLink.content`

  `footer.text` → `footer.content`