### PR TITLE
support custom label for back-to-top link

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -629,7 +629,8 @@ navigating between headings.
       'React.FC<{ id: string, children: string }>',
       'Custom renderer of TOC headings.'
     ],
-    ['toc.backToTop', 'boolean', 'Add `Scroll to top` link.']
+    ['toc.backToTop', 'boolean', 'Add `Scroll to top` link.'],
+    ['toc.scrollToTop', 'string | (() => string)', 'Label of the `Scroll to top` link.']
   ]}
 />
 

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -630,7 +630,7 @@ navigating between headings.
       'Custom renderer of TOC headings.'
     ],
     ['toc.backToTop', 'boolean', 'Add `Scroll to top` link.'],
-    ['toc.scrollToTop', 'string | (() => string)', 'Label of the `Scroll to top` link.']
+    ['toc.backToTopLabel', 'string | (() => string)', 'Label of the `Scroll to top` link.']
   ]}
 />
 

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -630,7 +630,11 @@ navigating between headings.
       'Custom renderer of TOC headings.'
     ],
     ['toc.backToTop', 'boolean', 'Add `Scroll to top` link.'],
-    ['toc.backToTopLabel', 'string | (() => string)', 'Label of the `Scroll to top` link.']
+    [
+      'toc.backToTopLabel',
+      'string | (() => string)',
+      'Label of the `Scroll to top` link.'
+    ]
   ]}
 />
 

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -34,7 +34,7 @@ export function BackToTop({ className }: { className?: string }): ReactElement {
         className
       )}
     >
-      {renderString(config.toc.scrollToTop)}
+      {renderString(config.toc.backToTopLabel)}
       <ArrowRightIcon className="-nx-rotate-90 nx-w-3.5 nx-h-3.5 nx-border nx-rounded-full nx-border-current" />
     </button>
   )

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -2,6 +2,8 @@ import cn from 'clsx'
 import { ArrowRightIcon } from 'nextra/icons'
 import type { ReactElement } from 'react'
 import { useEffect, useRef } from 'react'
+import { useConfig } from '../contexts'
+import { renderString } from '../utils'
 
 function scrollToTop() {
   window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -9,6 +11,7 @@ function scrollToTop() {
 
 export function BackToTop({ className }: { className?: string }): ReactElement {
   const ref = useRef<HTMLButtonElement>(null)
+  const config = useConfig()
   useEffect(() => {
     function toggleVisible() {
       const { scrollTop } = document.documentElement
@@ -31,7 +34,7 @@ export function BackToTop({ className }: { className?: string }): ReactElement {
         className
       )}
     >
-      Scroll to top
+      {renderString(config.toc.scrollToTop)}
       <ArrowRightIcon className="-nx-rotate-90 nx-w-3.5 nx-h-3.5 nx-border nx-rounded-full nx-border-current" />
     </button>
   )

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -152,6 +152,7 @@ export const themeSchema = z.strictObject({
   }),
   toc: z.strictObject({
     backToTop: z.boolean(),
+    scrollToTop: z.string().or(z.function().returns(z.string())),
     component: z.custom<ReactNode | FC<TOCProps>>(...reactNode),
     extraContent: z.custom<ReactNode | FC>(...reactNode),
     float: z.boolean(),
@@ -347,6 +348,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   },
   toc: {
     backToTop: false,
+    scrollToTop: 'Scroll to top',
     component: TOC,
     float: true,
     title: 'On This Page'

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -152,7 +152,7 @@ export const themeSchema = z.strictObject({
   }),
   toc: z.strictObject({
     backToTop: z.boolean(),
-    scrollToTop: z.string().or(z.function().returns(z.string())),
+    backToTopLabel: z.string().or(z.function().returns(z.string())),
     component: z.custom<ReactNode | FC<TOCProps>>(...reactNode),
     extraContent: z.custom<ReactNode | FC>(...reactNode),
     float: z.boolean(),
@@ -348,10 +348,10 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   },
   toc: {
     backToTop: false,
-    scrollToTop: 'Scroll to top',
+    backToTopLabel: 'Scroll to top',
     component: TOC,
     float: true,
-    title: 'On This Page'
+    title: 'On This Page',
   },
   useNextSeoProps: () => ({ titleTemplate: '%s – Nextra' })
 }

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -351,7 +351,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     backToTopLabel: 'Scroll to top',
     component: TOC,
     float: true,
-    title: 'On This Page',
+    title: 'On This Page'
   },
   useNextSeoProps: () => ({ titleTemplate: '%s – Nextra' })
 }


### PR DESCRIPTION
This PR resolves https://github.com/shuding/nextra/issues/2308 by adding a `backToTopLabel` field to the `toc` config.

I have confirmed in `examples/docs` that this change is working locally. The label is set to `Go back to top please` in the screenshot:

<img width="203" alt="Screen Shot 2024-05-21 at 00 16 22" src="https://github.com/shuding/nextra/assets/111333464/20019c4e-0805-4e20-b47f-dff850ce85d1">

Thank you in advance for your review.
