### PR TITLE
[v3] fix `RangeError: Maximum call stack size exceeded` in `findSummary` when `child.props.children` is `undefined`

### DIFF
--- a/.changeset/small-ads-glow.md
+++ b/.changeset/small-ads-glow.md
@@ -1,0 +1,8 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+add `flex-shrink: 0` for indent in `FileTree` for `<Ident />` and svg icons in `<Folder />`
+and `<File />`

--- a/.changeset/warm-mice-flash.md
+++ b/.changeset/warm-mice-flash.md
@@ -1,0 +1,6 @@
+---
+'nextra-theme-docs': patch
+---
+
+fix `RangeError: Maximum call stack size exceeded` in `findSummary` when `child.props.children`
+is `undefined`

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -132,7 +132,7 @@ function Details({
             })
             return
           }
-          if (child.type !== Details) {
+          if (child.type !== Details && child.props.children) {
             ;[summary, child] = findSummary(child.props.children)
           }
         }

--- a/packages/nextra/src/client/components/file-tree.tsx
+++ b/packages/nextra/src/client/components/file-tree.tsx
@@ -43,7 +43,8 @@ function Ident(): ReactElement {
   return (
     <>
       {Array.from({ length }, (_, i) => (
-        <span className="_w-5" key={i} />
+        // Text can shrink indent
+        <span className="_w-5 _shrink-0" key={i} />
       ))}
     </>
   )
@@ -69,7 +70,13 @@ const Folder = memo<FolderProps>(
           className="_inline-flex _cursor-pointer _items-center _py-1 hover:_opacity-60"
         >
           <Ident />
-          <svg width="1em" height="1em" viewBox="0 0 24 24">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            // Text can shrink icon
+            className="_shrink-0"
+          >
             <path
               fill="none"
               stroke="currentColor"
@@ -105,7 +112,13 @@ const File = memo<FileProps>(({ label, name, active }) => (
   >
     <span className="_inline-flex _cursor-default _items-center _py-1">
       <Ident />
-      <svg width="1em" height="1em" viewBox="0 0 24 24">
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        // Text can shrink icon
+        className="_shrink-0"
+      >
         <path
           fill="none"
           stroke="currentColor"


### PR DESCRIPTION
fixes https://github.com/the-guild-org/website/actions/runs/10024457855/job/27706559011?pr=1695