### PR TITLE
Uniform Path Separators using slash() Method

### DIFF
--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -131,12 +131,12 @@ ${themeConfigImport && '__nextra_internal__.themeConfig = __themeConfig'}`
   const locale =
     locales[0] === '' ? '' : mdxPath.replace(PAGES_DIR, '').split('/')[1]
 
-  const route = slash(
+  const route =
     '/' +
-    path
-      .relative(PAGES_DIR, mdxPath)
+    slash(path
+      .relative(PAGES_DIR, mdxPath))
       .replace(MARKDOWN_EXTENSION_REGEX, '')
-      .replace(/(^|\/)index$/, ''))
+      .replace(/(^|\/)index$/, '')
 
   const {
     result,

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -131,12 +131,12 @@ ${themeConfigImport && '__nextra_internal__.themeConfig = __themeConfig'}`
   const locale =
     locales[0] === '' ? '' : mdxPath.replace(PAGES_DIR, '').split('/')[1]
 
-  const route =
+  const route = slash(
     '/' +
     path
       .relative(PAGES_DIR, mdxPath)
       .replace(MARKDOWN_EXTENSION_REGEX, '')
-      .replace(/(^|\/)index$/, '')
+      .replace(/(^|\/)index$/, ''))
 
   const {
     result,


### PR DESCRIPTION
fix: https://github.com/shuding/nextra/issues/2424

This PR resolves a path separator inconsistency issue on different operating systems when creating the `route` constant. On Windows, `path.relative()` produces backslashes (`\`), while on Unix-based systems it produces forward slashes (`/`). This inconsistency can lead to unexpected behavior.

The solution is to use the `slash()` method to ensure all path separators are standardized to forward slashes (`/`). This change ensures consistent path formatting across all operating systems.

Changes proposed:
1. Use the `slash()` method when defining the `route` constant to convert any backslashes to forward slashes.
