### PR TITLE
[ISSUE-2731] chore: custom search component documentation

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -404,6 +404,22 @@ to learn how to add custom menus or links to the navbar.
   ]}
 />
 
+<Callout type="info">
+  When using a custom search component, make sure to pass on the `className` prop to the root element of the component to ensure proper responsiveness for mobile devices.
+  ```tsx filename="theme.config.jsx"
+  export default {
+    search: {
+      component: ({ className }) => (
+        <div className={className}>
+          <CustomSearch type="text" placeholder="Search..." />
+        </div>
+      )
+    }
+  }
+  
+  ```
+</Callout>
+
 ### Banner
 
 Show a banner on the top of the website. It can be used to show a warning or a


### PR DESCRIPTION
Per https://github.com/shuding/nextra/issues/2731 :

When using a custom search component as is, it will be duplicated on mobile (<768px), being visible on navbar + hamburger menu.

The build in css that is used to hide it from the navbar depends on nextra classes.

We can extract it from props and pass it on, which will allow it to behave similarly to the default search.