### PR TITLE
style : fix style for Bleed docs

### DIFF
--- a/packages/nextra-theme-docs/src/components/bleed.tsx
+++ b/packages/nextra-theme-docs/src/components/bleed.tsx
@@ -11,11 +11,12 @@ export function Bleed({
   return (
     <div
       className={cn(
-        'nextra-bleed _relative _-mx-6 _mt-6 md:_-mx-8 2xl:_-mx-24',
+        // 'nextra-bleed _relative _-mx-6 _mt-6 md:_-mx-8 2xl:_-mx-24',
+        'nextra-bleed _relative',
         full && [
           // 'md:mx:[calc(-50vw+50%+8rem)',
-          'ltr:xl:_ml-[calc(50%-50vw+16rem)] ltr:xl:_mr-[calc(50%-50vw)]',
-          'rtl:xl:_ml-[calc(50%-50vw)] rtl:xl:_mr-[calc(50%-50vw+16rem)]'
+          // 'ltr:xl:_ml-[calc(50%-50vw+16rem)] ltr:xl:_mr-[calc(50%-50vw)]',
+          // 'rtl:xl:_ml-[calc(50%-50vw)] rtl:xl:_mr-[calc(50%-50vw+16rem)]'
         ]
       )}
     >


### PR DESCRIPTION
The design of the Bleed Docs page was a bit messy. You can check the before and after to see the changes I made.

# Steps to Reproduce

1. Go , to this page.
https://nextra.site/docs/docs-theme/built-ins/bleed

Before Changes:
<img width="1147" alt="shuding-nextra" src="https://github.com/shuding/nextra/assets/90372904/2b12b48f-c9b9-4e84-a485-37fff5c7d458">

2. Now , after the changes made, you can see the changes below:

After Changes:

<img width="1040" alt="main" src="https://github.com/shuding/nextra/assets/90372904/3d1b1be1-cfa8-4ed2-9ea7-09ebeb81443f">
