### PR TITLE
fix: scroll-to-top interactivity with visibility 

### DIFF
--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -12,7 +12,7 @@ export function BackToTop({ className }: { className?: string }): ReactElement {
   useEffect(() => {
     function toggleVisible() {
       const { scrollTop } = document.documentElement
-      ref.current?.classList.toggle('nx-opacity-0', scrollTop < 300)
+      ref.current?.classList.toggle('nx-invisible', scrollTop < 300)
     }
 
     window.addEventListener('scroll', toggleVisible)
@@ -27,7 +27,7 @@ export function BackToTop({ className }: { className?: string }): ReactElement {
       aria-hidden="true"
       onClick={scrollToTop}
       className={cn(
-        'nx-flex nx-items-center nx-gap-1.5 nx-transition nx-opacity-0',
+        'nx-flex nx-items-center nx-gap-1.5 nx-transition nx-invisible',
         className
       )}
     >


### PR DESCRIPTION
## What does this PR do?

fixes: #2376

## What is the current behavior?
“Scroll to top” is interactive even when it is hidden.

![](https://user-images.githubusercontent.com/3247876/272613749-0baff765-6f31-42ba-9693-1c4772ac2930.gif)

## What is the new behavior?
“Scroll to top” is now **non-interactive** when it is hidden.

https://github.com/shuding/nextra/assets/92709590/eaba2e4a-8027-4e2a-bbf9-0830eac2e01a



