### PR TITLE
Move the tailwind CSS configuration postcss cli to tsup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ pnpm build
 | ----------------- | ------------------------ |
 | pnpm dev          | Watch mode               |
 | pnpm dev:layout   | Watch mode (layout only) |
-| pnpm dev:tailwind | Watch mode (style only)  |
 
 ### Development
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "packageManager": "pnpm@8.9.2",
   "scripts": {
-    "build": "turbo run build:tailwind build --filter=./packages/\\*",
-    "build:all": "turbo run build:tailwind build",
+    "build": "turbo run build build --filter=./packages/\\*",
+    "build:all": "turbo run build",
     "build:core": "pnpm build --filter=nextra",
     "build:theme-blog": "pnpm build --filter=nextra-theme-blog",
     "build:theme-docs": "pnpm build --filter=nextra-theme-docs",

--- a/packages/nextra-theme-blog/package.json
+++ b/packages/nextra-theme-blog/package.json
@@ -6,7 +6,7 @@
   "author": "Shu Ding <g@shud.in>",
   "license": "MIT",
   "exports": {
-    "./style.css": "./style.css",
+    "./style.css": "./dist/styles.css",
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.mts"
@@ -32,18 +32,13 @@
     }
   },
   "files": [
-    "dist",
-    "style.css"
+    "dist"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:all": "pnpm build && pnpm build:tailwind",
-    "build:tailwind": "pnpm postcss src/styles.css -o style.css --verbose",
-    "clean": "rimraf ./dist ./style.css",
-    "dev": "concurrently \"pnpm dev:layout\" \"pnpm dev:tailwind\"",
-    "dev:layout": "tsup --watch",
-    "dev:tailwind": "TAILWIND_MODE=watch pnpm postcss src/styles.css -o style.css --watch",
-    "prepublishOnly": "pnpm build:all",
+    "build": "tsup --minify",
+    "clean": "rimraf ./dist",
+    "dev": "tsup --watch",
+    "prepublishOnly": "pnpm build",
     "test": "vitest run",
     "types": "tsup --dts-only",
     "types:check": "tsc --noEmit"

--- a/packages/nextra-theme-blog/tsup.config.ts
+++ b/packages/nextra-theme-blog/tsup.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.tsx', 'src/cusdis.tsx', 'src/tags.tsx'],
+  entry: ['src/index.tsx', 'src/cusdis.tsx', 'src/tags.tsx', 'src/styles.css'],
+  dts: {
+    entry: ['src/index.tsx', 'src/cusdis.tsx', 'src/tags.tsx']
+  },
   format: 'esm',
-  dts: true,
   name: 'nextra-theme-blog',
   outExtension: () => ({ js: '.js' }),
   external: ['nextra']

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -6,26 +6,21 @@
   "author": "Shu Ding <g@shud.in>",
   "license": "MIT",
   "exports": {
-    "./style.css": "./style.css",
+    "./style.css": "./dist/css/styles.css",
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.mts"
+      "import": "./dist/src/index.js",
+      "types": "./dist/src/index.d.mts"
     }
   },
   "types": "./dist/index.d.mts",
   "files": [
-    "dist",
-    "style.css"
+    "dist"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:all": "pnpm build && pnpm build:tailwind",
-    "build:tailwind": "pnpm postcss css/styles.css -o style.css --verbose",
-    "clean": "rimraf ./dist ./style.css",
-    "dev": "concurrently \"pnpm dev:layout\" \"pnpm dev:tailwind\"",
-    "dev:layout": "tsup --watch",
-    "dev:tailwind": "TAILWIND_MODE=watch pnpm postcss css/styles.css -o style.css --watch",
-    "prepublishOnly": "pnpm build:all",
+    "build": "tsup --minify",
+    "clean": "rimraf ./dist",
+    "dev": "tsup --watch",
+    "prepublishOnly": "pnpm build",
     "test": "echo ❗ No tests, previous tests were moved to the `nextra` package",
     "types": "tsup --dts-only",
     "types:check": "tsc --noEmit"
@@ -64,7 +59,6 @@
     "next": "^13.5.6",
     "nextra": "workspace:*",
     "postcss": "^8.4.31",
-    "postcss-cli": "^10.1.0",
     "postcss-import": "^15.1.0",
     "postcss-lightningcss": "^1.0.0",
     "react": "^18.2.0",

--- a/packages/nextra-theme-docs/tsup.config.ts
+++ b/packages/nextra-theme-docs/tsup.config.ts
@@ -2,9 +2,12 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   name: 'nextra-theme-docs',
-  entry: ['src/index.tsx'],
+  entry: ['src/index.tsx', 'css/styles.css'],
+  dts: {
+    entry: ['src/index.tsx']
+  },
+  outDir:"dist",
   format: 'esm',
-  dts: true,
   external: ['nextra'],
   outExtension: () => ({ js: '.js' })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,9 +491,6 @@ importers:
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
-      postcss-cli:
-        specifier: ^10.1.0
-        version: 10.1.0(postcss@8.4.31)
       postcss-import:
         specifier: ^15.1.0
         version: 15.1.0(postcss@8.4.31)
@@ -511,7 +508,7 @@ importers:
         version: 3.3.3
       vitest:
         specifier: ^0.29.8
-        version: 0.29.8(@edge-runtime/vm@3.1.0)(jsdom@22.0.0)
+        version: 0.29.8(jsdom@22.0.0)
 
 packages:
 
@@ -10964,6 +10961,71 @@ packages:
         optional: true
     dependencies:
       '@edge-runtime/vm': 3.1.0
+      '@types/chai': 4.3.4
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.11.18
+      '@vitest/expect': 0.29.8
+      '@vitest/runner': 0.29.8
+      '@vitest/spy': 0.29.8
+      '@vitest/utils': 0.29.8
+      acorn: 8.9.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.7
+      debug: 4.3.4
+      jsdom: 22.0.0
+      local-pkg: 0.4.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      source-map: 0.6.1
+      std-env: 3.4.3
+      strip-literal: 1.0.0
+      tinybench: 2.3.1
+      tinypool: 0.4.0
+      tinyspy: 1.0.2
+      vite: 4.0.4(@types/node@18.11.18)
+      vite-node: 0.29.8(@types/node@18.11.18)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@0.29.8(jsdom@22.0.0):
+    resolution: {integrity: sha512-JIAVi2GK5cvA6awGpH0HvH/gEG9PZ0a/WoxdiV3PmqK+3CjQMf8c+J/Vhv4mdZ2nRyXFw66sAg6qz7VNkaHfDQ==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
       '@types/node': 18.11.18

--- a/turbo.json
+++ b/turbo.json
@@ -8,10 +8,6 @@
       ],
       "outputs": ["dist/**", ".next/**", "loader.js"]
     },
-    "build:tailwind": {
-      "dependsOn": [],
-      "outputs": ["style.css"]
-    },
     "test": {},
     "types:check": {
       "dependsOn": [


### PR DESCRIPTION
Remove the separate tailwind development `pnpm postcss src/styles.css -o style.css --verbose` command and build tailwind CSS with [tsup](https://tsup.egoist.dev/#css-support).

To build tailwind CSS just run `pnpm dev` command. It is generate the tailwind CSS for development. For production run `pnpm build` command it generates a minify tailwind CSS file.