### PR TITLE
fix: make `Bleed` don't block the `Toc`

### DIFF
--- a/packages/nextra-theme-docs/src/components/bleed.tsx
+++ b/packages/nextra-theme-docs/src/components/bleed.tsx
@@ -11,7 +11,7 @@ export function Bleed({
   return (
     <div
       className={cn(
-        'nextra-bleed nx-relative -nx-mx-6 nx-mt-6 md:-nx-mx-8 2xl:-nx-mx-24',
+        'nextra-bleed nx-relative -nx-mx-6 nx-mt-6 md:-nx-mx-8 2xl:-nx-mx-10',
         full && [
           // 'md:mx:[calc(-50vw+50%+8rem)',
           'ltr:xl:nx-ml-[calc(50%-50vw+16rem)] ltr:xl:nx-mr-[calc(50%-50vw)]',


### PR DESCRIPTION
related: #2591 

`Toc` needs some room to breathe

preview:
<img width="1642" alt="image" src="https://github.com/shuding/nextra/assets/22422393/338396c8-ef13-4bda-ad29-1736ed595e79">
