### PR TITLE
fix: theme-switich hidden not work

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,6 +16,7 @@
     "dirty-buttons-crash",
     "dull-pugs-train",
     "early-walls-hammer",
+    "eight-snails-allow",
     "fair-balloons-talk",
     "fast-falcons-report",
     "few-rivers-sell",

--- a/packages/nextra-theme-blog/CHANGELOG.md
+++ b/packages/nextra-theme-blog/CHANGELOG.md
@@ -1,5 +1,16 @@
 # nextra-theme-blog
 
+## 3.0.0-alpha.11
+
+### Major Changes
+
+- c2ad837d: update to MDX3
+
+### Patch Changes
+
+- Updated dependencies [c2ad837d]
+  - nextra@3.0.0-alpha.11
+
 ## 3.0.0-alpha.10
 
 ### Patch Changes

--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextra-theme-blog",
-  "version": "3.0.0-alpha.10",
+  "version": "3.0.0-alpha.11",
   "description": "A Nextra theme for blogs.",
   "repository": "https://github.com/shuding/nextra",
   "author": "Shu Ding <g@shud.in>",

--- a/packages/nextra-theme-docs/CHANGELOG.md
+++ b/packages/nextra-theme-docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # nextra-theme-docs
 
+## 3.0.0-alpha.11
+
+### Major Changes
+
+- c2ad837d: update to MDX3
+
+### Patch Changes
+
+- Updated dependencies [c2ad837d]
+  - nextra@3.0.0-alpha.11
+
 ## 3.0.0-alpha.10
 
 ### Patch Changes

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextra-theme-docs",
-  "version": "3.0.0-alpha.10",
+  "version": "3.0.0-alpha.11",
   "description": "A Nextra theme for documentation sites.",
   "repository": "https://github.com/shuding/nextra",
   "author": "Shu Ding <g@shud.in>",

--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -45,7 +45,7 @@ export function ThemeSwitch({
         name: (
           <div className="_flex _items-center _gap-2 _capitalize">
             <IconToUse />
-            <span className={lite ? 'md:_hidden' : ''}>
+            <span className={lite ? '_hidden' : ''}>
               {mounted ? options[theme as keyof typeof options] : options.light}
             </span>
           </div>

--- a/packages/nextra/CHANGELOG.md
+++ b/packages/nextra/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nextra
 
+## 3.0.0-alpha.11
+
+### Major Changes
+
+- c2ad837d: update to MDX3
+
 ## 3.0.0-alpha.10
 
 ### Patch Changes

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextra",
-  "version": "3.0.0-alpha.10",
+  "version": "3.0.0-alpha.11",
   "type": "module",
   "description": "Next.js and MDX based site generator.",
   "repository": "https://github.com/shuding/nextra",


### PR DESCRIPTION
The `Light` is not hidden.
<img width="239" alt="image" src="https://github.com/shuding/nextra/assets/4998018/a028880b-31a4-4244-b268-ae35a267aa46">

