### PR TITLE
fix: old import for useData

### DIFF
--- a/docs/pages/docs/guide/ssg.mdx
+++ b/docs/pages/docs/guide/ssg.mdx
@@ -7,7 +7,7 @@ can also be cached by a CDN to maximize the performance.
 
 This is supported by Nextra too. Here's an example:
 
-import { useData } from 'nextra/data'
+import { useData } from 'nextra/hooks'
 
 export const getStaticProps = ({ params }) => {
   return fetch(`https://api.github.com/repos/shuding/nextra`)
@@ -44,7 +44,7 @@ enabled, it will be kept up to date.
 Here's the MDX code for the example above:
 
 ```mdx
-import { useData } from 'nextra/data'
+import { useData } from 'nextra/hooks'
 
 export const getStaticProps = ({ params }) => {
   return fetch(`https://api.github.com/repos/shuding/nextra`)


### PR DESCRIPTION
When running the demo code listed [here](https://nextra.site/docs/guide/ssg) you get error: 

```
Module not found: Can't resolve 'nextra/data'
```

This is because of the fact that `useData` has moved to `nextra/hooks`. 

