### PR TITLE
feat: TOC and Sidebar override [v3]

### DIFF
--- a/.changeset/silver-chicken-bathe.md
+++ b/.changeset/silver-chicken-bathe.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+TOC and Sidebar override

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -418,6 +418,11 @@ Customize the entire navbar component.
 <OptionTable
   options={[
     [
+      'sidebar.component',
+      'React.ReactNode | React.FC<SideBarProps>',
+      'Custom renderer of the Sidebar.'
+    ],
+    [
       'sidebar.defaultMenuCollapseLevel',
       'number',
       'Specifies the folder level at which the menu on the left is collapsed by default. Defaults to 2.'

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -306,7 +306,7 @@ function Menu({
   )
 }
 
-interface SideBarProps {
+export type SideBarProps = {
   docsDirectories: PageItem[]
   fullDirectories: Item[]
   asPopover?: boolean

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -8,6 +8,7 @@ import {
   Flexsearch,
   Footer,
   Navbar,
+  Sidebar,
   ThemeSwitch,
   TOC
 } from './components'
@@ -182,6 +183,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     }
   },
   sidebar: {
+    component: Sidebar,
     defaultMenuCollapseLevel: 2,
     toggleButton: true
   },

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -102,7 +102,9 @@ export {
   SkipNavContent,
   SkipNavLink,
   ThemeSwitch,
-  LocaleSwitch
+  LocaleSwitch,
+  TOC,
+  Sidebar
 } from './components'
 
 export { useMenu } from './contexts'

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -26,6 +26,7 @@ import type { DocsThemeConfig } from './constants'
 import { useConfig, useSetActiveAnchor, useThemeConfig } from './contexts'
 import { useIntersectionObserver, useSlugs } from './contexts/active-anchor'
 import { renderComponent } from './utils'
+import { SideBarProps } from './components/sidebar';
 
 // Anchor links
 const createHeading = (
@@ -348,6 +349,15 @@ const DEFAULT_COMPONENTS: MDXComponents = {
           })}
         </nav>
       )
+
+    const sidebarProps: SideBarProps = {
+      docsDirectories: docsDirectories,
+      fullDirectories: directories,
+      toc: toc,
+      asPopover: config.hideSidebar,
+      includePlaceholder: themeContext.layout === 'default'
+    }
+
     return (
       <div
         className={cn(
@@ -355,13 +365,11 @@ const DEFAULT_COMPONENTS: MDXComponents = {
           themeContext.layout !== 'raw' && '_max-w-[90rem]'
         )}
       >
-        <Sidebar
-          docsDirectories={docsDirectories}
-          fullDirectories={directories}
-          toc={toc}
-          asPopover={config.hideSidebar}
-          includePlaceholder={themeContext.layout === 'default'}
-        />
+        {
+          themeConfig.sidebar.component
+            ? renderComponent(themeConfig.sidebar.component, sidebarProps)
+            : <Sidebar {...sidebarProps}/>
+        }
         {tocEl}
         <SkipNavContent />
         <Body>{children}</Body>

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -3,6 +3,7 @@ import type { FC, ReactNode } from 'react'
 import { z } from 'zod'
 import type { NavBarProps } from './components/navbar'
 import type { TOCProps } from './components/toc'
+import type { SideBarProps } from './components/sidebar';
 
 const i18nSchema = /* @__PURE__ */ (() =>
   z.array(
@@ -113,6 +114,7 @@ export const themeSchema = /* @__PURE__ */ (() =>
       placeholder: z.string().or(z.function().returns(z.string()))
     }),
     sidebar: z.strictObject({
+      component: z.custom<ReactNode | FC<SideBarProps>>(...reactNode),
       autoCollapse: z.boolean().optional(),
       defaultMenuCollapseLevel: z.number().min(1).int(),
       toggleButton: z.boolean()


### PR DESCRIPTION
This PR includes improvements to the TOC and Sidebar components that can be overridden through the theme config.

**1. TOC component export to allow the following:**

```ts
toc: {
  title: "Custom TOC title",
  backToTop: false,
  float: true,
  component(props: ComponentProps<typeof TOC>) {
    return (
      <div className="flex items-end justify-between">
        <div>Custom element</div>
        <TOC {...props} />
      </div>
    );
  }
}
```

This will allow us to add a wrapper around the built-in TOC component.

**2. A possibility to set a custom component for the Sidebar component + its export:**

```ts
sidebar: {
  component(props: ComponentProps<typeof Sidebar>) {
    return <div className="flex items-end justify-between">
      <div>Custom element</div>
      <Sidebar {...props}/>
    </div>
  },
  toggleButton: false
},
```

The same approach already exists for a number of other components, so I think it would be quite useful and fair to have the same DX for the TOC and Sidebar components.