### PR TITLE
[v3] enable `outline: 'none'` only for `:focus-visible` state, to fix double ring in Firefox

### DIFF
--- a/.changeset/blue-suits-scream.md
+++ b/.changeset/blue-suits-scream.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+enable `outline: 'none'` only for `:focus-visible` state, to fix double ring in Firefox

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -27,8 +27,8 @@ summary,
 button,
 input,
 [tabindex]:not([tabindex='-1']) {
-  @apply _outline-none;
   &:focus-visible {
+    @apply _outline-none;
     @apply _ring-2 _ring-primary-200 _ring-offset-1 _ring-offset-primary-300 dark:_ring-primary-800 dark:_ring-offset-primary-700;
   }
 }


### PR DESCRIPTION
<img width="403" alt="image" src="https://github.com/shuding/nextra/assets/7361780/9f6d01b0-c933-4876-b878-f405a915cb5b">
