### PR TITLE
docs: add remote content example using next-mdx-remote and a GitHub Gist

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "clsx": "^2.0.0",
     "framer-motion": "^10.0.0",
     "next": "^13.5.6",
+    "next-mdx-remote": "^4.2.1",
     "nextra": "workspace:*",
     "nextra-theme-docs": "workspace:*",
     "react": "^18.2.0",

--- a/docs/pages/docs/guide/advanced/remote.mdx
+++ b/docs/pages/docs/guide/advanced/remote.mdx
@@ -2,15 +2,15 @@ import { useData } from 'nextra/data'
 import { serialize } from 'next-mdx-remote/serialize'
 import { MDXRemote } from 'next-mdx-remote'
 
-export const getStaticProps = ({ params }) => {
-  const source = fetch(`https://gist.githubusercontent.com/eiiot/55984a720d8bf986b41d347b9895ed4b/raw/c6c48d57ca92ac2222cf358350494faf02c07d81/nextra-remote.md`)
-    .then(res => res.text())
-  const mdxSource = await serialize(source)
+export const getStaticProps = async () => {
+  const sourceRes = await fetch(`https://gist.githubusercontent.com/eiiot/55984a720d8bf986b41d347b9895ed4b/raw/f7a100728a5f9723241a37d84c359db1e636304c/nextra-remote.md`)
+  const source = await sourceRes.text();
+  const mdxSource = await serialize(source);
   return { props: { ssg: { source: mdxSource } } }
 }
 
 export const Remote = () => {
-  const { source } = useData()
+  const { source } = useData();
   return <MDXRemote {...source} />
 }
 
@@ -26,15 +26,15 @@ import { useData } from 'nextra/data'
 import { serialize } from 'next-mdx-remote/serialize'
 import { MDXRemote } from 'next-mdx-remote'
 
-export const getStaticProps = ({ params }) => {
-  const source = fetch(`https://gist.githubusercontent.com/eiiot/55984a720d8bf986b41d347b9895ed4b/raw/c6c48d57ca92ac2222cf358350494faf02c07d81/nextra-remote.md`)
-    .then(res => res.text())
-  const mdxSource = await serialize(source)
+export const getStaticProps = async () => {
+  const sourceRes = await fetch(`https://gist.githubusercontent.com/eiiot/55984a720d8bf986b41d347b9895ed4b/raw/f7a100728a5f9723241a37d84c359db1e636304c/nextra-remote.md`)
+  const source = await sourceRes.text();
+  const mdxSource = await serialize(source);
   return { props: { ssg: { source: mdxSource } } }
 }
 
 export const Remote = () => {
-  const { source } = useData()
+  const { source } = useData();
   return <MDXRemote {...source} />
 }
 

--- a/docs/pages/docs/guide/advanced/remote.mdx
+++ b/docs/pages/docs/guide/advanced/remote.mdx
@@ -1,7 +1,44 @@
+import { useData } from 'nextra/data'
+import { serialize } from 'next-mdx-remote/serialize'
+import { MDXRemote } from 'next-mdx-remote'
+
+export const getStaticProps = ({ params }) => {
+  const source = fetch(`https://gist.githubusercontent.com/eiiot/55984a720d8bf986b41d347b9895ed4b/raw/c6c48d57ca92ac2222cf358350494faf02c07d81/nextra-remote.md`)
+    .then(res => res.text())
+  const mdxSource = await serialize(source)
+  return { props: { ssg: { source: mdxSource } } }
+}
+
+export const Remote = () => {
+  const { source } = useData()
+  return <MDXRemote {...source} />
+}
+
 # Remote Content
 
-import { Callout } from 'nextra/components'
+<Remote />
+---
 
-<Callout emoji="🚨">
-  This page is a stub. Help us expand it by contributing!
-</Callout>
+Here's the MDX code for the example above:
+
+```mdx
+import { useData } from 'nextra/data'
+import { serialize } from 'next-mdx-remote/serialize'
+import { MDXRemote } from 'next-mdx-remote'
+
+export const getStaticProps = ({ params }) => {
+  const source = fetch(`https://gist.githubusercontent.com/eiiot/55984a720d8bf986b41d347b9895ed4b/raw/c6c48d57ca92ac2222cf358350494faf02c07d81/nextra-remote.md`)
+    .then(res => res.text())
+  const mdxSource = await serialize(source)
+  return { props: { ssg: { source: mdxSource } } }
+}
+
+export const Remote = () => {
+  const { source } = useData()
+  return <MDXRemote {...source} />
+}
+
+# Remote Content
+
+<Remote />
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       next:
         specifier: 13.5.6
         version: 13.5.6(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+      next-mdx-remote:
+        specifier: ^4.2.1
+        version: 4.2.1(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: workspace:*
         version: link:../packages/nextra


### PR DESCRIPTION
`next-mdx-remote` seems to be the best way to load remote content into nextra - I've used it successfully for interactive content with Next-Auth, for example.

This example uses a GitHub gist to render the first part of the help page. Obviously, the gist should be switched for something hosted under this repo.