### PR TITLE
Fix showing sidebar when darkmode is turned off

### DIFF
--- a/.changeset/bright-pots-taste.md
+++ b/.changeset/bright-pots-taste.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix showing sidebar when darkmode is turned off

--- a/.changeset/bright-pots-taste.md
+++ b/.changeset/bright-pots-taste.md
@@ -2,4 +2,4 @@
 'nextra-theme-docs': patch
 ---
 
-fix showing sidebar when darkmode is turned off
+fix showing toggle sidebar button when darkmode is turned off and i18n was not set

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -387,7 +387,7 @@ export function Sidebar({
   }, [router.asPath, setMenu])
 
   const hasI18n = config.i18n.length > 0
-  const hasMenu = config.darkMode || hasI18n || !!config.sidebar.toggleButton
+  const hasMenu = config.darkMode || hasI18n || config.sidebar.toggleButton
 
   return (
     <>
@@ -498,12 +498,7 @@ export function Sidebar({
             {config.sidebar.toggleButton && (
               <button
                 title={showSidebar ? 'Hide sidebar' : 'Show sidebar'}
-                className={cn(
-                  'max-md:nx-hidden nx-h-7 nx-rounded-md nx-transition-colors nx-text-gray-600 nx-px-2',
-                  'hover:nx-bg-gray-100 hover:nx-text-gray-900',
-                  'dark:nx-text-gray-400 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50',
-                  showSidebar && !config.darkMode ? 'nx-ml-auto' : ''
-                )}
+                className="max-md:nx-hidden nx-h-7 nx-rounded-md nx-transition-colors nx-text-gray-600 dark:nx-text-gray-400 nx-px-2 hover:nx-bg-gray-100 hover:nx-text-gray-900 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50"
                 onClick={() => {
                   setSidebar(!showSidebar)
                   setToggleAnimation(true)

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -387,7 +387,7 @@ export function Sidebar({
   }, [router.asPath, setMenu])
 
   const hasI18n = config.i18n.length > 0
-  const hasMenu = config.darkMode || hasI18n
+  const hasMenu = config.darkMode || hasI18n || !!config.sidebar.toggleButton
 
   return (
     <>
@@ -498,7 +498,12 @@ export function Sidebar({
             {config.sidebar.toggleButton && (
               <button
                 title={showSidebar ? 'Hide sidebar' : 'Show sidebar'}
-                className="max-md:nx-hidden nx-h-7 nx-rounded-md nx-transition-colors nx-text-gray-600 dark:nx-text-gray-400 nx-px-2 hover:nx-bg-gray-100 hover:nx-text-gray-900 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50"
+                className={cn(
+                  'max-md:nx-hidden nx-h-7 nx-rounded-md nx-transition-colors nx-text-gray-600 nx-px-2',
+                  'hover:nx-bg-gray-100 hover:nx-text-gray-900',
+                  'dark:nx-text-gray-400 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50',
+                  showSidebar && !config.darkMode ? 'nx-ml-auto' : ''
+                )}
                 onClick={() => {
                   setSidebar(!showSidebar)
                   setToggleAnimation(true)


### PR DESCRIPTION
Allow sidebar toggle button to be visible if `darkMode` is `false`
Add `margin-left: auto` if darkMode select is not visible in order to stick toggle to the right side

Fixes https://github.com/shuding/nextra/issues/2310

![2023-09-26 00 20 46](https://github.com/shuding/nextra/assets/36774784/28de4d50-5524-4956-b28e-75d8fa9371e7)