### PR TITLE
[ISSUE-3124] fix: Bleed demo image

### DIFF
--- a/docs/pages/docs/docs-theme/built-ins/bleed.mdx
+++ b/docs/pages/docs/docs-theme/built-ins/bleed.mdx
@@ -33,7 +33,7 @@ For example, you can put text, image, video or any component inside:
 You can even make it full-bleed using `<Bleed full>`:
 
 <Bleed full>
-  <>![Landscape](https://source.unsplash.com/eaxwP9J_V6s/1600x398)</>
+  ![OGimage](/og.jpeg)
 </Bleed>
 
 ## Usage
@@ -44,7 +44,7 @@ import { Bleed } from 'nextra-theme-docs'
 <Bleed>Hey, I can use **Markdown** syntax here.</Bleed>
 
 <Bleed full>
-  ![Landscape](https://source.unsplash.com/eaxwP9J_V6s/1600x398)
+   ![OGimage](/og.jpeg) // or external image
 </Bleed>
 
 <Bleed full>

--- a/docs/pages/docs/docs-theme/built-ins/bleed.mdx
+++ b/docs/pages/docs/docs-theme/built-ins/bleed.mdx
@@ -44,7 +44,7 @@ import { Bleed } from 'nextra-theme-docs'
 <Bleed>Hey, I can use **Markdown** syntax here.</Bleed>
 
 <Bleed full>
-   ![OGimage](/og.jpeg) // or external image
+   ![OGimage](https://nextra.site/og.jpeg)
 </Bleed>
 
 <Bleed full>

--- a/docs/pages/docs/docs-theme/built-ins/bleed.mdx
+++ b/docs/pages/docs/docs-theme/built-ins/bleed.mdx
@@ -32,9 +32,7 @@ For example, you can put text, image, video or any component inside:
 
 You can even make it full-bleed using `<Bleed full>`:
 
-<Bleed full>
-  ![OGimage](/og.jpeg)
-</Bleed>
+<Bleed full>![Nextra](/og.jpeg)</Bleed>
 
 ## Usage
 
@@ -43,9 +41,7 @@ import { Bleed } from 'nextra-theme-docs'
 
 <Bleed>Hey, I can use **Markdown** syntax here.</Bleed>
 
-<Bleed full>
-   ![OGimage](https://nextra.site/og.jpeg)
-</Bleed>
+<Bleed full>![Nextra](https://nextra.site/og.jpeg)</Bleed>
 
 <Bleed full>
   <iframe

--- a/docs/pages/docs/guide/built-ins/filetree.mdx
+++ b/docs/pages/docs/guide/built-ins/filetree.mdx
@@ -6,7 +6,7 @@ A built-in component to visually represent a file tree.
 
 ## Example
 
-Click the folder to test the dynamic functionality of the file tree. 
+Click the folder to test the dynamic functionality of the file tree.
 
 <FileTree>
   <FileTree.Folder name="pages" defaultOpen>
@@ -23,7 +23,9 @@ Click the folder to test the dynamic functionality of the file tree.
 
 ## Usage
 
-Create the file tree structure by nesting `<FileTree.Folder>` and `<FileTree.File>` components within a `<FileTree>`. Name each file or folder with the `name` attribute. Use `defaultOpen` to set the folder to open on load.
+Create the file tree structure by nesting `<FileTree.Folder>` and
+`<FileTree.File>` components within a `<FileTree>`. Name each file or folder
+with the `name` attribute. Use `defaultOpen` to set the folder to open on load.
 
 ```mdx filename="Markdown"
 import { FileTree } from 'nextra/components'

--- a/examples/docs/src/pages/themes/docs/bleed.mdx
+++ b/examples/docs/src/pages/themes/docs/bleed.mdx
@@ -21,7 +21,7 @@ import { Bleed } from 'nextra-theme-docs'
 It provides a better reading experience when you want to present some graphical
 information, which normally looks nicer in a larger size.
 
-For example you can put text, image, video or any component inside:
+For example, you can put text, image, video or any component inside:
 
 <Bleed>
   <iframe
@@ -35,9 +35,7 @@ For example you can put text, image, video or any component inside:
 
 You can even make it full-bleed using `<Bleed full>`:
 
-<Bleed full>
-  ![OGimage](/og.jpeg)
-</Bleed>
+<Bleed full>![Nextra](/og.png)</Bleed>
 
 ## Usage
 
@@ -46,9 +44,7 @@ You can even make it full-bleed using `<Bleed full>`:
 ```mdx filename="bleed.mdx"
 <Bleed>Hey, I can use **Markdown** syntax here.</Bleed>
 
-<Bleed full>
-  ![OGimage](https://nextra.site/og.jpeg)
-</Bleed>
+<Bleed full>![Nextra](https://nextra.site/og.jpeg)</Bleed>
 
 <Bleed full>
   <iframe

--- a/examples/docs/src/pages/themes/docs/bleed.mdx
+++ b/examples/docs/src/pages/themes/docs/bleed.mdx
@@ -36,7 +36,7 @@ For example you can put text, image, video or any component inside:
 You can even make it full-bleed using `<Bleed full>`:
 
 <Bleed full>
-  ![Landscape](https://source.unsplash.com/eaxwP9J_V6s/1600x398)
+  ![OGimage](/og.jpeg)
 </Bleed>
 
 ## Usage
@@ -47,7 +47,7 @@ You can even make it full-bleed using `<Bleed full>`:
 <Bleed>Hey, I can use **Markdown** syntax here.</Bleed>
 
 <Bleed full>
-  ![Landscape](https://source.unsplash.com/eaxwP9J_V6s/1600x398)
+  ![OGimage](https://nextra.site/og.jpeg)
 </Bleed>
 
 <Bleed full>
@@ -68,7 +68,7 @@ import { Bleed } from 'nextra-theme-docs'
 <Bleed>Hey, I can use **Markdown** syntax here.</Bleed>
 
 <Bleed full>
-  ![Landscape](https://source.unsplash.com/eaxwP9J_V6s/1600x398)
+  ![OgImage](https://nextra.site/og.jpeg)
 </Bleed>
 
 <Bleed full>

--- a/examples/docs/src/pages/themes/docs/bleed.mdx
+++ b/examples/docs/src/pages/themes/docs/bleed.mdx
@@ -64,7 +64,7 @@ import { Bleed } from 'nextra-theme-docs'
 <Bleed>Hey, I can use **Markdown** syntax here.</Bleed>
 
 <Bleed full>
-  ![OgImage](https://nextra.site/og.jpeg)
+  ![Nextra](https://nextra.site/og.jpeg)
 </Bleed>
 
 <Bleed full>


### PR DESCRIPTION
https://github.com/shuding/nextra/issues/3124

* Previous demo image was external from Unsplash. It was removed from origin server and started returning `404`

* Replaced with internal image that doesn't depend on 3rd party.