### PR TITLE
Search improvements

### DIFF
--- a/packages/nextra-theme-docs/__tests__/search.test.ts
+++ b/packages/nextra-theme-docs/__tests__/search.test.ts
@@ -1,5 +1,13 @@
+import { expect } from 'vitest'
 import nextraDataEnglish from '../../../examples/swr-site/.next/static/chunks/nextra-data-en.json'
-import { compileQuery, getResults, loadIndexes, scoreText, summarize } from '../src/components/flexsearch'
+import {
+  compileQuery,
+  getResults,
+  highlight,
+  loadIndexes,
+  scoreText,
+  summarize
+} from '../src/components/flexsearch'
 
 const fetch = (globalThis.fetch = vi.fn())
 
@@ -19,98 +27,188 @@ describe('search', () => {
   describe('results', async () => {
     await loadIndexes('', LOCALE)
 
-    const expectPage = (query: string, route: string) => {
-      return expect(
-        getResults(query, LOCALE).find(page => page.route === route)
-      )
+    const position = (query: string, route: string) => {
+      let position = 1
+      for (const result of getResults(query, LOCALE)) {
+        for (const section of result.sections) {
+          if (
+            route === result.route ||
+            route === `${result.route}#${section.anchor}`
+          ) {
+            return position
+          }
+          position++
+        }
+      }
+
+      return undefined
     }
 
     it.skip('should return no results for `>  a`', () => {
       expect(getResults('>  a', LOCALE)).toEqual([])
     })
 
-    it('should return results for `This Is A Page`', () => {
-      expectPage('This Is A Page', '/en/about/a-page').toBeDefined()
+    it('should match `This Is A Page`', () => {
+      expect(position('This Is A Page', '/en/about/a-page')).toEqual(1)
+    })
+
+    it('should match `Pre-fill Data`', () => {
+      expect(
+        position('Pre-fill Data', '/en/docs/prefetching#pre-fill-data')
+      ).toEqual(1)
+    })
+
+    it('should match `Next.js SSR`', () => {
+      expect(position('Next.js SSR', '/en/examples/ssr')).toEqual(1)
+    })
+
+    it('should match `Key Change + Previous Data + Fallback`', () => {
+      expect(
+        position(
+          'Key Change + Previous Data + Fallback',
+          '/en/docs/understanding#key-change--previous-data--fallback'
+        )
+      ).toEqual(1)
+    })
+
+    it('should return only one result for `eslint`', () => {
+      expect(getResults('eslint', LOCALE).length).toEqual(1)
     })
   })
 })
 
-describe("compileQuery", () => {
-  it("should work", () => {
-    expect(compileQuery("").toString()).toEqual("/^$/")
-    expect(compileQuery("one").toString()).toEqual("/(one)/gi")
-    expect(compileQuery("one two").toString()).toEqual("/(one|two)/gi")
-    expect(compileQuery("(one)(two)").toString()).toEqual("/(one|two)/gi")
-    expect(compileQuery("a of abc").toString()).toEqual("/(abc)/gi")
+describe('compileQuery', () => {
+  it('should work', () => {
+    expect(compileQuery('').toString()).toEqual('/^$/')
+    expect(compileQuery('one').toString()).toEqual('/(one)/gi')
+    expect(compileQuery('one two').toString()).toEqual('/(one|two)/gi')
+    expect(compileQuery('google.com').toString()).toEqual('/(google|com)/gi')
+    expect(compileQuery('(one)(two)').toString()).toEqual('/(one|two)/gi')
+    expect(compileQuery('a of abc').toString()).toEqual('/(abc)/gi')
   })
 })
 
-describe("scoreText", () => {
-  it("should work", () => {
-    const empty = compileQuery("");
-    const one = compileQuery("one");
-    const oneTwo = compileQuery("one two");
+describe('scoreText', () => {
+  it('should work', () => {
+    const empty = compileQuery('')
+    const one = compileQuery('one')
+    const oneTwo = compileQuery('one two')
 
-    expect(scoreText(empty, "")).toEqual(0);
-    expect(scoreText(empty, " ")).toEqual(0);
-    expect(scoreText(one, "")).toEqual(0);
-    expect(scoreText(one, "one")).toEqual(1);
-    expect(scoreText(one, "two")).toEqual(0);
-    expect(scoreText(one, "one two")).toEqual(1);
-    expect(scoreText(oneTwo, " one")).toEqual(1);
-    expect(scoreText(oneTwo, "two ")).toEqual(1);
-    expect(scoreText(oneTwo, "one two")).toEqual(2);
-    expect(scoreText(oneTwo, "onetwo")).toEqual(2);
-    expect(scoreText(oneTwo, "one two one")).toEqual(3);
-    expect(scoreText(oneTwo, "one two two one" )).toEqual(4);
-  });
-});
+    expect(scoreText(empty, '')).toEqual(0)
+    expect(scoreText(empty, ' ')).toEqual(0)
+    expect(scoreText(one, '')).toEqual(0)
+    expect(scoreText(one, 'one')).toEqual(3)
+    expect(scoreText(one, 'two')).toEqual(0)
+    expect(scoreText(one, 'one two')).toEqual(3)
+    expect(scoreText(oneTwo, ' one')).toEqual(3)
+    expect(scoreText(oneTwo, 'two ')).toEqual(3)
+    expect(scoreText(oneTwo, 'one two')).toEqual(6)
+    expect(scoreText(oneTwo, 'onetwo')).toEqual(6)
+    expect(scoreText(oneTwo, 'one two one')).toEqual(6)
+    expect(scoreText(oneTwo, 'one two two one')).toEqual(6)
+  })
+})
 
-describe("summarize", () => {
-  it("should work", () => {
-    expect(summarize("", [])).toEqual([]);
-    expect(summarize("one", [])).toEqual([{value: 'one'}]);
-    expect(summarize("one two", [])).toEqual([{value: 'one two'}]);
-    expect(summarize("  one two ", [])).toEqual([{value: '  one two '}]);
-    expect(summarize("one two", [0,3])).toEqual([
-      {value: 'one', highlight: true},
-      {value: ' two'},
-    ]);
-    expect(summarize("one two", [4,7])).toEqual([
-      {value: 'one '},
-      {value: 'two', highlight: true},
-    ]);
-    expect(summarize("one two three", [4,7])).toEqual([
-      {value: 'one '},
-      {value: 'two', highlight: true},
-      {value: ' three'},
-    ]);
-    expect(summarize("one two three", [0,7])).toEqual([
-      {value: 'one two', highlight: true},
-      {value: ' three'},
-    ]);
-    expect(summarize("one two three", [8,13])).toEqual([
-      {value: 'one two '},
-      {value: 'three', highlight: true},
-    ]);
-    expect(summarize("one two three", [0,2])).toEqual([
-      {value: 'on', highlight: true},
-      {value: 'e two three'},
-    ]);
-    expect(summarize("one two three", [1,3])).toEqual([
-      {value: 'o'},
-      {value: 'ne', highlight: true},
-      {value: ' two three'},
-    ]);
-    expect(summarize('a'.repeat(100) + ' one ' + 'b'.repeat(100), [101, 104])).toEqual([
-      {value: '... '},
-      {value: 'one', highlight: true},
-      {value: ' ...'},
-    ]);
-    expect(summarize('a'.repeat(30) + ' zero one two ' + 'b'.repeat(57), [31, 35])).toEqual([
-      {value: 'a'.repeat(30) + ' '},
-      {value: 'zero', highlight: true},
-      {value: ' one two ...'},
-    ]);
-  });
-});
+describe('summarize', () => {
+  it('should work', () => {
+    expect(summarize('', [])).toEqual([])
+    expect(summarize('one', [])).toEqual([{ value: 'one' }])
+    expect(summarize('one two', [])).toEqual([{ value: 'one two' }])
+    expect(summarize('  one two ', [])).toEqual([{ value: '  one two ' }])
+    expect(summarize('one two', [0, 3])).toEqual([
+      { value: 'one', highlight: true },
+      { value: ' two' }
+    ])
+    expect(summarize('one two', [4, 7])).toEqual([
+      { value: 'one ' },
+      { value: 'two', highlight: true }
+    ])
+    expect(summarize('one two three', [4, 7])).toEqual([
+      { value: 'one ' },
+      { value: 'two', highlight: true },
+      { value: ' three' }
+    ])
+    expect(summarize('one two three', [0, 7])).toEqual([
+      { value: 'one two', highlight: true },
+      { value: ' three' }
+    ])
+    expect(summarize('one two three', [8, 13])).toEqual([
+      { value: 'one two ' },
+      { value: 'three', highlight: true }
+    ])
+    expect(summarize('one two three', [0, 2])).toEqual([
+      { value: 'on', highlight: true },
+      { value: 'e two three' }
+    ])
+    expect(summarize('one two three', [1, 3])).toEqual([
+      { value: 'o' },
+      { value: 'ne', highlight: true },
+      { value: ' two three' }
+    ])
+    expect(
+      summarize('a'.repeat(100) + ' one ' + 'b'.repeat(100), [101, 104])
+    ).toEqual([
+      { value: '... ' },
+      { value: 'one', highlight: true },
+      { value: ' ...' }
+    ])
+    expect(
+      summarize('a'.repeat(30) + ' zero one two ' + 'b'.repeat(57), [31, 35])
+    ).toEqual([
+      { value: 'a'.repeat(30) + ' ' },
+      { value: 'zero', highlight: true },
+      { value: ' one two ...' }
+    ])
+  })
+})
+
+describe('highlight', () => {
+  it('should handle non-words at edges', () => {
+    const regex = compileQuery('callout')
+
+    expect(highlight(regex, '<Callout />')).toEqual([
+      { value: '<' },
+      { highlight: true, value: 'Callout' },
+      { value: ' />' }
+    ])
+  })
+
+  it('should hande long words', () => {
+    const value = 'X'.repeat(100)
+    expect(highlight(/^$/, 'X'.repeat(100))).toEqual([{ value }])
+    expect(highlight(/^$/, 'X'.repeat(200))).toEqual([
+      { value: 'X'.repeat(100) + ' ...' }
+    ])
+  })
+
+  it('should correctly orient highlights', () => {
+    const regex = compileQuery('one two three four')
+    expect(
+      highlight(
+        regex,
+        'foobar '.repeat(100) +
+          'one two' +
+          'hello '.repeat(100) +
+          'one two three four'
+      )
+    ).toEqual([
+      {
+        value: '... foobar foobar foobar foobar foobar foobar foobar '
+      },
+      {
+        highlight: true,
+        value: 'one'
+      },
+      {
+        value: ' '
+      },
+      {
+        highlight: true,
+        value: 'two'
+      },
+      {
+        value: 'hello hello hello hello hello hello hello ...'
+      }
+    ])
+  })
+})

--- a/packages/nextra-theme-docs/__tests__/search.test.ts
+++ b/packages/nextra-theme-docs/__tests__/search.test.ts
@@ -1,5 +1,5 @@
 import nextraDataEnglish from '../../../examples/swr-site/.next/static/chunks/nextra-data-en.json'
-import { getResults, loadIndexes } from '../src/components/flexsearch'
+import { compileQuery, getResults, loadIndexes, scoreText, summarize } from '../src/components/flexsearch'
 
 const fetch = (globalThis.fetch = vi.fn())
 
@@ -34,3 +34,83 @@ describe('search', () => {
     })
   })
 })
+
+describe("compileQuery", () => {
+  it("should work", () => {
+    expect(compileQuery("").toString()).toEqual("/^$/")
+    expect(compileQuery("one").toString()).toEqual("/(one)/gi")
+    expect(compileQuery("one two").toString()).toEqual("/(one|two)/gi")
+    expect(compileQuery("(one)(two)").toString()).toEqual("/(one|two)/gi")
+    expect(compileQuery("a of abc").toString()).toEqual("/(abc)/gi")
+  })
+})
+
+describe("scoreText", () => {
+  it("should work", () => {
+    const empty = compileQuery("");
+    const one = compileQuery("one");
+    const oneTwo = compileQuery("one two");
+
+    expect(scoreText(empty, "")).toEqual(0);
+    expect(scoreText(empty, " ")).toEqual(0);
+    expect(scoreText(one, "")).toEqual(0);
+    expect(scoreText(one, "one")).toEqual(1);
+    expect(scoreText(one, "two")).toEqual(0);
+    expect(scoreText(one, "one two")).toEqual(1);
+    expect(scoreText(oneTwo, " one")).toEqual(1);
+    expect(scoreText(oneTwo, "two ")).toEqual(1);
+    expect(scoreText(oneTwo, "one two")).toEqual(2);
+    expect(scoreText(oneTwo, "onetwo")).toEqual(2);
+    expect(scoreText(oneTwo, "one two one")).toEqual(3);
+    expect(scoreText(oneTwo, "one two two one" )).toEqual(4);
+  });
+});
+
+describe("summarize", () => {
+  it("should work", () => {
+    expect(summarize("", [])).toEqual([]);
+    expect(summarize("one", [])).toEqual([{value: 'one'}]);
+    expect(summarize("one two", [])).toEqual([{value: 'one two'}]);
+    expect(summarize("  one two ", [])).toEqual([{value: '  one two '}]);
+    expect(summarize("one two", [0,3])).toEqual([
+      {value: 'one', highlight: true},
+      {value: ' two'},
+    ]);
+    expect(summarize("one two", [4,7])).toEqual([
+      {value: 'one '},
+      {value: 'two', highlight: true},
+    ]);
+    expect(summarize("one two three", [4,7])).toEqual([
+      {value: 'one '},
+      {value: 'two', highlight: true},
+      {value: ' three'},
+    ]);
+    expect(summarize("one two three", [0,7])).toEqual([
+      {value: 'one two', highlight: true},
+      {value: ' three'},
+    ]);
+    expect(summarize("one two three", [8,13])).toEqual([
+      {value: 'one two '},
+      {value: 'three', highlight: true},
+    ]);
+    expect(summarize("one two three", [0,2])).toEqual([
+      {value: 'on', highlight: true},
+      {value: 'e two three'},
+    ]);
+    expect(summarize("one two three", [1,3])).toEqual([
+      {value: 'o'},
+      {value: 'ne', highlight: true},
+      {value: ' two three'},
+    ]);
+    expect(summarize('a'.repeat(100) + ' one ' + 'b'.repeat(100), [101, 104])).toEqual([
+      {value: '... '},
+      {value: 'one', highlight: true},
+      {value: ' ...'},
+    ]);
+    expect(summarize('a'.repeat(30) + ' zero one two ' + 'b'.repeat(57), [31, 35])).toEqual([
+      {value: 'a'.repeat(30) + ' '},
+      {value: 'zero', highlight: true},
+      {value: ' one two ...'},
+    ]);
+  });
+});

--- a/packages/nextra-theme-docs/__tests__/search.test.ts
+++ b/packages/nextra-theme-docs/__tests__/search.test.ts
@@ -5,6 +5,7 @@ import {
   getResults,
   highlight,
   loadIndexes,
+  reduceHighlights,
   scoreText,
   summarize
 } from '../src/components/flexsearch'
@@ -111,6 +112,33 @@ describe('scoreText', () => {
     expect(scoreText(oneTwo, 'one two one')).toEqual(6)
     expect(scoreText(oneTwo, 'one two two one')).toEqual(6)
     expect(scoreText(fallback, ' 你好吗 ')).toEqual(3)
+  })
+})
+
+describe('reduceHighlights', () => {
+  it('should work', () => {
+    expect(reduceHighlights([])).toEqual([])
+    expect(reduceHighlights([0, 10])).toEqual([0, 10])
+    expect(reduceHighlights([0, 100])).toEqual([0, 100])
+    expect(reduceHighlights([0, 1000])).toEqual([0, 1000])
+    expect(reduceHighlights([0, 10, 200, 210])).toEqual([0, 10])
+    expect(reduceHighlights([0, 10, 200, 210, 230, 240])).toEqual([
+      200, 210, 230, 240
+    ])
+  })
+
+  it('should prefer highlights below length threshold', () => {
+    expect(
+      reduceHighlights([
+        0, 2, 3, 5, 100, 1000, 1010, 1012, 1500, 1501, 1502, 1503
+      ])
+    ).toEqual([0, 2, 3, 5])
+  })
+
+  it('should optimize for the final results', () => {
+    expect(
+      reduceHighlights([0, 2, 3, 5, 1000, 1001, 1500, 1503, 2000, 2003])
+    ).toEqual([0, 2, 3, 5])
   })
 })
 

--- a/packages/nextra-theme-docs/__tests__/search.test.ts
+++ b/packages/nextra-theme-docs/__tests__/search.test.ts
@@ -18,12 +18,19 @@ describe('search', () => {
 
   describe('results', async () => {
     await loadIndexes('', LOCALE)
+
+    const expectPage = (query: string, route: string) => {
+      return expect(
+        getResults(query, LOCALE).find(page => page.route === route)
+      )
+    }
+
     it.skip('should return no results for `>  a`', () => {
       expect(getResults('>  a', LOCALE)).toEqual([])
     })
 
-    it.skip('should return results for `showcase`', () => {
-      expect(getResults('showcase', LOCALE)).not.toEqual([])
+    it('should return results for `This Is A Page`', () => {
+      expectPage('This Is A Page', '/en/about/a-page').toBeDefined()
     })
   })
 })

--- a/packages/nextra-theme-docs/src/components/flexsearch.tsx
+++ b/packages/nextra-theme-docs/src/components/flexsearch.tsx
@@ -9,6 +9,7 @@ import { useCallback, useState } from 'react'
 import { DEFAULT_LOCALE } from '../constants'
 import type { SearchResult } from '../types'
 import { Search } from './search'
+import {HighlightMatches} from "./highlight-matches";
 
 const TARGET_SUMMARY_LENGTH = 100
 const MIN_TOKEN_LENGTH = 3
@@ -120,7 +121,7 @@ const loadIndexesImpl = async (
   indexes[locale] = index
 }
 
-function compileQuery(query: string): RegExp {
+export function compileQuery(query: string): RegExp {
   const tokens = query
     .split(/\W+/)
     .filter(token => token.length >= MIN_TOKEN_LENGTH)
@@ -131,7 +132,7 @@ function compileQuery(query: string): RegExp {
     : /^$/
 }
 
-function scoreText(regex: RegExp, text: string): number {
+export function scoreText(regex: RegExp, text: string): number {
   let score = 0
   if (text) {
     regex.lastIndex = 0
@@ -140,7 +141,7 @@ function scoreText(regex: RegExp, text: string): number {
   return score
 }
 
-function summarize(content: string, highlights: number[]): SummaryPart[] {
+export function summarize(content: string, highlights: number[]): SummaryPart[] {
   // attempt to find highlights that fit within target summary length
   while (
     highlights.length > 2 &&
@@ -391,7 +392,7 @@ export function Flexsearch({
         setLoading(true)
         try {
           await loadIndexes(basePath, locale)
-        } catch (e) {
+        } catch {
           setError(true)
         }
         setLoading(false)
@@ -402,14 +403,12 @@ export function Flexsearch({
 
   const handleChange = async (value: string) => {
     setSearch(value)
-    if (loading) {
-      return
-    }
+    if (loading) return
     if (!indexes[locale]) {
       setLoading(true)
       try {
         await loadIndexes(basePath, locale)
-      } catch (e) {
+      } catch {
         setError(true)
       }
       setLoading(false)

--- a/packages/nextra-theme-docs/src/components/flexsearch.tsx
+++ b/packages/nextra-theme-docs/src/components/flexsearch.tsx
@@ -1,47 +1,63 @@
 import cn from 'clsx'
+import escapeStringRegexp from 'escape-string-regexp'
 // flexsearch types are incorrect, they were overwritten in tsconfig.json
 import FlexSearch from 'flexsearch'
 import type { SearchData } from 'nextra'
 import { useRouter } from 'nextra/hooks'
-import type { ReactElement, ReactNode } from 'react'
+import type { ReactElement } from 'react'
 import { useCallback, useState } from 'react'
 import { DEFAULT_LOCALE } from '../constants'
 import type { SearchResult } from '../types'
-import { HighlightMatches } from './highlight-matches'
 import { Search } from './search'
 
-type SectionIndex = FlexSearch.Document<
-  {
-    id: string
-    url: string
-    title: string
-    pageId: string
-    content: string
-    display?: string
-  },
-  ['title', 'content', 'url', 'display']
->
+const TARGET_SUMMARY_LENGTH = 100
+const MIN_TOKEN_LENGTH = 3
+const PAGE_TITLE_SCORE_BOOST = 8
+const SECTION_TITLE_SCORE_BOOST = 4
 
-type PageIndex = FlexSearch.Document<
-  {
-    id: number
-    title: string
-    content: string
-  },
-  ['title']
->
+const SEARCH_LIMIT = 100
+const PAGE_LIMIT = 5
+const SECTION_LIMIT = 3
 
-type Result = {
-  _page_rk: number
-  _section_rk: number
+type Section = {
+  anchor: string
+  title: string
+  content: string
+}
+
+type Document = {
+  title: string
   route: string
-  prefix: ReactNode
-  children: ReactNode
+  sections: Section[]
+}
+
+type PageIndex = FlexSearch.Document<Document, ['title', 'route', 'sections']>
+
+interface ScoredDocument {
+  score: number
+  doc: Document
+}
+
+interface SummaryPart {
+  highlight?: boolean
+  value: string
+}
+
+type PageSection = {
+  title: string
+  anchor: string
+  summaryParts: SummaryPart[]
+}
+
+type Page = {
+  title: string
+  route: string
+  sections: PageSection[]
 }
 
 // This can be global for better caching.
 const indexes: {
-  [locale: string]: [PageIndex, SectionIndex]
+  [locale: string]: PageIndex
 } = {}
 
 // Caches promises that load the index
@@ -68,29 +84,13 @@ const loadIndexesImpl = async (
   )
   const searchData = (await response.json()) as SearchData
 
-  const pageIndex: PageIndex = new FlexSearch.Document({
+  const index: PageIndex = new FlexSearch.Document({
     cache: 100,
     tokenize: 'full',
     document: {
       id: 'id',
-      index: 'content',
-      store: ['title']
-    },
-    context: {
-      resolution: 9,
-      depth: 2,
-      bidirectional: true
-    }
-  })
-
-  const sectionIndex: SectionIndex = new FlexSearch.Document({
-    cache: 100,
-    tokenize: 'full',
-    document: {
-      id: 'id',
-      index: 'content',
-      tag: 'pageId',
-      store: ['title', 'content', 'url', 'display']
+      index: ['title', 'sections[]:title', 'sections[]:content'],
+      store: ['title', 'route', 'sections']
     },
     context: {
       resolution: 9,
@@ -102,135 +102,276 @@ const loadIndexesImpl = async (
   let pageId = 0
 
   for (const [route, structurizedData] of Object.entries(searchData)) {
-    let pageContent = ''
-    ++pageId
+    const sections: Section[] = []
 
     for (const [key, content] of Object.entries(structurizedData.data)) {
-      const [headingId, headingValue] = key.split('#')
-      const url = route + (headingId ? '#' + headingId : '')
-      const title = headingValue || structurizedData.title
-      const paragraphs = content.split('\n')
+      const [anchor, title] = key.split('#', 2)
 
-      sectionIndex.add({
-        id: url,
-        url,
-        title,
-        pageId: `page_${pageId}`,
-        content: title,
-        ...(paragraphs[0] && { display: paragraphs[0] })
-      })
-
-      for (let i = 0; i < paragraphs.length; i++) {
-        sectionIndex.add({
-          id: `${url}_${i}`,
-          url,
-          title,
-          pageId: `page_${pageId}`,
-          content: paragraphs[i]
-        })
-      }
-
-      // Add the page itself.
-      pageContent += ` ${title} ${content}`
+      sections.push({ anchor, title, content })
     }
 
-    pageIndex.add({
-      id: pageId,
+    index.add(pageId++, {
+      route,
       title: structurizedData.title,
-      content: pageContent
+      sections
     })
   }
 
-  indexes[locale] = [pageIndex, sectionIndex]
+  indexes[locale] = index
 }
 
-export function getResults(search: string, locale: string) {
-  if (!search) return
-  const [pageIndex, sectionIndex] = indexes[locale]
+function compileQuery(query: string): RegExp {
+  const tokens = query
+    .split(/\W+/)
+    .filter(token => token.length >= MIN_TOKEN_LENGTH)
+    .map(escapeStringRegexp)
 
-  // Show the results for the top 5 pages
-  const pageResults =
-    pageIndex.search<true>(search, 5, {
-      enrich: true,
-      suggest: true
-    })[0]?.result || []
+  return tokens.length
+    ? new RegExp('(' + tokens.map(escapeStringRegexp).join('|') + ')', 'ig')
+    : /^$/
+}
 
-  const results: Result[] = []
-  const pageTitleMatches: Record<number, number> = {}
+function scoreText(regex: RegExp, text: string): number {
+  let score = 0
+  if (text) {
+    regex.lastIndex = 0
+    while (regex.exec(text)) score += 1
+  }
+  return score
+}
 
-  for (let i = 0; i < pageResults.length; i++) {
-    const result = pageResults[i]
-    pageTitleMatches[i] = 0
+function summarize(content: string, highlights: number[]): SummaryPart[] {
+  // attempt to find highlights that fit within target summary length
+  while (
+    highlights.length > 2 &&
+    highlights[highlights.length - 1] - highlights[0] > TARGET_SUMMARY_LENGTH
+  ) {
+    let largestGap = 0
+    let largestGapIndex = 0
 
-    // Show the top 5 results for each page
-    const sectionResults =
-      sectionIndex.search<true>(search, 5, {
-        enrich: true,
-        suggest: true,
-        tag: `page_${result.id}`
-      })[0]?.result || []
-
-    let isFirstItemOfPage = true
-    const occurred: Record<string, boolean> = {}
-
-    for (let j = 0; j < sectionResults.length; j++) {
-      const { doc } = sectionResults[j]
-      const isMatchingTitle = doc.display !== undefined
-      if (isMatchingTitle) {
-        pageTitleMatches[i]++
+    for (let i = 0; i < highlights.length - 2; i += 2) {
+      const gap = highlights[i + 2] - highlights[i + 1]
+      if (gap >= largestGap) {
+        largestGap = gap
+        largestGapIndex = i
       }
-      const { url, title } = doc
-      const content = doc.display || doc.content
-      if (occurred[url + '@' + content]) continue
-      occurred[url + '@' + content] = true
-      results.push({
-        _page_rk: i,
-        _section_rk: j,
-        route: url,
-        prefix: isFirstItemOfPage && (
-          <div
-            className={cn(
-              '_mx-2.5 _mb-2 _mt-6 _select-none _border-b _border-black/10 _px-2.5 _pb-1.5 _text-xs _font-semibold _uppercase _text-gray-500 first:_mt-0 dark:_border-white/20 dark:_text-gray-300',
-              'contrast-more:_border-gray-600 contrast-more:_text-gray-900 contrast-more:dark:_border-gray-50 contrast-more:dark:_text-gray-50'
-            )}
-          >
-            {result.doc.title}
-          </div>
-        ),
-        children: (
-          <>
-            <div className="_text-base _font-semibold _leading-5">
-              <HighlightMatches match={search} value={title} />
-            </div>
-            {content && (
-              <div className="excerpt _mt-1 _text-sm _leading-[1.35rem] _text-gray-600 dark:_text-gray-400 contrast-more:dark:_text-gray-50">
-                <HighlightMatches match={search} value={content} />
-              </div>
-            )}
-          </>
-        )
-      })
-      isFirstItemOfPage = false
     }
+
+    // remove gap
+    highlights = highlights
+      .slice(0, largestGapIndex)
+      .concat(highlights.slice(largestGapIndex + 2))
+  }
+
+  let startIndex = 0
+  let endIndex = TARGET_SUMMARY_LENGTH
+  if (highlights.length) {
+    startIndex = highlights[0]
+    endIndex = highlights[highlights.length - 1]
+  }
+
+  // expand start and end at word boundaries until we've hit our target summary
+  // length
+  const wb = /\b/g
+  let result: RegExpExecArray | null = null
+  let remaining = TARGET_SUMMARY_LENGTH - (endIndex - startIndex)
+  while (remaining > 0) {
+    // expand head using nearest left word boundary
+    wb.lastIndex = Math.max(startIndex - remaining, 0)
+    if (wb.lastIndex < startIndex) {
+      let lastIndex = startIndex
+
+      while ((result = wb.exec(content)) != null && result.index < startIndex) {
+        lastIndex = result.index
+        wb.lastIndex = lastIndex + 1
+      }
+
+      if (
+        lastIndex < startIndex &&
+        endIndex - lastIndex < TARGET_SUMMARY_LENGTH
+      ) {
+        startIndex = lastIndex
+      }
+    }
+
+    // expand tail using near right word boundary
+    wb.lastIndex = endIndex + 1
+    result = wb.exec(content)
+    if (result != null && result.index - startIndex < TARGET_SUMMARY_LENGTH) {
+      endIndex = result.index
+    }
+
+    const newRemaining = TARGET_SUMMARY_LENGTH - (endIndex - startIndex)
+    // if we don't make any progress stop
+    if (newRemaining === remaining) break
+    remaining = newRemaining
+  }
+
+  const parts: SummaryPart[] = []
+
+  let bufferIndex = startIndex
+  while (highlights.length) {
+    // add leading non-highlighted text
+    if (bufferIndex < highlights[0]) {
+      parts.push({ value: content.slice(bufferIndex, highlights[0]) })
+    }
+
+    // add highlighted text
+    const start = highlights.shift() as number
+    const end = highlights.shift() as number
+    parts.push({
+      value: content.slice(start, end),
+      highlight: true
+    })
+    bufferIndex = end
+  }
+
+  // if we have no highlights end index might be TARGET_SUMMARY_LENGTH,
+  // truncate to actual length
+  endIndex = Math.min(endIndex, content.length)
+
+  // add remaining text
+  if (bufferIndex < endIndex) {
+    parts.push({ value: content.slice(bufferIndex, endIndex) })
+  }
+
+  // add leading and trailing '...' if content truncated
+  if (parts.length) {
+    if (startIndex !== 0) {
+      const first = parts[0]
+      first.value = first.value.trimStart()
+      if (first.highlight) {
+        parts.unshift({ value: '... ' })
+      } else {
+        first.value = '... ' + first.value
+      }
+    }
+    if (endIndex < content.length) {
+      const last = parts[parts.length - 1]
+      last.value = last.value.trimEnd()
+      if (last.highlight) {
+        parts.push({ value: ' ...' })
+      } else {
+        last.value += ' ...'
+      }
+    }
+  }
+
+  return parts
+}
+
+export function getResults(query: string, locale: string) {
+  if (!query) return []
+
+  const index = indexes[locale]
+  if (!index) return []
+
+  const resultSets = index.search<true>(query, SEARCH_LIMIT, {
+    enrich: true,
+    suggest: true
+  })
+  if (!resultSets.length) {
+    return []
+  }
+
+  const queryRegex = compileQuery(query)
+
+  // score docs by number of times matched and title
+  const scoredDocMap: Record<string, ScoredDocument> = {}
+  for (const resultSet of resultSets) {
+    for (const { doc } of resultSet.result) {
+      let scoredDoc: ScoredDocument = scoredDocMap[doc.route]
+      if (!scoredDoc) {
+        scoredDoc = {
+          score: scoreText(queryRegex, doc.title) * PAGE_TITLE_SCORE_BOOST,
+          doc
+        }
+        scoredDocMap[doc.route] = scoredDoc
+      }
+      scoredDoc.score++
+    }
+  }
+
+  // get top scoring pages
+  const scoredDocs = Object.values(scoredDocMap)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, PAGE_LIMIT)
+
+  const results: Page[] = []
+  for (const { doc } of scoredDocs) {
+    // score each section and create summary with highlighted parts
+    let sections = doc.sections.map(({ title, content, anchor }) => {
+      let score = scoreText(queryRegex, title) * SECTION_TITLE_SCORE_BOOST
+
+      if (!content) {
+        return {
+          score,
+          title,
+          anchor,
+          summaryParts: []
+        }
+      }
+
+      const tokenScored: Record<string, boolean> = {}
+      const highlights: number[] = []
+      let result: RegExpExecArray | null = null
+
+      // find and score matched tokens
+      queryRegex.lastIndex = 0
+      while ((result = queryRegex.exec(content)) != null) {
+        const value = result[1] || ''
+
+        // only unique tokens contribute to score
+        const token = value.toLowerCase()
+        if (value.length >= 3) {
+          if (!tokenScored[token]) score += 1
+          tokenScored[token] = true
+        }
+
+        // track slices to highlight
+        highlights.push(result.index, result.index + value.length)
+      }
+
+      return {
+        score,
+        title,
+        anchor,
+        summaryParts: summarize(content, highlights)
+      }
+    })
+
+    sections.sort((a, b) => b.score - a.score)
+
+    let placeholderSummaryParts: SummaryPart[] = []
+
+    // remove zero score sections
+    while (sections.length && sections[sections.length - 1].score === 0) {
+      const section = sections.pop()
+      if (section?.summaryParts.length) {
+        placeholderSummaryParts = section.summaryParts
+      }
+    }
+
+    // if we don't have any matched sections, add a placeholder
+    if (!sections.length) {
+      sections.push({
+        title: doc.title,
+        anchor: '',
+        summaryParts: placeholderSummaryParts,
+        score: 0
+      })
+    } else if (sections.length > SECTION_LIMIT) {
+      sections = sections.slice(0, SECTION_LIMIT)
+    }
+
+    results.push({
+      title: doc.title,
+      route: doc.route,
+      sections: sections
+    })
   }
 
   return results
-    .sort((a, b) => {
-      // Sort by number of matches in the title.
-      if (a._page_rk === b._page_rk) {
-        return a._section_rk - b._section_rk
-      }
-      if (pageTitleMatches[a._page_rk] !== pageTitleMatches[b._page_rk]) {
-        return pageTitleMatches[b._page_rk] - pageTitleMatches[a._page_rk]
-      }
-      return a._page_rk - b._page_rk
-    })
-    .map(res => ({
-      id: `${res._page_rk}_${res._section_rk}`,
-      route: res.route,
-      prefix: res.prefix,
-      children: res.children
-    }))
 }
 
 export function Flexsearch({
@@ -250,7 +391,7 @@ export function Flexsearch({
         setLoading(true)
         try {
           await loadIndexes(basePath, locale)
-        } catch {
+        } catch (e) {
           setError(true)
         }
         setLoading(false)
@@ -261,18 +402,64 @@ export function Flexsearch({
 
   const handleChange = async (value: string) => {
     setSearch(value)
-    if (loading) return
+    if (loading) {
+      return
+    }
     if (!indexes[locale]) {
       setLoading(true)
       try {
         await loadIndexes(basePath, locale)
-      } catch {
+      } catch (e) {
         setError(true)
       }
       setLoading(false)
     }
     const newResults = getResults(value, locale)
-    if (newResults) setResults(newResults)
+    setResults(
+      getResults(value, locale).flatMap(page => {
+        return page.sections.map((section, i) => {
+          const route = section.anchor
+            ? `${page.route}#${section.anchor}`
+            : page.route
+
+          return {
+            id: route,
+            route,
+            prefix: i == 0 && (
+              <div
+                className={cn(
+                  '_mx-2.5 _mb-2 _mt-6 _select-none _border-b _border-black/10 _px-2.5 _pb-1.5 _text-xs _font-semibold _uppercase _text-gray-500 first:_mt-0 dark:_border-white/20 dark:_text-gray-300',
+                  'contrast-more:_border-gray-600 contrast-more:_text-gray-900 contrast-more:dark:_border-gray-50 contrast-more:dark:_text-gray-50'
+                )}
+              >
+                {page.title}
+              </div>
+            ),
+            children: (
+              <>
+                <div className="_text-base _font-semibold _leading-5">
+                  {section.title || page.title}
+                </div>
+                {!!section.summaryParts.length && (
+                  <div className="excerpt _mt-1 _text-sm _leading-[1.35rem] _text-gray-600 dark:_text-gray-400 contrast-more:dark:_text-gray-50">
+                    {section.summaryParts.map(({ value, highlight }, index) => {
+                      return (
+                        <span
+                          key={index}
+                          className={cn({ '_text-primary-600': highlight })}
+                        >
+                          {value}
+                        </span>
+                      )
+                    })}
+                  </div>
+                )}
+              </>
+            )
+          }
+        })
+      })
+    )
   }
 
   return (


### PR DESCRIPTION
Some of the things I've changed/tweaked:
 * Use one index instead of two
 * Attempted to improve ranking/scoring
 * Truncate summaries while attempting to retain useful highlights
 * Fix #2438
 * Remove results that point to the same anchor

I've done a bunch of manual side-by-side comparison of the results on the Nextra docs site, the swr-site, and my private project.

I've personally found the results to be much better with the new search logic, but I'd love to get another set of eyes on it, and any example of regressions so I can dig into them.

You added a test for no results for `>  a` which I purposely didn't address. I'm not sure it's a useful issue to fix and it's going to do weird stuff for people entering Chinese/Japanese/Korean characters (without adding language aware tokenizers). The current code handles boosting the score for these languages pretty poorly, but I didn't want to just hard filter them out.

Might be nice to get the preview version of this deployed to vercel to make the side-by-side comparison easier (assuming v3 branch is deployed somewhere we can compare it to).

---

Things that probably need more work/resarch:
 * ~Summaries aren't truncated at word boundaries~
 * ~Titles aren't highlighted~
 * ~Tests~
 * ~Make sure memory usage didn't get worse~

From a UI perspective it might be worth considering adding page links and making the page title/item selectable, which would alleviate the need for the placeholder section item.

---

Things to follow up on later:

 * look into including page hierarchy in the index/title (e.g. I have a couple of "Getting Started" guides in my docs and it's difficult to tell them apart in the search). Having the context would also improve the ranking of results
 * dig into the `structurizedData` data generation and attempt to fix merged paragraphs
 * look into possibly adding keywords to frontMatter and including them in the index