### PR TITLE
Enhancement nextra cascade layer

### DIFF
--- a/.changeset/light-onions-hunt.md
+++ b/.changeset/light-onions-hunt.md
@@ -1,0 +1,6 @@
+---
+"nextra-theme-blog": minor
+"nextra-theme-docs": minor
+---
+
+Added `nextra` CSS cascade layer to blog and docs theme

--- a/packages/nextra-theme-blog/src/styles.css
+++ b/packages/nextra-theme-blog/src/styles.css
@@ -1,47 +1,49 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
-@import 'nextra/styles/variables.css';
-@import 'nextra/styles/code-block.css';
-@import 'nextra/styles/subheading-anchor.css';
-@import 'nextra/styles/scrollbar.css';
-@import 'nextra/styles/steps.css';
-@import 'nextra/styles/cards.css';
+@layer nextra {
+  @import 'tailwindcss/base';
+  @import 'tailwindcss/components';
+  @import 'tailwindcss/utilities';
+  @import 'nextra/styles/variables.css';
+  @import 'nextra/styles/code-block.css';
+  @import 'nextra/styles/subheading-anchor.css';
+  @import 'nextra/styles/scrollbar.css';
+  @import 'nextra/styles/steps.css';
+  @import 'nextra/styles/cards.css';
 
-html {
-  @apply nx-scroll-pt-5;
-}
-
-body {
-  @apply nx-px-4;
-}
-
-article {
-  @apply nx-mx-auto nx-block nx-pt-20 nx-pb-32;
-}
-
-article img {
-  @apply nx-mx-auto;
-}
-
-h1 {
-  letter-spacing: -0.03em;
-}
-
-.nx-prose code {
-  &:before,
-  &:after {
-    @apply nx-hidden;
+  html {
+    @apply nx-scroll-pt-5;
   }
-  .line {
-    @apply nx-font-normal;
+
+  body {
+    @apply nx-px-4;
   }
-}
 
-.nx-prose .nextra-callout p {
-  @apply nx-m-0;
-}
+  article {
+    @apply nx-mx-auto nx-block nx-pt-20 nx-pb-32;
+  }
 
-.footnotes a[data-footnote-backref] {
-  font-family: initial;
+  article img {
+    @apply nx-mx-auto;
+  }
+
+  h1 {
+    letter-spacing: -0.03em;
+  }
+
+  .nx-prose code {
+    &:before,
+    &:after {
+      @apply nx-hidden;
+    }
+    .line {
+      @apply nx-font-normal;
+    }
+  }
+
+  .nx-prose .nextra-callout p {
+    @apply nx-m-0;
+  }
+
+  .footnotes a[data-footnote-backref] {
+    font-family: initial;
+  }
 }

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -1,177 +1,184 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
-@import 'nextra/styles/variables.css';
-@import 'nextra/styles/code-block.css';
-@import 'nextra/styles/subheading-anchor.css';
-@import 'nextra/styles/scrollbar.css';
-@import 'nextra/styles/steps.css';
-@import 'nextra/styles/cards.css';
-@import './hamburger.css';
-@import './typesetting-article.css';
+@layer nextra {
+  @import 'tailwindcss/base';
+  @import 'tailwindcss/components';
+  @import 'tailwindcss/utilities';
+  @import 'nextra/styles/variables.css';
+  @import 'nextra/styles/code-block.css';
+  @import 'nextra/styles/subheading-anchor.css';
+  @import 'nextra/styles/scrollbar.css';
+  @import 'nextra/styles/steps.css';
+  @import 'nextra/styles/cards.css';
 
-html {
-  @apply nx-antialiased nx-text-base nx-scroll-pt-[--nextra-navbar-height];
-  font-feature-settings:
-    'rlig' 1,
-    'calt' 1,
-    'ss01' 1;
-  -webkit-tap-highlight-color: transparent;
-}
+  @import './hamburger.css';
+  @import './typesetting-article.css';
 
-body {
-  @apply nx-w-full nx-bg-white dark:nx-bg-dark dark:nx-text-gray-100;
-}
-
-a,
-summary,
-button,
-input,
-[tabindex]:not([tabindex='-1']) {
-  @apply nx-outline-none;
-  &:focus-visible {
-    @apply nx-ring-2 nx-ring-primary-200 nx-ring-offset-1 nx-ring-offset-primary-300 dark:nx-ring-primary-800 dark:nx-ring-offset-primary-700;
+  .thing {
+    background-color: green;
   }
-}
 
-a,
-summary {
-  @apply nx-rounded;
-}
+  html {
+    @apply nx-antialiased nx-text-base nx-scroll-pt-[--nextra-navbar-height];
+    font-feature-settings:
+      'rlig' 1,
+      'calt' 1,
+      'ss01' 1;
+    -webkit-tap-highlight-color: transparent;
+  }
 
-.nextra-content {
-  @apply nx-text-slate-700 dark:nx-text-slate-200;
-}
+  body {
+    @apply nx-w-full nx-bg-white dark:nx-bg-dark dark:nx-text-gray-100;
+  }
 
-@media (max-width: 767px) {
-  .nextra-sidebar-container {
-    @apply nx-fixed nx-pt-[calc(var(--nextra-navbar-height))] nx-top-0 nx-w-full nx-bottom-0 nx-z-[15] nx-overscroll-contain nx-bg-white dark:nx-bg-dark;
-    transition: transform 0.8s cubic-bezier(0.52, 0.16, 0.04, 1);
-    will-change: transform, opacity;
-    contain: layout style;
-    backface-visibility: hidden;
+  a,
+  summary,
+  button,
+  input,
+  [tabindex]:not([tabindex='-1']) {
+    @apply nx-outline-none;
+    &:focus-visible {
+      @apply nx-ring-2 nx-ring-primary-200 nx-ring-offset-1 nx-ring-offset-primary-300 dark:nx-ring-primary-800 dark:nx-ring-offset-primary-700;
+    }
+  }
 
-    & > .nextra-scrollbar {
+  a,
+  summary {
+    @apply nx-rounded;
+  }
+
+  .nextra-content {
+    @apply nx-text-slate-700 dark:nx-text-slate-200;
+  }
+
+  @media (max-width: 767px) {
+    .nextra-sidebar-container {
+      @apply nx-fixed nx-pt-[calc(var(--nextra-navbar-height))] nx-top-0 nx-w-full nx-bottom-0 nx-z-[15] nx-overscroll-contain nx-bg-white dark:nx-bg-dark;
+      transition: transform 0.8s cubic-bezier(0.52, 0.16, 0.04, 1);
+      will-change: transform, opacity;
+      contain: layout style;
+      backface-visibility: hidden;
+
+      & > .nextra-scrollbar {
+        mask-image: linear-gradient(to bottom, transparent, #000 20px),
+          linear-gradient(to left, #000 10px, transparent 10px);
+      }
+    }
+
+    .nextra-banner-container ~ div {
+      .nextra-sidebar-container {
+        @apply nx-pt-[6.5rem];
+      }
+      &.nextra-nav-container {
+        @apply nx-top-10 md:nx-top-0;
+      }
+    }
+    .nextra-banner-hidden {
+      .nextra-banner-container ~ div .nextra-sidebar-container {
+        @apply nx-pt-16;
+      }
+      .nextra-nav-container {
+        @apply !nx-top-0;
+      }
+    }
+    .nextra-search .excerpt {
+      @apply nx-overflow-hidden nx-text-ellipsis;
+      display: -webkit-box;
+      line-clamp: 1;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) and (max-width: 767px) {
+    article:before,
+    .nextra-sidebar-container,
+    .nextra-sidebar-container.open,
+    body.resizing .nextra-sidebar-container {
+      @apply nx-transition-none;
+    }
+  }
+
+  /* Content Typography */
+  article details > summary {
+    &::-webkit-details-marker {
+      @apply nx-hidden;
+    }
+    &::before {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z' clip-rule='evenodd' /%3E%3C/svg%3E");
+      height: 1.2em;
+      width: 1.2em;
+      vertical-align: -4px;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .nextra-toc > .div,
+    .nextra-sidebar-container {
       mask-image: linear-gradient(to bottom, transparent, #000 20px),
         linear-gradient(to left, #000 10px, transparent 10px);
     }
   }
 
-  .nextra-banner-container ~ div {
-    .nextra-sidebar-container {
-      @apply nx-pt-[6.5rem];
+  @supports (
+    (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
+  ) {
+    .nextra-search ul {
+      @apply nx-backdrop-blur-lg nx-bg-white/70 dark:nx-bg-dark/80;
     }
-    &.nextra-nav-container {
-      @apply nx-top-10 md:nx-top-0;
-    }
-  }
-  .nextra-banner-hidden {
-    .nextra-banner-container ~ div .nextra-sidebar-container {
-      @apply nx-pt-16;
-    }
-    .nextra-nav-container {
-      @apply !nx-top-0;
+    .nextra-nav-container-blur {
+      @apply nx-backdrop-blur-md nx-bg-white/[.85] dark:!nx-bg-dark/80;
     }
   }
-  .nextra-search .excerpt {
-    @apply nx-overflow-hidden nx-text-ellipsis;
-    display: -webkit-box;
-    line-clamp: 1;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
-  }
-}
 
-@media (prefers-reduced-motion: reduce) and (max-width: 767px) {
-  article:before,
-  .nextra-sidebar-container,
-  .nextra-sidebar-container.open,
-  body.resizing .nextra-sidebar-container {
-    @apply nx-transition-none;
+  input[type='search'] {
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      -webkit-appearance: none;
+    }
   }
-}
 
-/* Content Typography */
-article details > summary {
-  &::-webkit-details-marker {
+  .contains-task-list {
+    @apply nx-ml-0 nx-list-none;
+    input[type='checkbox'] {
+      @apply nx-mr-1;
+    }
+  }
+
+  .nextra-banner-hidden .nextra-banner-container {
     @apply nx-hidden;
   }
-  &::before {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z' clip-rule='evenodd' /%3E%3C/svg%3E");
-    height: 1.2em;
-    width: 1.2em;
-    vertical-align: -4px;
-  }
-}
 
-@media (min-width: 768px) {
-  .nextra-toc > .div,
   .nextra-sidebar-container {
-    mask-image: linear-gradient(to bottom, transparent, #000 20px),
-      linear-gradient(to left, #000 10px, transparent 10px);
+    [data-toggle-animation='show'] button {
+      opacity: 0;
+      animation: nextra-fadein 1s ease 0.2s forwards;
+    }
+    [data-toggle-animation='hide'] button {
+      opacity: 0;
+      animation: nextra-fadein2 1s ease 0.2s forwards;
+    }
   }
-}
 
-@supports (
-  (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))
-) {
-  .nextra-search ul {
-    @apply nx-backdrop-blur-lg nx-bg-white/70 dark:nx-bg-dark/80;
+  .footnotes a[data-footnote-backref] {
+    font-family: initial;
   }
-  .nextra-nav-container-blur {
-    @apply nx-backdrop-blur-md nx-bg-white/[.85] dark:!nx-bg-dark/80;
-  }
-}
 
-input[type='search'] {
-  &::-webkit-search-decoration,
-  &::-webkit-search-cancel-button,
-  &::-webkit-search-results-button,
-  &::-webkit-search-results-decoration {
-    -webkit-appearance: none;
+  @keyframes nextra-fadein {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
   }
-}
 
-.contains-task-list {
-  @apply nx-ml-0 nx-list-none;
-  input[type='checkbox'] {
-    @apply nx-mr-1;
-  }
-}
-
-.nextra-banner-hidden .nextra-banner-container {
-  @apply nx-hidden;
-}
-
-.nextra-sidebar-container {
-  [data-toggle-animation='show'] button {
-    opacity: 0;
-    animation: nextra-fadein 1s ease 0.2s forwards;
-  }
-  [data-toggle-animation='hide'] button {
-    opacity: 0;
-    animation: nextra-fadein2 1s ease 0.2s forwards;
-  }
-}
-
-.footnotes a[data-footnote-backref] {
-  font-family: initial;
-}
-
-@keyframes nextra-fadein {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes nextra-fadein2 {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
+  @keyframes nextra-fadein2 {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
   }
 }

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -12,10 +12,6 @@
   @import './hamburger.css';
   @import './typesetting-article.css';
 
-  .thing {
-    background-color: green;
-  }
-
   html {
     @apply nx-antialiased nx-text-base nx-scroll-pt-[--nextra-navbar-height];
     font-feature-settings:

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -8,7 +8,6 @@
   @import 'nextra/styles/scrollbar.css';
   @import 'nextra/styles/steps.css';
   @import 'nextra/styles/cards.css';
-
   @import './hamburger.css';
   @import './typesetting-article.css';
 


### PR DESCRIPTION
Adding a all styles from `nextra-theme-blog` and `nextra-theme-docs` into their own CSS cascade layer called `nextra` to remove the styles from the implicit outer layer.

This will allow end users of these themes to additionally use their own cascade layers without the default theme styles overriding everything.

Attached images showing both
1. Styling a `div` with a class from a custom cascade layer (`@layer my-layer`)
2. Overriding nextra `<p>` styles inside the same layer

See issue [2613](https://github.com/shuding/nextra/issues/2613)

![div-with-cascade-class](https://github.com/shuding/nextra/assets/31055758/e11f564e-1eb8-418f-ac51-28c101edae1d)
![p-override-nextra-styles](https://github.com/shuding/nextra/assets/31055758/09955cf0-fa5b-4a78-be40-9cda23433f58)
