### PR TITLE
Tailwind imports using path instead of package

### DIFF
--- a/.changeset/shy-hotels-pay.md
+++ b/.changeset/shy-hotels-pay.md
@@ -1,0 +1,7 @@
+---
+"nextra-theme-docs": patch
+"nextra": patch
+"docs": patch
+---
+
+- use Package instead of Path for taildwind imports

--- a/packages/nextra-theme-docs/tailwind.config.js
+++ b/packages/nextra-theme-docs/tailwind.config.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const colors = require('tailwindcss/colors')
 
 const makePrimaryColor =
@@ -14,8 +15,8 @@ module.exports = {
   prefix: 'nx-',
   content: [
     './src/**/*.tsx',
-    '../nextra/src/icons/*.tsx',
-    '../nextra/src/components/*.tsx'
+    path.join(path.dirname(require.resolve('nextra')), '/components/*.js'),
+    path.join(path.dirname(require.resolve('nextra')), '/icons/*.js')
   ],
   theme: {
     screens: {


### PR DESCRIPTION
The current tailwind config for the Docs theme generates tailwind classes for nextra components that cross the package boundary. This leads to weird behavior if a user wants to modify either nextra or the docs theme without effecting the other as the css is coupled. 

This PR uses the Nextra build assets instead of the source files from the Nextra package. This should make it easier for developers to build in the monorepo without unexpected css issues. 
