### PR TITLE
fix: About Nextra link redirect 

### DIFF
--- a/.changeset/smooth-knives-approve.md
+++ b/.changeset/smooth-knives-approve.md
@@ -1,0 +1,6 @@
+---
+'nextra': minor
+---
+
+Fixed the About Nextra pagination link. Now it redirects to the About Nextra
+page properly.

--- a/packages/nextra/src/normalize-pages.ts
+++ b/packages/nextra/src/normalize-pages.ts
@@ -247,7 +247,7 @@ export function normalizePages({
     if (key !== '*') {
       items.push({
         name: key,
-        route: '#',
+        route: meta[key]['href'], // updating --More section's route
         ...meta[key]
       })
     }


### PR DESCRIPTION
## What does this PR do?
fixes: #1829

## What is the current behavior?
we can't redirect to `About Nextra` page.

## What is the new behavior?
we can redirect to  `About Nextra` !


https://github.com/shuding/nextra/assets/92709590/e4d199ea-438b-4bee-90a0-6247d1ee8163


