### PR TITLE
chore: use `pull_request_target` event to fix comment on pr

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -1,7 +1,7 @@
 name: Next.js Bundle Analysis
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches: [main, v3]
   workflow_dispatch:


### PR DESCRIPTION
The bundle analysis comment was failing on PR from fork. Changed the event to `pull_request_target`, this event will allow commenting on pr as it uses workflow file from the base branch so all the actions are safe to run