### PR TITLE
feat: support route injection

### DIFF
--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -1,6 +1,5 @@
 import { Menu, Transition } from '@headlessui/react'
 import cn from 'clsx'
-import { useFSRoute } from 'nextra/hooks'
 import { ArrowRightIcon, MenuIcon } from 'nextra/icons'
 import type { Item, MenuItem, PageItem } from 'nextra/normalize-pages'
 import type { ReactElement, ReactNode } from 'react'
@@ -80,7 +79,7 @@ function NavbarMenu({
 
 export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
   const config = useConfig()
-  const activeRoute = useFSRoute()
+  const activeRoute = config.useRoute()
   const { menu, setMenu } = useMenu()
 
   return (

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -1,7 +1,7 @@
 import cn from 'clsx'
 import { useRouter } from 'next/router'
 import type { Heading } from 'nextra'
-import { useFSRoute, useMounted } from 'nextra/hooks'
+import { useMounted } from 'nextra/hooks'
 import { ArrowRightIcon, ExpandIcon } from 'nextra/icons'
 import type { Item, MenuItem, PageItem } from 'nextra/normalize-pages'
 import type { ReactElement } from 'react'
@@ -61,16 +61,39 @@ const classes = {
   )
 }
 
+type ActiveRoute = {
+  active: boolean
+  activeRouteInside: boolean
+}
+
+function useActiveRoute(itemRoute: string | undefined): ActiveRoute {
+  const config = useConfig()
+  const route = config.useRoute()
+
+  // It is possible that the item doesn't have any route - for example an external link.
+  if (!itemRoute) {
+    return {
+      active: false,
+      activeRouteInside: false
+    }
+  }
+
+  const active = [route, route + '/'].includes(itemRoute + '/')
+  const activeRouteInside = active || route.startsWith(itemRoute + '/')
+
+  return {
+    active,
+    activeRouteInside
+  }
+}
+
 type FolderProps = {
   item: PageItem | MenuItem | Item
   anchors: Heading[]
 }
 
 function FolderImpl({ item, anchors }: FolderProps): ReactElement {
-  const routeOriginal = useFSRoute()
-  const [route] = routeOriginal.split('#')
-  const active = [route, route + '/'].includes(item.route + '/')
-  const activeRouteInside = active || route.startsWith(item.route + '/')
+  const { active, activeRouteInside } = useActiveRoute(item.route)
 
   const focusedRoute = useContext(FocusedItemContext)
   const focusedRouteInside = !!focusedRoute?.startsWith(item.route + '/')
@@ -225,11 +248,10 @@ function File({
   item: PageItem | Item
   anchors: Heading[]
 }): ReactElement {
-  const route = useFSRoute()
   const onFocus = useContext(OnFocusItemContext)
 
-  // It is possible that the item doesn't have any route - for example an external link.
-  const active = item.route && [route, route + '/'].includes(item.route + '/')
+  const { active } = useActiveRoute(item.route)
+
   const activeAnchor = useActiveAnchor()
   const { setMenu } = useMenu()
   const config = useConfig()

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -1,18 +1,21 @@
+;
 /* eslint sort-keys: error */
-import type { NextSeoProps } from 'next-seo'
-import { useRouter } from 'next/router'
-import { DiscordIcon, GitHubIcon } from 'nextra/icons'
-import type { Item } from 'nextra/normalize-pages'
-import type { FC, ReactNode } from 'react'
-import { isValidElement } from 'react'
-import { z } from 'zod'
-import { Anchor, Flexsearch, Footer, Navbar, TOC } from './components'
-import { MatchSorterSearch } from './components/match-sorter-search'
-import type { NavBarProps } from './components/navbar'
-import { themeOptionsSchema, ThemeSwitch } from './components/theme-switch'
-import type { TOCProps } from './components/toc'
-import { useConfig } from './contexts'
-import { getGitIssueUrl, useGitEditUrl } from './utils'
+import type { NextSeoProps } from 'next-seo';
+import { useRouter } from 'next/router';
+import { useFSRoute } from "nextra/hooks";
+import { DiscordIcon, GitHubIcon } from 'nextra/icons';
+import type { Item } from 'nextra/normalize-pages';
+import type { FC, ReactNode } from 'react';
+import { isValidElement } from 'react';
+import { z } from 'zod';
+import { Anchor, Flexsearch, Footer, Navbar, TOC } from './components';
+import { MatchSorterSearch } from './components/match-sorter-search';
+import type { NavBarProps } from './components/navbar';
+import { themeOptionsSchema, ThemeSwitch } from './components/theme-switch';
+import type { TOCProps } from './components/toc';
+import { useConfig } from './contexts';
+import { getGitIssueUrl, useGitEditUrl } from './utils';
+
 
 export const DEFAULT_LOCALE = 'en-US'
 
@@ -158,7 +161,8 @@ export const themeSchema = z.strictObject({
       .optional(),
     title: z.custom<ReactNode | FC>(...reactNode)
   }),
-  useNextSeoProps: z.custom<() => NextSeoProps | void>(isFunction)
+  useNextSeoProps: z.custom<() => NextSeoProps | void>(isFunction),
+  useRoute: z.custom<() => string>(isFunction)
 })
 
 const publicThemeSchema = themeSchema.deepPartial().extend({
@@ -349,7 +353,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     float: true,
     title: 'On This Page'
   },
-  useNextSeoProps: () => ({ titleTemplate: '%s – Nextra' })
+  useNextSeoProps: () => ({ titleTemplate: '%s – Nextra' }),
+  useRoute: useFSRoute
 }
 
 export const DEEP_OBJECT_KEYS = Object.entries(DEFAULT_THEME)

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -4,7 +4,7 @@ import type { ReactElement, ReactNode } from 'react'
 import { useMemo } from 'react'
 import 'focus-visible'
 import cn from 'clsx'
-import { useFSRoute, useMounted } from 'nextra/hooks'
+import { useMounted } from 'nextra/hooks'
 import { MDXProvider } from 'nextra/mdx'
 import './polyfill'
 import type { PageTheme } from 'nextra/normalize-pages'
@@ -21,6 +21,7 @@ import { DEFAULT_LOCALE, PartialDocsThemeConfig } from './constants'
 import { ActiveAnchorProvider, ConfigProvider, useConfig } from './contexts'
 import { getComponents } from './mdx-components'
 import { renderComponent } from './utils'
+
 
 interface BodyProps {
   themeContext: PageTheme
@@ -116,7 +117,7 @@ const InnerLayout = ({
 }: PageOpts & { children: ReactNode }): ReactElement => {
   const config = useConfig()
   const { locale = DEFAULT_LOCALE, defaultLocale } = useRouter()
-  const fsPath = useFSRoute()
+  const route = config.useRoute()
 
   const {
     activeType,
@@ -134,9 +135,9 @@ const InnerLayout = ({
         list: pageMap,
         locale,
         defaultLocale,
-        route: fsPath
+        route
       }),
-    [pageMap, locale, defaultLocale, fsPath]
+    [pageMap, locale, defaultLocale, route]
   )
 
   const themeContext = { ...activeThemeContext, ...frontMatter }


### PR DESCRIPTION
Adds an option to the docs theme to override the current active route. Will default to `useFSRoute`, resulting in unchanged behavior unless the theme option is provided. The purpose of this change is to allow optionally controlling the current route without using Next's router. 