### PR TITLE
[v3] allow `items: Map` for `type: 'menu'` since object can't guaranty the insertion order

### DIFF
--- a/.changeset/tall-cobras-juggle.md
+++ b/.changeset/tall-cobras-juggle.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+allow `items: Map` for `type: 'menu'` since object can't guaranty the insertion order

--- a/docs/pages/api/og.jsx
+++ b/docs/pages/api/og.jsx
@@ -78,7 +78,6 @@ export default async function (req) {
             letterSpacing: -4,
             backgroundImage: 'linear-gradient(90deg, #fff 40%, #aaa)',
             backgroundClip: 'text',
-            '-webkit-background-clip': 'text',
             color: 'transparent'
           }}
         >

--- a/examples/swr-site/pages/en/_meta.ts
+++ b/examples/swr-site/pages/en/_meta.ts
@@ -16,25 +16,28 @@ export default {
   about: {
     type: 'menu',
     title: 'About',
-    items: {
-      contributors: {
-        title: 'Contributors',
-        href: 'https://github.com/vercel/swr/graphs/contributors',
-        newWindow: true
-      },
-      team: {
-        title: 'Team'
-      },
-      acknowledgement: {
-        title: 'Acknowledgement'
-      },
-      'a-page': {
-        title: 'A Page'
-      },
-      changelog: {
-        title: 'Changelog'
-      }
-    }
+    items: new Map([
+      [
+        'contributors',
+        {
+          title: 'Contributors',
+          href: 'https://github.com/vercel/swr/graphs/contributors',
+          newWindow: true
+        }
+      ],
+      ['team', { title: 'Team' }],
+      ['acknowledgement', { title: 'Acknowledgement' }],
+      ['a-page', { title: 'A Page' }],
+      ['changelog', { title: 'Changelog' }],
+      [
+        '123',
+        {
+          title: 'Last, key is number',
+          href: 'https://google.com',
+          newWindow: true
+        }
+      ]
+    ])
   },
   examples: {
     type: 'page',

--- a/packages/nextra-theme-blog/CHANGELOG.md
+++ b/packages/nextra-theme-blog/CHANGELOG.md
@@ -228,6 +228,12 @@
 - Updated dependencies [576cb6f1]
   - nextra@3.0.0-alpha.0
 
+## 2.13.4
+
+### Patch Changes
+
+- nextra@2.13.4
+
 ## 2.13.3
 
 ### Patch Changes

--- a/packages/nextra-theme-docs/CHANGELOG.md
+++ b/packages/nextra-theme-docs/CHANGELOG.md
@@ -306,6 +306,14 @@
 - Updated dependencies [576cb6f1]
   - nextra@3.0.0-alpha.0
 
+## 2.13.4
+
+### Patch Changes
+
+- f7fc10b4: fix for the memory leak issue in the `highlight-matches.tsx`
+  component when search query contain multiple whitespaces
+  - nextra@2.13.4
+
 ## 2.13.3
 
 ### Patch Changes

--- a/packages/nextra-theme-docs/src/components/highlight-matches.tsx
+++ b/packages/nextra-theme-docs/src/components/highlight-matches.tsx
@@ -16,26 +16,27 @@ export const HighlightMatches = memo<MatchArgs>(function HighlightMatches({
   }
   const splitText = value.split('')
   const escapedSearch = escapeStringRegexp(match.trim())
-  const regexp = new RegExp(escapedSearch.replaceAll(' ', '|'), 'ig')
+  const regexp = new RegExp(escapedSearch.replaceAll(/\s+/g, '|'), 'ig')
   let result
   let index = 0
   const content: (string | ReactNode)[] = []
 
-  while (
-    (result = regexp.exec(value)) &&
-    // case `>  ` replaced previously to `>||` + some character provoke memory leak because
-    // `RegExp#exec` will always return a match
-    regexp.lastIndex !== 0
-  ) {
-    const before = splitText.splice(0, result.index - index).join('')
-    const after = splitText.splice(0, regexp.lastIndex - result.index).join('')
-    content.push(
-      before,
-      <span key={result.index} className="_text-primary-600">
-        {after}
-      </span>
-    )
-    index = regexp.lastIndex
+  while ((result = regexp.exec(value))) {
+    if (result.index === regexp.lastIndex) {
+      regexp.lastIndex++
+    } else {
+      const before = splitText.splice(0, result.index - index).join('')
+      const after = splitText
+        .splice(0, regexp.lastIndex - result.index)
+        .join('')
+      content.push(
+        before,
+        <span key={result.index} className="_text-primary-600">
+          {after}
+        </span>
+      )
+      index = regexp.lastIndex
+    }
   }
 
   return (

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -35,6 +35,10 @@ function NavbarMenu({
   const routes = Object.fromEntries(
     (menu.children || []).map(route => [route.name, route])
   )
+  const entries =
+    items instanceof Map
+      ? Array.from(items.entries())
+      : Object.entries(items || {})
 
   return (
     <Menu as="div" className="_relative">
@@ -54,7 +58,7 @@ function NavbarMenu({
         as={Menu.Items}
         className="_absolute _right-0 _z-20 _mt-1 _max-h-64 _min-w-full _overflow-auto _rounded-md _ring-1 _ring-black/5 _bg-white _py-1 _text-sm _shadow-lg dark:_ring-white/20 dark:_bg-neutral-800"
       >
-        {Object.entries(items || {}).map(([key, item]) => (
+        {entries.map(([key, item]) => (
           <Menu.Item key={key}>
             {({ active }) => (
               <Anchor

--- a/packages/nextra/CHANGELOG.md
+++ b/packages/nextra/CHANGELOG.md
@@ -240,6 +240,8 @@
 
 - d8a406b4: add `"sideEffects": false` for better tree-shaking
 
+## 2.13.4
+
 ## 2.13.3
 
 ### Patch Changes

--- a/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
+++ b/packages/nextra/__test__/__snapshots__/page-map.test.ts.snap
@@ -6,23 +6,28 @@ exports[`Page Process > should match i18n site page maps 1`] = `
     {
       "data": {
         "about": {
-          "items": {
-            "a-page": {
-              "title": "A Page",
-            },
-            "acknowledgement": {
-              "title": "Acknowledgement",
-            },
-            "changelog": {
-              "title": "Changelog",
-            },
-            "contributors": {
+          "items": Map {
+            "contributors" => {
               "href": "https://github.com/vercel/swr/graphs/contributors",
               "newWindow": true,
               "title": "Contributors",
             },
-            "team": {
+            "team" => {
               "title": "Team",
+            },
+            "acknowledgement" => {
+              "title": "Acknowledgement",
+            },
+            "a-page" => {
+              "title": "A Page",
+            },
+            "changelog" => {
+              "title": "Changelog",
+            },
+            "123" => {
+              "href": "https://google.com",
+              "newWindow": true,
+              "title": "Last, key is number",
             },
           },
           "title": "About",
@@ -637,23 +642,28 @@ exports[`Page Process > should match i18n site page maps 1`] = `
     {
       "data": {
         "about": {
-          "items": {
-            "a-page": {
-              "title": "A Page",
-            },
-            "acknowledgement": {
-              "title": "Acknowledgement",
-            },
-            "changelog": {
-              "title": "Changelog",
-            },
-            "contributors": {
+          "items": Map {
+            "contributors" => {
               "href": "https://github.com/vercel/swr/graphs/contributors",
               "newWindow": true,
               "title": "Contributors",
             },
-            "team": {
+            "team" => {
               "title": "Team",
+            },
+            "acknowledgement" => {
+              "title": "Acknowledgement",
+            },
+            "a-page" => {
+              "title": "A Page",
+            },
+            "changelog" => {
+              "title": "Changelog",
+            },
+            "123" => {
+              "href": "https://google.com",
+              "newWindow": true,
+              "title": "Last, key is number",
             },
           },
           "title": "About",


### PR DESCRIPTION
* fix: Invalid webkit style

"-webkit-background-clip" is an invalid style for JSX, this commit switches this to the "WebkitBackgroundClip" style.

* refactor: Remove webkit styling