### PR TITLE
[V3] remove `toc.headingComponent`, rename `pageOpts.headings` to `toc`

### DIFF
--- a/.changeset/chilled-kids-fetch.md
+++ b/.changeset/chilled-kids-fetch.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': major
+---
+
+remove `toc.headingComponent`

--- a/.changeset/fuzzy-meals-care.md
+++ b/.changeset/fuzzy-meals-care.md
@@ -1,0 +1,5 @@
+---
+'nextra': minor
+---
+
+should not add virtual `_meta` file if missing

--- a/.changeset/wet-years-serve.md
+++ b/.changeset/wet-years-serve.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': major
+'nextra-theme-docs': major
+'nextra': major
+---
+
+rename `pageOpts.headings` to `toc`

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "rm -rf .next && next build",
     "dev": "next",
     "start": "next start"
   },

--- a/docs/pages/docs/custom-theme.mdx
+++ b/docs/pages/docs/custom-theme.mdx
@@ -80,7 +80,7 @@ import Head from 'next/head'
 import type { NextraThemeLayoutProps } from 'nextra'
 
 export default function Layout({ children, pageOpts }: NextraThemeLayoutProps) {
-  const { title, frontMatter, headings } = pageOpts
+  const { title, frontMatter, toc } = pageOpts
 
   return (
     <div>
@@ -91,7 +91,7 @@ export default function Layout({ children, pageOpts }: NextraThemeLayoutProps) {
       <h1>My Theme</h1>
       Table of Contents:
       <ul>
-        {headings.map(heading => (
+        {toc.map(heading => (
           <li key={heading.value}>{heading.value}</li>
         ))}
       </ul>

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -589,11 +589,6 @@ navigating between headings.
       'React.ReactNode | React.FC',
       'Title of the TOC sidebar. By default it’s “On This Page”.'
     ],
-    [
-      'toc.headingComponent',
-      'React.FC<{ id: string, children: string }>',
-      'Custom renderer of TOC headings.'
-    ],
     ['toc.backToTop', 'boolean', 'Add `Scroll to top` link.']
   ]}
 />

--- a/examples/swr-site/package.json
+++ b/examples/swr-site/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "analyze": "ANALYZE=true pnpm build",
-    "build": "next build",
+    "build": "rm -rf .next && next build",
     "clean": "rimraf .next .turbo",
     "debug": "NODE_OPTIONS='--inspect' next dev",
     "dev": "next",

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -195,15 +195,7 @@ const config: DocsThemeConfig = {
       // eslint-disable-next-line @next/next/no-img-element -- ignore since url is external and dynamic
       <img alt="placeholder cat" src="https://placekitten.com/g/300/200" />
     ),
-    float: true,
-    headingComponent: function Heading({ id, children }) {
-      return (
-        <>
-          {children}
-          {id === 'installation' && ' 💿'}
-        </>
-      )
-    }
+    float: true
   },
   useNextSeoProps() {
     const { locale } = useRouter()

--- a/packages/nextra-theme-blog/__test__/__fixture__/pageMap.ts
+++ b/packages/nextra-theme-blog/__test__/__fixture__/pageMap.ts
@@ -59,13 +59,7 @@ export const indexOpts: BlogPageOpts = {
     }
   ],
   title: 'Nextra',
-  headings: [
-    {
-      depth: 1,
-      value: 'Nextra',
-      id: 'nextra'
-    }
-  ]
+  toc: []
 }
 
 export const postsOpts: BlogPageOpts = {
@@ -127,13 +121,7 @@ export const postsOpts: BlogPageOpts = {
     }
   ],
   title: 'Random Thoughts',
-  headings: [
-    {
-      depth: 1,
-      value: 'Random Thoughts',
-      id: 'random-thoughts'
-    }
-  ]
+  toc: []
 }
 
 export const articleOpts: BlogPageOpts = {
@@ -198,12 +186,7 @@ export const articleOpts: BlogPageOpts = {
     }
   ],
   title: 'Notes on A Programmable Web by Aaron Swartz',
