### PR TITLE
Add topLevelLink option

### DIFF
--- a/packages/nextra/src/client/normalize-pages.ts
+++ b/packages/nextra/src/client/normalize-pages.ts
@@ -18,6 +18,7 @@ const DEFAULT_PAGE_THEME: PageTheme = {
   sidebar: true,
   timestamp: true,
   toc: true,
+  topLevelLink: true,
   typesetting: 'default'
 }
 
@@ -343,14 +344,16 @@ export function normalizePages({
           pageItem.children.push(...normalizedChildren.directories)
           docsDirectories.push(...normalizedChildren.docsDirectories)
 
-          // If it's a page with children inside, we inject itself as a page too.
-          if (normalizedChildren.flatDirectories.length) {
-            pageItem.firstChildRoute = findFirstRoute(
-              normalizedChildren.flatDirectories
-            )
-            topLevelNavbarItems.push(pageItem)
-          } else if (pageItem.withIndexPage) {
-            topLevelNavbarItems.push(pageItem)
+          if (extendedMeta.theme?.topLevelLink) {
+            // If it's a page with children inside, we inject itself as a page too.
+            if (normalizedChildren.flatDirectories.length) {
+              pageItem.firstChildRoute = findFirstRoute(
+                normalizedChildren.flatDirectories
+              )
+              topLevelNavbarItems.push(pageItem)
+            } else if (pageItem.withIndexPage) {
+              topLevelNavbarItems.push(pageItem)
+            }
           }
 
           break
@@ -374,7 +377,9 @@ export function normalizePages({
       switch (type) {
         case 'page':
         case 'menu':
-          topLevelNavbarItems.push(pageItem)
+          if (extendedMeta.theme?.topLevelLink) {
+            topLevelNavbarItems.push(pageItem)
+          }
           break
         case 'doc': {
           const withHrefProp = 'href' in item

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -118,6 +118,7 @@ export const pageThemeSchema = z.strictObject({
   navbar: z.boolean(),
   pagination: z.boolean(),
   sidebar: z.boolean(),
+  topLevelLink: z.boolean(),
   timestamp: z.boolean(),
   toc: z.boolean(),
   typesetting: z.enum(['default', 'article']),


### PR DESCRIPTION
When type is set as page - the page is displayed in the navbar. I can add `display: hidden` and it will be hidden from all navigations. However, sometimes you want to hide this page only in the navbar itself, and instead, for example, add it to the menu.

As an example - my website https://nimpl.tech/. I want to split the documentation, but keep them in dropdown lists.