### PR TITLE
fix: Cut the navbar items when it's too long (#2785)

### DIFF
--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -93,7 +93,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           'contrast-more:nx-shadow-[0_0_0_1px_#000] contrast-more:dark:nx-shadow-[0_0_0_1px_#fff]'
         )}
       />
-      <nav className="nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[90rem] nx-items-center nx-justify-end nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]">
+      <nav className="nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[90rem] nx-items-center nx-justify-between nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]">
         {config.logoLink ? (
           <Anchor
             href={typeof config.logoLink === 'string' ? config.logoLink : '/'}
@@ -106,61 +106,71 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
             {renderComponent(config.logo)}
           </div>
         )}
-        {items.map(pageOrMenu => {
-          if (pageOrMenu.display === 'hidden') return null
 
-          if (pageOrMenu.type === 'menu') {
-            const menu = pageOrMenu as MenuItem
-            return (
-              <NavbarMenu
-                key={menu.title}
-                className={cn(
-                  classes.link,
-                  'nx-flex nx-gap-1',
-                  classes.inactive
-                )}
-                menu={menu}
-              >
-                {menu.title}
-                <ArrowRightIcon
-                  className="nx-h-[18px] nx-min-w-[18px] nx-rounded-sm nx-p-0.5"
-                  pathClassName="nx-origin-center nx-transition-transform nx-rotate-90"
-                />
-              </NavbarMenu>
-            )
-          }
-          const page = pageOrMenu as PageItem
-          let href = page.href || page.route || '#'
+        <div className="nx-flex-auto nx-overflow-auto">
+          <div className="nx-flex nx-flex-row-reverse">
+            {items.map(pageOrMenu => {
+              if (pageOrMenu.display === 'hidden') return null
 
-          // If it's a directory
-          if (page.children) {
-            href =
-              (page.withIndexPage ? page.route : page.firstChildRoute) || href
-          }
+              if (pageOrMenu.type === 'menu') {
+                const menu = pageOrMenu as MenuItem
+                return (
+                  <NavbarMenu
+                    key={menu.title}
+                    className={cn(
+                      classes.link,
+                      'nx-flex nx-gap-1',
+                      classes.inactive
+                    )}
+                    menu={menu}
+                  >
+                    {menu.title}
+                    <ArrowRightIcon
+                      className="nx-h-[18px] nx-min-w-[18px] nx-rounded-sm nx-p-0.5"
+                      pathClassName="nx-origin-center nx-transition-transform nx-rotate-90"
+                    />
+                  </NavbarMenu>
+                )
+              }
+              const page = pageOrMenu as PageItem
+              let href = page.href || page.route || '#'
 
-          const isActive =
-            page.route === activeRoute ||
-            activeRoute.startsWith(page.route + '/')
+              // If it's a directory
+              if (page.children) {
+                href =
+                  (page.withIndexPage ? page.route : page.firstChildRoute) ||
+                  href
+              }
 
-          return (
-            <Anchor
-              href={href}
-              key={href}
-              className={cn(
-                classes.link,
-                'nx-relative -nx-ml-2 nx-hidden nx-whitespace-nowrap nx-p-2 md:nx-inline-block',
-                !isActive || page.newWindow ? classes.inactive : classes.active
-              )}
-              newWindow={page.newWindow}
-              aria-current={!page.newWindow && isActive}
-            >
-              <span className="nx-absolute nx-inset-x-0 nx-text-center">
-                {page.title}
-              </span>
-              <span className="nx-invisible nx-font-medium">{page.title}</span>
-            </Anchor>
-          )
-        })}
+              const isActive =
+                page.route === activeRoute ||
+                activeRoute.startsWith(page.route + '/')
+
+              return (
+                <Anchor
+                  href={href}
+                  key={href}
+                  className={cn(
+                    classes.link,
+                    'nx-relative -nx-ml-2 nx-hidden nx-whitespace-nowrap nx-p-2 md:nx-inline-block',
+                    !isActive || page.newWindow
+                      ? classes.inactive
+                      : classes.active
+                  )}
+                  newWindow={page.newWindow}
+                  aria-current={!page.newWindow && isActive}
+                >
+                  <span className="nx-absolute nx-inset-x-0 nx-text-center">
+                    {page.title}
+                  </span>
+                  <span className="nx-invisible nx-font-medium">
+                    {page.title}
+                  </span>
+                </Anchor>
+              )
+            })}
+          </div>
+        </div>
 
         {renderComponent(config.search.component, {
           directories: flatDirectories,

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -107,7 +107,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           </div>
         )}
 
-        <div className="nx-flex-auto nx-overflow-auto">
+        <div className="nx-flex-auto">
           <div className="nx-flex nx-justify-end">
             {items.map(pageOrMenu => {
               if (pageOrMenu.display === 'hidden') return null

--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -108,7 +108,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         )}
 
         <div className="nx-flex-auto nx-overflow-auto">
-          <div className="nx-flex nx-flex-row-reverse">
+          <div className="nx-flex nx-justify-end">
             {items.map(pageOrMenu => {
               if (pageOrMenu.display === 'hidden') return null
 

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import { useActiveAnchor, useConfig, useMenu } from '../contexts'
+import { NavOverflowProvider, useNavOverflow } from '../contexts/nav-overflow'
 import { renderComponent } from '../utils'
 import { Anchor } from './anchor'
 import { Collapse } from './collapse'
@@ -344,6 +345,7 @@ export function Sidebar({
   const [focused, setFocused] = useState<null | string>(null)
   const [showSidebar, setSidebar] = useState(true)
   const [showToggleAnimation, setToggleAnimation] = useState(false)
+  const { navOverflow } = useNavOverflow()
 
   const anchors = useMemo(() => headings.filter(v => v.depth === 2), [headings])
   const sidebarRef = useRef<HTMLDivElement>(null)
@@ -450,7 +452,16 @@ export function Sidebar({
                   />
                 </Collapse>
               )}
-              {mounted && window.innerWidth < 768 && (
+              {mounted && (window.innerWidth < 768 || navOverflow) && (
+                <Menu
+                  className="nextra-menu-mobile"
+                  // The mobile dropdown menu, shows all the directories.
+                  directories={fullDirectories}
+                  // Always show the anchor links on mobile (`md`).
+                  anchors={anchors}
+                />
+              )}
+              {/* {mounted && window.innerWidth < 768 && (
                 <Menu
                   className="nextra-menu-mobile md:nx-hidden"
                   // The mobile dropdown menu, shows all the directories.
@@ -458,7 +469,7 @@ export function Sidebar({
                   // Always show the anchor links on mobile (`md`).
                   anchors={anchors}
                 />
-              )}
+              )} */}
             </div>
           </OnFocusItemContext.Provider>
         </FocusedItemContext.Provider>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import { useActiveAnchor, useConfig, useMenu } from '../contexts'
-import { NavOverflowProvider, useNavOverflow } from '../contexts/nav-overflow'
+import { useNavOverflow } from '../contexts/nav-overflow'
 import { renderComponent } from '../utils'
 import { Anchor } from './anchor'
 import { Collapse } from './collapse'
@@ -444,24 +444,17 @@ export function Sidebar({
                   <Menu
                     className="nextra-menu-desktop max-md:nx-hidden"
                     // The sidebar menu, shows only the docs directories.
-                    directories={docsDirectories}
+                    directories={
+                      navOverflow ? fullDirectories : docsDirectories
+                    }
                     // When the viewport size is larger than `md`, hide the anchors in
                     // the sidebar when `floatTOC` is enabled.
                     anchors={config.toc.float ? [] : anchors}
-                    onlyCurrentDocs
+                    onlyCurrentDocs={!navOverflow}
                   />
                 </Collapse>
               )}
               {mounted && (window.innerWidth < 768 || navOverflow) && (
-                <Menu
-                  className="nextra-menu-mobile"
-                  // The mobile dropdown menu, shows all the directories.
-                  directories={fullDirectories}
-                  // Always show the anchor links on mobile (`md`).
-                  anchors={anchors}
-                />
-              )}
-              {/* {mounted && window.innerWidth < 768 && (
                 <Menu
                   className="nextra-menu-mobile md:nx-hidden"
                   // The mobile dropdown menu, shows all the directories.
@@ -469,7 +462,7 @@ export function Sidebar({
                   // Always show the anchor links on mobile (`md`).
                   anchors={anchors}
                 />
-              )} */}
+              )}
             </div>
           </OnFocusItemContext.Provider>
         </FocusedItemContext.Provider>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -454,7 +454,7 @@ export function Sidebar({
                   />
                 </Collapse>
               )}
-              {mounted && (window.innerWidth < 768 || navOverflow) && (
+              {mounted && window.innerWidth < 768 && (
                 <Menu
                   className="nextra-menu-mobile md:nx-hidden"
                   // The mobile dropdown menu, shows all the directories.

--- a/packages/nextra-theme-docs/src/contexts/config.tsx
+++ b/packages/nextra-theme-docs/src/contexts/config.tsx
@@ -8,6 +8,7 @@ import type { DocsThemeConfig } from '../constants'
 import { DEEP_OBJECT_KEYS, DEFAULT_THEME, themeSchema } from '../constants'
 import type { Context } from '../types'
 import { MenuProvider } from './menu'
+import { NavOverflowProvider } from './nav-overflow'
 
 type Config<FrontMatterType = FrontMatter> = DocsThemeConfig &
   Pick<
@@ -72,6 +73,8 @@ export const ConfigProvider = ({
   value: Context
 }): ReactElement => {
   const [menu, setMenu] = useState(false)
+  const [navOverflow, setNavOverflow] = useState(false)
+
   // Merge only on first load
   theme ||= {
     ...DEFAULT_THEME,
@@ -119,7 +122,11 @@ export const ConfigProvider = ({
       forcedTheme={nextThemes.forcedTheme}
     >
       <ConfigContext.Provider value={extendedConfig}>
-        <MenuProvider value={{ menu, setMenu }}>{children}</MenuProvider>
+        <MenuProvider value={{ menu, setMenu }}>
+          <NavOverflowProvider value={{ navOverflow, setNavOverflow }}>
+            {children}
+          </NavOverflowProvider>
+        </MenuProvider>
       </ConfigContext.Provider>
     </ThemeProvider>
   )

--- a/packages/nextra-theme-docs/src/contexts/nav-overflow.ts
+++ b/packages/nextra-theme-docs/src/contexts/nav-overflow.ts
@@ -1,0 +1,16 @@
+import type { Dispatch, SetStateAction } from 'react'
+import { createContext, useContext } from 'react'
+
+interface NavOverflow {
+  navOverflow: boolean
+  setNavOverflow: Dispatch<SetStateAction<boolean>>
+}
+
+const NavOverflowContext = createContext<NavOverflow>({
+  navOverflow: false,
+  setNavOverflow: () => false
+})
+
+export const useNavOverflow = () => useContext(NavOverflowContext)
+
+export const NavOverflowProvider = NavOverflowContext.Provider


### PR DESCRIPTION
This pull request addresses issue #2785, ensuring that when the navbar has many items or items with long names, the overflow is managed elegantly without pushing the logo out of view.

Previously, an overflow of menu items caused layout issues, leading to a cluttered and inaccessible navbar.

## Before

![image](https://github.com/shuding/nextra/assets/52880665/fb6f852e-ab0c-4466-aac2-e6c4b2974106)

## After

![Screenshot 2024-03-14 at 21 02 41](https://github.com/shuding/nextra/assets/52880665/3832b151-4bf1-484e-8751-05d148899a17)

It's important to note that for most configurations, the visual appearance of the navbar remains unchanged:

![Screenshot 2024-03-14 at 21 04 40](https://github.com/shuding/nextra/assets/52880665/e3ae7b74-b9dc-4051-9dab-2fcf7539ecc2)