-  headings: [
-    {
-      depth: 1,
-      value: 'Notes on A Programmable Web by Aaron Swartz',
-      id: 'notes-on-a-programmable-web-by-aaron-swartz'
-    },
+  toc: [
     {
       depth: 2,
       value: 'Quotes About WWW',

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -325,7 +325,7 @@ interface SideBarProps {
   docsDirectories: PageItem[]
   fullDirectories: Item[]
   asPopover?: boolean
-  headings: Heading[]
+  toc: Heading[]
   includePlaceholder: boolean
 }
 
@@ -333,7 +333,7 @@ export function Sidebar({
   docsDirectories,
   fullDirectories,
   asPopover = false,
-  headings,
+  toc,
   includePlaceholder
 }: SideBarProps): ReactElement {
   const config = useConfig()
@@ -343,7 +343,7 @@ export function Sidebar({
   const [showSidebar, setSidebar] = useState(true)
   const [showToggleAnimation, setToggleAnimation] = useState(false)
 
-  const anchors = useMemo(() => headings.filter(v => v.depth === 2), [headings])
+  const anchors = useMemo(() => toc.filter(v => v.depth === 2), [toc])
   const sidebarRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const mounted = useMounted()

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -89,10 +89,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
                     'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words'
                   )}
                 >
-                  {config.toc.headingComponent?.({
-                    id,
-                    children: value
-                  }) ?? value}
+                  {value}
                 </a>
               </li>
             ))}

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -1,7 +1,7 @@
 import cn from 'clsx'
 import type { Heading } from 'nextra'
 import type { ReactElement } from 'react'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import { useActiveAnchor, useConfig } from '../contexts'
 import { renderComponent } from '../utils'
@@ -9,7 +9,7 @@ import { Anchor } from './anchor'
 import { BackToTop } from './back-to-top'
 
 export type TOCProps = {
-  headings: Heading[]
+  toc: Heading[]
   filePath: string
 }
 
@@ -18,17 +18,12 @@ const linkClassName = cn(
   'contrast-more:nx-text-gray-800 contrast-more:dark:nx-text-gray-50'
 )
 
-export function TOC({ headings, filePath }: TOCProps): ReactElement {
+export function TOC({ toc, filePath }: TOCProps): ReactElement {
   const activeAnchor = useActiveAnchor()
   const config = useConfig()
   const tocRef = useRef<HTMLDivElement>(null)
 
-  const items = useMemo(
-    () => headings.filter(heading => heading.depth > 1),
-    [headings]
-  )
-
-  const hasHeadings = items.length > 0
+  const hasHeadings = toc.length > 0
   const hasMetaInfo = Boolean(
     config.feedback.content ||
       config.editLink.component ||
@@ -70,7 +65,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
             {renderComponent(config.toc.title)}
           </p>
           <ul>
-            {items.map(({ id, value, depth }) => (
+            {toc.map(({ id, value, depth }) => (
               <li className="nx-my-2 nx-scroll-my-6 nx-scroll-py-6" key={id}>
                 <a
                   href={`#${id}`}
@@ -81,10 +76,10 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
                       4: 'ltr:nx-pl-8 rtl:nx-pr-8',
                       5: 'ltr:nx-pl-12 rtl:nx-pr-12',
                       6: 'ltr:nx-pl-16 rtl:nx-pr-16'
-                    }[depth as Exclude<typeof depth, 1>],
-                    'nx-inline-block',
+                    }[depth],
+                    'nx-inline-block nx-transition-colors nx-subpixel-antialiased',
                     activeAnchor[id]?.isActive
-                      ? 'nx-text-primary-600 nx-subpixel-antialiased contrast-more:!nx-text-primary-600'
+                      ? 'nx-text-primary-600 contrast-more:!nx-text-primary-600'
                       : 'nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-300',
                     'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words'
                   )}

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -110,7 +110,7 @@ function InnerLayout({
   filePath,
   pageMap,
   frontMatter,
-  headings,
+  toc,
   timestamp,
   children
 }: PageOpts & { children: ReactNode }): ReactElement {
@@ -152,7 +152,7 @@ function InnerLayout({
         aria-label="table of contents"
       >
         {renderComponent(config.toc.component, {
-          headings: config.toc.float ? headings : [],
+          toc: config.toc.float ? toc : [],
           filePath
         })}
       </nav>
@@ -191,7 +191,7 @@ function InnerLayout({
           <Sidebar
             docsDirectories={docsDirectories}
             fullDirectories={directories}
-            headings={headings}
+            toc={toc}
             asPopover={hideSidebar}
             includePlaceholder={themeContext.layout === 'default'}
           />

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -143,9 +143,6 @@ export const themeSchema = /* @__PURE__ */ (() =>
       component: z.custom<ReactNode | FC<TOCProps>>(...reactNode),
       extraContent: z.custom<ReactNode | FC>(...reactNode),
       float: z.boolean(),
-      headingComponent: z
-        .custom<FC<{ id: string; children: string }>>(...fc)
-        .optional(),
       title: z.custom<ReactNode | FC>(...reactNode)
     }),
     useNextSeoProps: z.custom<() => NextSeoProps | void>(isFunction)

--- a/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/compile.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Process heading > code-h1 1`] = `
   "result": "/*@jsxRuntime automatic @jsxImportSource react*/
 import {useMDXComponents as _provideComponents} from \\"nextra/mdx\\";
 export const frontMatter = {};
-export const __toc = [];
+export const toc = [];
 function _createMdxContent(props) {
   const _components = Object.assign({
     h1: \\"h1\\",
@@ -30,7 +30,7 @@ exports[`Process heading > code-with-text-h1 1`] = `
   "result": "/*@jsxRuntime automatic @jsxImportSource react*/
 import {useMDXComponents as _provideComponents} from \\"nextra/mdx\\";
 export const frontMatter = {};
-export const __toc = [];
+export const toc = [];
 function _createMdxContent(props) {
   const _components = Object.assign({
     h1: \\"h1\\",
@@ -60,7 +60,7 @@ export const TagName = () => {
   const {tag} = useRouter().query;
   return tag || null;
 };
-export const __toc = [];
+export const toc = [];
 function _createMdxContent(props) {
   const _components = Object.assign({
     h1: \\"h1\\"
@@ -83,7 +83,7 @@ exports[`Process heading > no-h1 1`] = `
   "result": "/*@jsxRuntime automatic @jsxImportSource react*/
 import {useMDXComponents as _provideComponents} from \\"nextra/mdx\\";
 export const frontMatter = {};
-export const __toc = [{
+export const toc = [{
   depth: 2,
   value: \\"H2\\",
   id: \\"h2\\"
@@ -109,7 +109,7 @@ exports[`Process heading > static-h1 1`] = `
   "result": "/*@jsxRuntime automatic @jsxImportSource react*/
 import {useMDXComponents as _provideComponents} from \\"nextra/mdx\\";
 export const frontMatter = {};
-export const __toc = [];
+export const toc = [];
 function _createMdxContent(props) {
   const _components = Object.assign({
     h1: \\"h1\\"

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -266,12 +266,6 @@ exports[`Page Process > should match i18n site page maps 1`] = `
             {
               "children": [
                 {
-                  "data": {
-                    "loooooooooooooooooooong-title": "Loooooooooooooooooooong Title",
-                    "tree": "Tree",
-                  },
-                },
-                {
                   "frontMatter": {
                     "sidebar_label": "Loooooooooooooooooooong Title",
                   },
@@ -280,13 +274,6 @@ exports[`Page Process > should match i18n site page maps 1`] = `
                 },
                 {
                   "children": [
-                    {
-                      "data": {
-                        "one": "One",
-                        "three": "Three",
-                        "two": "Two",
-                      },
-                    },
                     {
                       "frontMatter": {
                         "sidebar_label": "One",
@@ -596,12 +583,6 @@ exports[`Page Process > should match i18n site page maps 1`] = `
     },
     {
       "children": [
-        {
-          "data": {
-            "graphql-eslint": "GraphQL Eslint",
-            "graphql-yoga": "GraphQL Yoga",
-          },
-        },
         {
           "children": [
             {

--- a/packages/nextra/__test__/compile.test.ts
+++ b/packages/nextra/__test__/compile.test.ts
@@ -97,19 +97,19 @@ import Last from './three.mdx'
       "/*@jsxRuntime automatic @jsxImportSource react*/
       import {useMDXComponents as _provideComponents} from \\"nextra/mdx\\";
       export const frontMatter = {};
-      import FromMdx, {__toc as __toc0} from './one.mdx';
-      import FromMarkdown, {__toc as __toc1} from './two.md';
+      import FromMdx, {toc as toc0} from './one.mdx';
+      import FromMarkdown, {toc as toc1} from './two.md';
       import IgnoreMe from './foo';
-      import Last, {__toc as __toc2} from './three.mdx';
-      export const __toc = [{
+      import Last, {toc as toc2} from './three.mdx';
+      export const toc = [{
         depth: 2,
         value: \\"❤️\\",
         id: \\"️\\"
-      }, ...__toc0, {
+      }, ...toc0, {
         depth: 2,
         value: \\"✅\\",
         id: \\"\\"
-      }, ...__toc1, ...__toc2, {
+      }, ...toc1, ...toc2, {
         depth: 2,
         value: \\"👋\\",
         id: \\"-1\\"
@@ -142,7 +142,7 @@ import Last from './three.mdx'
 `,
       { mdxOptions }
     )
-    expect(result).toMatch('export const __toc = [];')
+    expect(result).toMatch('export const toc = [];')
     expect(result).not.toMatch('id="custom-id"')
   })
 })

--- a/packages/nextra/__test__/page-map.test.ts
+++ b/packages/nextra/__test__/page-map.test.ts
@@ -140,11 +140,6 @@ describe('collectPageMap', () => {
             name: \\"more\\",
             route: \\"/en/docs/advanced/more\\",
             children: [{
-              data: {
-                \\"loooooooooooooooooooong-title\\": \\"Loooooooooooooooooooong Title\\",
-                \\"tree\\": \\"Tree\\"
-              }
-            }, {
               name: \\"loooooooooooooooooooong-title\\",
               route: \\"/en/docs/advanced/more/loooooooooooooooooooong-title\\",
               frontMatter: {
@@ -154,12 +149,6 @@ describe('collectPageMap', () => {
               name: \\"tree\\",
               route: \\"/en/docs/advanced/more/tree\\",
               children: [{
-                data: {
-                  \\"one\\": \\"One\\",
-                  \\"three\\": \\"Three\\",
-                  \\"two\\": \\"Two\\"
-                }
-              }, {
                 name: \\"one\\",
                 route: \\"/en/docs/advanced/more/tree/one\\",
                 frontMatter: {
@@ -407,11 +396,6 @@ describe('collectPageMap', () => {
         name: \\"remote\\",
         route: \\"/en/remote\\",
         children: [{
-          data: {
-            \\"graphql-eslint\\": \\"GraphQL Eslint\\",
-            \\"graphql-yoga\\": \\"GraphQL Yoga\\"
-          }
-        }, {
           name: \\"graphql-eslint\\",
           route: \\"/en/remote/graphql-eslint\\",
           children: [{
@@ -456,7 +440,7 @@ describe('Page Process', () => {
     `)
   })
 
-  it("should add `_meta.json` file if it's missing", async () => {
+  it("should not add `_meta.json` file if it's missing", async () => {
     const rawJs = await collectPageMap({
       dir: path.join(
         CWD,
@@ -468,11 +452,6 @@ describe('Page Process', () => {
     })
     expect(rawJs).toMatchInlineSnapshot(`
       "export const pageMap = [{
-        data: {
-          \\"callout\\": \\"Callout\\",
-          \\"tabs\\": \\"Tabs\\"
-        }
-      }, {
         name: \\"callout\\",
         route: \\"/callout\\",
         frontMatter: {
@@ -503,18 +482,9 @@ describe('Page Process', () => {
 
     expect(rawJs).toMatchInlineSnapshot(`
       "export const pageMap = [{
-        data: {
-          \\"docs\\": \\"Docs\\",
-          \\"test1\\": \\"Test1\\"
-        }
-      }, {
         name: \\"docs\\",
         route: \\"/docs\\",
         children: [{
-          data: {
-            \\"test2\\": \\"Test2\\"
-          }
-        }, {
           name: \\"test2\\",
           route: \\"/docs/test2\\",
           frontMatter: {

--- a/packages/nextra/src/client/setup-page.tsx
+++ b/packages/nextra/src/client/setup-page.tsx
@@ -146,7 +146,6 @@ function NextraLayout({
   }
 
   let { pageOpts } = pageContext
-  const { Content } = pageContext
 
   if (__nextra_pageMap) {
     pageOpts = {
@@ -167,7 +166,7 @@ function NextraLayout({
   return (
     <Layout themeConfig={themeConfig} pageOpts={pageOpts} pageProps={props}>
       <DataProvider value={props}>
-        <Content />
+        <pageContext.Content />
       </DataProvider>
     </Layout>
   )

--- a/packages/nextra/src/client/setup-page.tsx
+++ b/packages/nextra/src/client/setup-page.tsx
@@ -156,10 +156,10 @@ function NextraLayout({
   }
 
   if (__nextra_dynamic_opts) {
-    const { headings, title, frontMatter } = JSON.parse(__nextra_dynamic_opts)
+    const { toc, title, frontMatter } = JSON.parse(__nextra_dynamic_opts)
     pageOpts = {
       ...pageOpts,
-      headings,
+      toc,
       title,
       frontMatter
     }

--- a/packages/nextra/src/server/compile.ts
+++ b/packages/nextra/src/server/compile.ts
@@ -204,7 +204,7 @@ export async function compileMdx(
       ...(hasJsxInH1 && { hasJsxInH1 }),
       ...(readingTime && { readingTime }),
       ...(searchIndexKey !== null && { searchIndexKey, structurizedData }),
-      ...(isRemoteContent && { headings: vFile.data.headings }),
+      ...(isRemoteContent && { toc: vFile.data.headings }),
       frontMatter
     }
   } catch (err) {

--- a/packages/nextra/src/server/constants.ts
+++ b/packages/nextra/src/server/constants.ts
@@ -44,7 +44,7 @@ export const CODE_BLOCK_FILENAME_REGEX = /filename="([^"]+)"/
 
 export const DEFAULT_LOCALES = ['']
 
-// experimental, need to deep dive why bundle becomes bigger and there is full
+// Experimental, need to deep dive why bundle becomes bigger and there is full
 // reload while navigating between pages every time
 export const IMPORT_FRONTMATTER = false
 

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -219,8 +219,7 @@ ${themeConfigImport && '__nextra_internal__.themeConfig = __themeConfig'}`
   const finalResult = transform ? await transform(result, { route }) : result
 
   const stringifiedPageOpts =
-    JSON.stringify(pageOpts).slice(0, -1) +
-    ',toc,pageMap,frontMatter}'
+    JSON.stringify(pageOpts).slice(0, -1) + ',toc,pageMap,frontMatter}'
 
   const lastIndexOfFooter = finalResult.lastIndexOf(FOOTER_TO_REMOVE)
   const mdxContent =

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -218,8 +218,7 @@ ${themeConfigImport && '__nextra_internal__.themeConfig = __themeConfig'}`
   }
   const finalResult = transform ? await transform(result, { route }) : result
 
-  const stringifiedPageOpts =
-    JSON.stringify(pageOpts).slice(0, -1) + ',toc,pageMap,frontMatter}'
+  const stringifiedPageOpts = JSON.stringify(pageOpts).slice(0, -1)
 
   const lastIndexOfFooter = finalResult.lastIndexOf(FOOTER_TO_REMOVE)
   const mdxContent =
@@ -237,7 +236,11 @@ if (typeof window === 'undefined') {
   globalThis.__nextra_resolvePageMap = resolvePageMap(dynamicMetaModules)
 }
 
-export default setupNextraPage(MDXContent, '${route}', ${stringifiedPageOpts})`
+export default setupNextraPage(
+  MDXContent,
+  '${route}',
+  ${stringifiedPageOpts},toc,pageMap,frontMatter}
+)`
 
   return rawJs
 }

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -220,7 +220,7 @@ ${themeConfigImport && '__nextra_internal__.themeConfig = __themeConfig'}`
 
   const stringifiedPageOpts =
     JSON.stringify(pageOpts).slice(0, -1) +
-    ',headings:__toc,pageMap,frontMatter}'
+    ',toc,pageMap,frontMatter}'
 
   const lastIndexOfFooter = finalResult.lastIndexOf(FOOTER_TO_REMOVE)
   const mdxContent =

--- a/packages/nextra/src/server/mdx-plugins/remark-headings.ts
+++ b/packages/nextra/src/server/mdx-plugins/remark-headings.ts
@@ -24,7 +24,7 @@ const SKIP_FOR_PARENT_NAMES = new Set(['Tab', 'Tabs.Tab'])
 export const remarkHeadings: Plugin<
   [{ exportName?: string; isRemoteContent?: boolean }],
   Root
-> = ({ exportName = '__toc', isRemoteContent }) => {
+> = ({ exportName = 'toc', isRemoteContent }) => {
   const headings: (Heading | string)[] = []
   let hasJsxInH1: boolean
   let title: string
@@ -38,9 +38,9 @@ export const remarkHeadings: Plugin<
       ast,
       [
         'heading',
-        // push partial component's __toc export name to headings list
+        // push partial component's `toc` export name to headings list
         'mdxJsxFlowElement',
-        // verify .md/.mdx exports and attach named __toc export
+        // verify .md/.mdx exports and attach named `toc` export
         'mdxjsEsm'
       ],
       (node, _index, parent) => {
@@ -109,7 +109,7 @@ export const remarkHeadings: Plugin<
     file.data.title = title
 
     if (isRemoteContent) {
-      // Attach headings for remote content, because we can't access to __toc variable
+      // Attach headings for remote content, because we can't access to `toc` variable
       file.data.headings = headings
       return
     }

--- a/packages/nextra/src/server/page-map.ts
+++ b/packages/nextra/src/server/page-map.ts
@@ -153,26 +153,6 @@ async function collectFiles({
 
   const items = (await Promise.all(promises)).filter(truthy)
 
-  // @ts-expect-error TODO: fix type
-  const hasMeta = items.some(item => item.properties[0].key.name === 'data')
-
-  if (items.length && !hasMeta) {
-    const allPages = items
-      // Capitalize name of pages and folders
-      // @ts-expect-error TODO: fix type
-      .map(item => item.properties[0].value.value)
-
-    items.unshift(
-      createAstObject({
-        data: valueToEstree(
-          Object.fromEntries(
-            allPages.map(name => [name, pageTitleFromFilename(name)])
-          )
-        )
-      })
-    )
-  }
-
   return {
     pageMapAst: { type: 'ArrayExpression', elements: items },
     imports,

--- a/packages/nextra/src/server/remote.ts
+++ b/packages/nextra/src/server/remote.ts
@@ -8,7 +8,7 @@ export async function buildDynamicMDX(
     throw new Error('`remarkLinkRewriteOptions` was removed')
   }
 
-  const { result, headings, frontMatter, title } = await compileMdx(
+  const { result, toc, frontMatter, title } = await compileMdx(
     content,
     compileMdxOptions
   )
@@ -16,7 +16,7 @@ export async function buildDynamicMDX(
   return {
     __nextra_dynamic_mdx: result,
     __nextra_dynamic_opts: JSON.stringify({
-      headings,
+      toc,
       frontMatter,
       title: frontMatter.title || title
     })

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -55,7 +55,7 @@ export type Page = (MdxFile | Folder<Page>) & {
 }
 
 export type Heading = {
-  depth: MDASTHeading['depth']
+  depth: Exclude<MDASTHeading['depth'], 1>
   value: string
   id: string
 }
@@ -65,7 +65,7 @@ export type PageOpts<FrontMatterType = FrontMatter> = {
   frontMatter: FrontMatterType
   pageMap: PageMapItem[]
   title: string
-  headings: Heading[]
+  toc: Heading[]
   hasJsxInH1?: boolean
   timestamp?: number
   readingTime?: ReadingTime


### PR DESCRIPTION
- remove `toc.headingComponent`

- should not add virtual `_meta` file if missing

- rename `pageOpts.headings` to `toc`