### PR TITLE
[v3] Fix the line-numbers style in syntax highlighting

### DIFF
--- a/.changeset/warm-cameras-vanish.md
+++ b/.changeset/warm-cameras-vanish.md
@@ -1,5 +1,7 @@
 ---
 'nextra': patch
+'nextra-theme-docs': patch
+'nextra-theme-blog': patch
 ---
 
 Fix the line highlighting background-color does not extend to the full width of the code block when a scrollbar appears with line numbers.

--- a/.changeset/warm-cameras-vanish.md
+++ b/.changeset/warm-cameras-vanish.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+Fix the line highlighting background-color does not extend to the full width of the code block when a scrollbar appears with line numbers.

--- a/packages/nextra/styles/code-block.css
+++ b/packages/nextra/styles/code-block.css
@@ -25,7 +25,7 @@ pre code:not([class*='twoslash-']) {
     &::before {
       counter-increment: line;
       content: counter(line);
-      @apply _float-left _pr-4 _text-right _min-w-[2.6rem] _text-gray-500;
+      @apply _inline-block _pr-4 _text-right _min-w-[2.6rem] _text-gray-500;
     }
   }
 


### PR DESCRIPTION
## What

Fix the line highlighting background-color does not extend to the full width of the code block when a scrollbar appears with line numbers.

https://github.com/shuding/nextra/assets/26923823/c5a7d769-46fa-46b3-9b33-4a50e07cace3

## How

adding `_inline-block` class and removing `_float-left` class

https://github.com/shuding/nextra/assets/26923823/7c175be9-2930-4b8e-916f-3bb635813def


