### PR TITLE
Increase the li::marker color contrast in the theme blog's dark mode

### DIFF
--- a/.changeset/chilled-lions-trade.md
+++ b/.changeset/chilled-lions-trade.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-blog': patch
+---
+
+Increase the list item marker color contrast in the theme blog's dark mode.

--- a/packages/nextra-theme-blog/tailwind.config.js
+++ b/packages/nextra-theme-blog/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
         dark: {
           css: {
             color: theme('colors.gray[300]'),
+            'li::marker': { color: theme('colors.gray[300]') },
             '[class~="lead"]': { color: theme('colors.gray[400]') },
             a: { color: theme('colors.gray[100]') },
             strong: { color: theme('colors.gray[100]') },


### PR DESCRIPTION
## What

In the dark mode of the blog theme, the list item marker color still references the variables from the light mode, resulting in a lack of color contrast for the ordered list item markers.

I can create another pull request for the v3 branch if needed.

## How

Referencing the current styles in the doc theme, apply the basic text color to the list item color in the blog theme.

## Before

```css
.nx-prose :where(ol>li):not(:where([class~=nx-not-prose] *))::marker {
    color: var(--tw-prose-counters); /* #6b7280 */
    font-weight: 400;
}

.nx-prose :where(ul>li):not(:where([class~=nx-not-prose] *))::marker {
    color: var(--tw-prose-bullets); /* #d1d5db */
}
```

![image](https://github.com/shuding/nextra/assets/26923823/86896b1c-3f72-4e4c-bac0-7bb2a61f78a7)

## After

```css
:is(html[class~=dark] .dark\:nx-prose-dark) :where(li):not(:where([class~=nx-not-prose] *))::marker {
    color: #d1d5db;
}
```

![image](https://github.com/shuding/nextra/assets/26923823/dd7250f1-d5f4-42ba-a77c-8b60b712707f)

