### PR TITLE
types: fix card typings

### DIFF
--- a/.changeset/mighty-days-clean.md
+++ b/.changeset/mighty-days-clean.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+children in Card component is required only if the image prop is true

--- a/packages/nextra/src/client/components/cards.tsx
+++ b/packages/nextra/src/client/components/cards.tsx
@@ -34,13 +34,20 @@ function Card({
   href,
   ...props
 }: {
-  children: ReactNode
   title: string
   icon: ReactNode
-  image?: boolean
   arrow?: boolean
   href: string
-}) {
+} & (
+  | {
+      children?: never
+      image?: false
+    }
+  | {
+      children: ReactNode
+      image: true
+    }
+)) {
   const animatedArrow = arrow ? arrowEl : null
 
   if (image) {


### PR DESCRIPTION
fixes: #1961

the `children` prop is only required when `image` is true