### PR TITLE
Import useRouter in theme configuration example

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -87,6 +87,7 @@ that will be replaced by the page title.
 You can also return it conditionally to avoid adding the suffix to the homepage:
 
 ```js
+import { useRouter } from 'next/router'
 export default {
   useNextSeoProps() {
     const { asPath } = useRouter()


### PR DESCRIPTION
Copy and pasting from the docs caused this example to error due to missing `useRouter` import. People new to Next might not know where to import `useRouter` from, so I've added it to the example.