### PR TITLE
fix(Card): change TW from justify-start to justify-center

### DIFF
--- a/packages/nextra/src/client/components/cards.tsx
+++ b/packages/nextra/src/client/components/cards.tsx
@@ -8,7 +8,7 @@ const classes = {
     '_not-prose' // for nextra-theme-blog
   ),
   card: cn(
-    'nextra-card _group _flex _flex-col _justify-start _overflow-hidden _rounded-lg _border _border-gray-200',
+    'nextra-card _group _flex _flex-col _justify-center _overflow-hidden _rounded-lg _border _border-gray-200',
     '_text-current _no-underline dark:_shadow-none',
     'hover:_shadow-gray-100 dark:hover:_shadow-none _shadow-gray-100',
     'active:_shadow-sm active:_shadow-gray-200',


### PR DESCRIPTION
The Card components <a> tag is using justify-start. This is not necessary since the nested span already has it.
When used with the `Cards` grid component, the layout becomes inconsistent across the rows.

Changing to justify-center to ensure the span content remains centered across a row.

**Before**
<img width="856" alt="before" src="https://github.com/shuding/nextra/assets/133849024/c5aed600-278f-4bf7-be3e-a5eddacabac5">


**After**
<img width="856" alt="after" src="https://github.com/shuding/nextra/assets/133849024/a1d91969-bb72-4b99-9e86-5f6ac061d9e7">

