### PR TITLE
fix: Invalid webkit style

### DIFF
--- a/docs/pages/api/og.jsx
+++ b/docs/pages/api/og.jsx
@@ -78,7 +78,7 @@ export default async function (req) {
             letterSpacing: -4,
             backgroundImage: 'linear-gradient(90deg, #fff 40%, #aaa)',
             backgroundClip: 'text',
-            '-webkit-background-clip': 'text',
+            WebkitBackgroundClip: 'text',
             color: 'transparent'
           }}
         >

--- a/docs/pages/api/og.jsx
+++ b/docs/pages/api/og.jsx
@@ -78,7 +78,6 @@ export default async function (req) {
             letterSpacing: -4,
             backgroundImage: 'linear-gradient(90deg, #fff 40%, #aaa)',
             backgroundClip: 'text',
-            WebkitBackgroundClip: 'text',
             color: 'transparent'
           }}
         >


### PR DESCRIPTION
# The issue
I noticed that `-webkit-background-clip` was being used in the JSX style prop in the OpenGraph image generation to the nextra site.

`-webkit-background-clip` is an invalid JSX style prop, and `WebkitBackgroundClip` should be used instead.

Although the webkit clip would not matter most of the time as `BackgroundClip` is present, I believe it is still best to use `WebkitBackgroundClip`.

## Example
Here is an example where I copied the image JSX and removed the `backgroundClip` style prop to compare the difference when `-webkit-background-clip` or `WebkitBackgroundClip` is used.

![image](https://github.com/shuding/nextra/assets/104479537/994a0a17-6d91-4ac1-9a78-ed15042622c3)
![image](https://github.com/shuding/nextra/assets/104479537/e98857c5-a818-4a01-8d44-93fba62ee6b0)
