### PR TITLE
Fix leaky styles

### DIFF
--- a/.changeset/tame-geckos-rhyme.md
+++ b/.changeset/tame-geckos-rhyme.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Fix leaky global styles

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -23,20 +23,12 @@ body {
   @apply nx-w-full nx-bg-white dark:nx-bg-dark dark:nx-text-gray-100;
 }
 
-a,
-summary,
-button,
-input,
-[tabindex]:not([tabindex='-1']) {
+.nextra-focusable {
   @apply nx-outline-none;
+
   &:focus-visible {
     @apply nx-ring-2 nx-ring-primary-200 nx-ring-offset-1 nx-ring-offset-primary-300 dark:nx-ring-primary-800 dark:nx-ring-offset-primary-700;
   }
-}
-
-a,
-summary {
-  @apply nx-rounded;
 }
 
 .nextra-content {
@@ -83,7 +75,7 @@ summary {
 }
 
 @media (prefers-reduced-motion: reduce) and (max-width: 767px) {
-  article:before,
+  article::before,
   .nextra-sidebar-container,
   .nextra-sidebar-container.open,
   body.resizing .nextra-sidebar-container {
@@ -92,7 +84,7 @@ summary {
 }
 
 /* Content Typography */
-article details > summary {
+.nx-summary {
   &::-webkit-details-marker {
     @apply nx-hidden;
   }

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -84,7 +84,7 @@ body {
 }
 
 /* Content Typography */
-.nx-summary {
+.nextra-summary {
   &::-webkit-details-marker {
     @apply nx-hidden;
   }

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -27,7 +27,7 @@ export function BackToTop({ className }: { className?: string }): ReactElement {
       aria-hidden="true"
       onClick={scrollToTop}
       className={cn(
-        'nx-flex nx-items-center nx-gap-1.5 nx-transition nx-opacity-0',
+        'nx-flex nx-items-center nx-gap-1.5 nx-transition nx-opacity-0 nextra-focusable',
         className
       )}
     >

--- a/packages/nextra-theme-docs/src/components/banner.tsx
+++ b/packages/nextra-theme-docs/src/components/banner.tsx
@@ -31,7 +31,7 @@ export function Banner(): ReactElement | null {
           <button
             type="button"
             aria-label="Dismiss banner"
-            className="nx-w-8 nx-h-8 nx-opacity-80 hover:nx-opacity-100"
+            className="nx-w-8 nx-h-8 nx-opacity-80 hover:nx-opacity-100 nextra-focusable"
             onClick={() => {
               try {
                 localStorage.setItem(banner.key, '0')

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -43,7 +43,7 @@ function NavbarMenu({
         <Menu.Button
           className={cn(
             className,
-            '-nx-ml-2 nx-hidden nx-items-center nx-whitespace-nowrap nx-rounded nx-p-2 md:nx-inline-flex',
+            '-nx-ml-2 nx-hidden nx-items-center nx-whitespace-nowrap nx-rounded nx-p-2 md:nx-inline-flex nextra-focusable',
             classes.inactive
           )}
         >
@@ -192,7 +192,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         <button
           type="button"
           aria-label="Menu"
-          className="nextra-hamburger -nx-mr-2 nx-rounded nx-p-2 active:nx-bg-gray-400/20 md:nx-hidden"
+          className="nextra-hamburger -nx-mr-2 nx-rounded nx-p-2 active:nx-bg-gray-400/20 md:nx-hidden nextra-focusable"
           onClick={() => setMenu(!menu)}
         >
           <MenuIcon className={cn({ open: menu })} />

--- a/packages/nextra-theme-docs/src/components/select.tsx
+++ b/packages/nextra-theme-docs/src/components/select.tsx
@@ -50,7 +50,7 @@ export function Select({
           ref={trigger}
           title={title}
           className={cn(
-            'nx-h-7 nx-rounded-md nx-px-2 nx-text-left nx-text-xs nx-font-medium nx-text-gray-600 nx-transition-colors dark:nx-text-gray-400',
+            'nx-h-7 nx-rounded-md nx-px-2 nx-text-left nx-text-xs nx-font-medium nx-text-gray-600 nx-transition-colors dark:nx-text-gray-400 nextra-focusable',
             open
               ? 'nx-bg-gray-200 nx-text-gray-900 dark:nx-bg-primary-100/10 dark:nx-text-gray-50'
               : 'hover:nx-bg-gray-100 hover:nx-text-gray-900 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50',

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -274,7 +274,7 @@ function File({
                 href={`#${id}`}
                 className={cn(
                   classes.link,
-                  'nx-flex nx-gap-2 before:nx-opacity-25 before:nx-content-["#"]',
+                  'nx-flex nx-gap-2 before:nx-opacity-25 before:nx-content-["#"] nextra-focusable',
                   activeAnchor[id]?.isActive ? classes.active : classes.inactive
                 )}
                 onClick={() => {
@@ -498,7 +498,7 @@ export function Sidebar({
             {config.sidebar.toggleButton && (
               <button
                 title={showSidebar ? 'Hide sidebar' : 'Show sidebar'}
-                className="max-md:nx-hidden nx-h-7 nx-rounded-md nx-transition-colors nx-text-gray-600 dark:nx-text-gray-400 nx-px-2 hover:nx-bg-gray-100 hover:nx-text-gray-900 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50"
+                className="max-md:nx-hidden nx-h-7 nx-rounded-md nx-transition-colors nx-text-gray-600 dark:nx-text-gray-400 nx-px-2 hover:nx-bg-gray-100 hover:nx-text-gray-900 dark:hover:nx-bg-primary-100/5 dark:hover:nx-text-gray-50 nextra-focusable"
                 onClick={() => {
                   setSidebar(!showSidebar)
                   setToggleAnimation(true)

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -86,7 +86,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
                     activeAnchor[id]?.isActive
                       ? 'nx-text-primary-600 nx-subpixel-antialiased contrast-more:!nx-text-primary-600'
                       : 'nx-text-gray-500 hover:nx-text-gray-900 dark:nx-text-gray-400 dark:hover:nx-text-gray-300',
-                    'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words'
+                    'contrast-more:nx-text-gray-900 contrast-more:nx-underline contrast-more:dark:nx-text-gray-50 nx-w-full nx-break-words nextra-focusable'
                   )}
                 >
                   {config.toc.headingComponent?.({

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -68,7 +68,7 @@ function HeadingLink({
         <a
           href={`#${id}`}
           id={id}
-          className="subheading-anchor"
+          className="subheading-anchor nextra-focusable"
           aria-label="Permalink for this section"
           ref={obRef}
         />
@@ -149,7 +149,7 @@ const Summary = (props: ComponentProps<'summary'>): ReactElement => {
       className={cn(
         'nx-flex nx-items-center nx-cursor-pointer nx-list-none nx-p-1 nx-transition-colors hover:nx-bg-gray-100 dark:hover:nx-bg-neutral-800',
         "before:nx-mr-1 before:nx-inline-block before:nx-transition-transform before:nx-content-[''] dark:before:nx-invert before:nx-shrink-0",
-        'rtl:before:nx-rotate-180 [[data-expanded]>&]:before:nx-rotate-90'
+        'rtl:before:nx-rotate-180 [[data-expanded]>&]:before:nx-rotate-90 nextra-focusable'
       )}
       {...props}
       onClick={e => {
@@ -167,7 +167,7 @@ export const Link = ({ href = '', className, ...props }: AnchorProps) => (
     href={href}
     newWindow={EXTERNAL_HREF_REGEX.test(href)}
     className={cn(
-      'nx-text-primary-600 nx-underline nx-decoration-from-font [text-underline-position:from-font]',
+      'nx-text-primary-600 nx-underline nx-decoration-from-font nextra-focusable [text-underline-position:from-font]',
       className
     )}
     {...props}

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -149,7 +149,7 @@ const Summary = (props: ComponentProps<'summary'>): ReactElement => {
       className={cn(
         'nx-flex nx-items-center nx-cursor-pointer nx-list-none nx-p-1 nx-transition-colors hover:nx-bg-gray-100 dark:hover:nx-bg-neutral-800',
         "before:nx-mr-1 before:nx-inline-block before:nx-transition-transform before:nx-content-[''] dark:before:nx-invert before:nx-shrink-0",
-        'rtl:before:nx-rotate-180 [[data-expanded]>&]:before:nx-rotate-90 nextra-focusable'
+        'rtl:before:nx-rotate-180 [[data-expanded]>&]:before:nx-rotate-90 nextra-summary nextra-focusable'
       )}
       {...props}
       onClick={e => {


### PR DESCRIPTION
## Changes

Fixes #2764 by scoping conflicting global styles to a classname. Now this is scoped to Nextra internal elements, while letting user styles operate as-expected.

![CleanShot 2024-03-05 at 15 47 32](https://github.com/shuding/nextra/assets/1369770/42c5e1d3-e34b-4e81-8cb7-9a65fde4e3bc)
