### PR TITLE
Add ability to dynamically hide menu / nav items

### DIFF
--- a/packages/nextra-theme-docs/src/components/navbar.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar.tsx
@@ -88,6 +88,8 @@ export function Navbar({ items }: NavBarProps): ReactElement {
   const activeRoute = useFSRoute()
   const { menu, setMenu } = useMenu()
 
+  const { visibilityCheck } = themeConfig.menuItems
+
   return (
     <div className="nextra-nav-container _sticky _top-0 _z-20 _w-full _bg-transparent print:_hidden">
       <div className="nextra-nav-container-blur" />
@@ -109,6 +111,10 @@ export function Navbar({ items }: NavBarProps): ReactElement {
           </div>
         )}
         {items.map(pageOrMenu => {
+          if (visibilityCheck && !visibilityCheck(pageOrMenu)) {
+            return null
+          }
+
           if (pageOrMenu.display === 'hidden') return null
 
           if (pageOrMenu.type === 'menu') {

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -364,6 +364,14 @@ export function Sidebar({
   const hasMenu =
     themeConfig.darkMode || hasI18n || themeConfig.sidebar.toggleButton
 
+  const { visibilityCheck } = themeConfig.menuItems
+  const filteredDocsDirectories = docsDirectories.filter(
+    item => !visibilityCheck || visibilityCheck(item)
+  )
+  const filteredFullDirectories = fullDirectories.filter(
+    item => !visibilityCheck || visibilityCheck(item)
+  )
+
   return (
     <>
       {includePlaceholder && asPopover && (
@@ -417,7 +425,7 @@ export function Sidebar({
                   <Menu
                     className="nextra-menu-desktop max-md:_hidden"
                     // The sidebar menu, shows only the docs directories.
-                    directories={docsDirectories}
+                    directories={filteredDocsDirectories}
                     // When the viewport size is larger than `md`, hide the anchors in
                     // the sidebar when `floatTOC` is enabled.
                     anchors={themeConfig.toc.float ? [] : anchors}
@@ -429,7 +437,7 @@ export function Sidebar({
                 <Menu
                   className="nextra-menu-mobile md:_hidden"
                   // The mobile dropdown menu, shows all the directories.
-                  directories={fullDirectories}
+                  directories={filteredFullDirectories}
                   // Always show the anchor links on mobile (`md`).
                   anchors={anchors}
                 />

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -139,6 +139,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     </>
   ),
   logoLink: true,
+  menuItems: {},
   navbar: {
     component: Navbar
   },

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -67,6 +67,10 @@ export const themeSchema = /* @__PURE__ */ (() =>
     logo: z.custom<ReactNode | FC>(...reactNode),
     logoLink: z.boolean().or(z.string()),
     main: z.custom<FC<{ children: ReactNode }>>(...fc).optional(),
+    menuItems: z.strictObject({
+      // eslint-disable-next-line no-restricted-syntax
+      visibilityCheck: z.function().args(z.object({}).partial()).optional()
+    }),
     navbar: z.strictObject({
       component: z.custom<ReactNode | FC<NavBarProps>>(...reactNode),
       extraContent: z.custom<ReactNode | FC>(...reactNode).optional()


### PR DESCRIPTION
Hi there!

Loving what you're doing with the v3 branch. We have a use-case where we want to dynamically hide / show certain pages (we have some docs behind auth).

It isn't possible to dynamically do checks as to whether these pages are shown or not, so I've added a config option that takes a function, that allows you to check if the menu item should be rendered or not (both for the Navbar and Sidebar)

It is used like so in your `theme.config.tsx`:

```typescript
export default {
  menuItems: {
    visibilityCheck: (item: PageItem | Item) => {
      if (item.route === '/hidden-page') {
        return false;
      }

      return true;
    }
  }
}
```

I thought a better route would be supporting `_meta.tsx` with a dynamic visibility type, but that would require the meta file supporting items as functions and I'm not sure how to do that 😄 

Feedback appreciated!