### PR TITLE
fix(nextra): package.json exports declaration error

### DIFF
--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -10,7 +10,10 @@
   "main": "./dist/index.js",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/index.js",
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/types.d.mts"
+    },
     "./catch-all": "./dist/catch-all.js",
     "./data": {
       "import": "./dist/ssg.js",


### PR DESCRIPTION
nextra only declare a js path string in `exports`'s `"."`, which will make typescript report `Could not find a declaration file for module 'nextra'. `

<img width="865" alt="image" src="https://github.com/shuding/nextra/assets/15249633/8ed30f1a-c45e-41dc-9d4a-d7d7c67dc812">

This PR add `"types": "./dist/types.d.mts"` into `exports`'s `"."` property, and make typescript work correctly
