### PR TITLE
feat: add `sidebar.firstComponent` for `nextra-theme-docs`

### DIFF
--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -417,6 +417,7 @@ export function Sidebar({
         )}
         ref={containerRef}
       >
+        {renderComponent(config.sidebar.firstComponent)}
         <div className="nx-px-4 nx-pt-4 md:nx-hidden">
           {renderComponent(config.search.component, {
             directories: flatDirectories

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -131,6 +131,7 @@ export const themeSchema = z.strictObject({
   sidebar: z.strictObject({
     autoCollapse: z.boolean().optional(),
     defaultMenuCollapseLevel: z.number().min(1).int(),
+    firstComponent: z.custom<ReactNode | FC>(...reactNode),
     titleComponent: z.custom<
       ReactNode | FC<{ title: string; type: string; route: string }>
     >(...reactNode),


### PR DESCRIPTION
This PR added `sidebar.firstComponent` in order to let the user add a custom component on top of their sidebar.

Example:

<img width="306" alt="266761004-adb29650-9f53-4c5a-8ef8-e227e78856e4" src="https://github.com/shuding/nextra/assets/120007119/23a28e39-966b-4edb-8fd3-7252f2533cab">

Resolves #2277 