### PR TITLE
export use menu

### DIFF
--- a/.changeset/loud-ties-swim.md
+++ b/.changeset/loud-ties-swim.md
@@ -2,4 +2,4 @@
 'nextra-theme-docs': minor
 ---
 
-exported useMenu context
+export `useMenu` hook

--- a/.changeset/loud-ties-swim.md
+++ b/.changeset/loud-ties-swim.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+exported useMenu context

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -104,3 +104,7 @@ export {
   ThemeSwitch,
   LocaleSwitch
 } from './components'
+
+export {
+  useMenu
+} from './contexts'


### PR DESCRIPTION
fixes #2781 

Exports the use menu context so you can create a custom navbar component to open/close the sidebar in mobile.