### PR TITLE
[v3] fix `TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))` on dev environment when `frontMatter.searchable: false`

### DIFF
--- a/.changeset/rotten-spies-exist.md
+++ b/.changeset/rotten-spies-exist.md
@@ -1,0 +1,6 @@
+---
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+fix `TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))` on dev environment when `frontMatter.searchable: false`

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -175,14 +175,16 @@ ${themeConfigImport && '__nextra_internal__.themeConfig = __themeConfig'}`
     return `${result}
 export default MDXLayout`
   }
-  if (searchIndexKey && frontMatter.searchable !== false) {
+  if (searchIndexKey) {
     // Store all the things in buildInfo.
     const { buildInfo } = this._module as any
     buildInfo.nextraSearch = {
       indexKey: searchIndexKey,
-      title,
-      data: structurizedData,
-      route
+      ...(frontMatter.searchable !== false && {
+        title,
+        data: structurizedData,
+        route
+      })
     }
   }
 

--- a/packages/nextra/src/server/webpack-plugins/nextra-search.ts
+++ b/packages/nextra/src/server/webpack-plugins/nextra-search.ts
@@ -48,7 +48,9 @@ export class NextraSearchPlugin {
               const { title, data, indexKey, route } = nextraSearch
               const indexFilename = `nextra-data-${indexKey}.json`
               indexFiles[indexFilename] ??= {}
-              indexFiles[indexFilename][route] = { title, data }
+              if (route) {
+                indexFiles[indexFilename][route] = { title, data }
+              }
             }
           }
           for (const [file, content] of Object.entries(indexFiles)) {


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/2763