### PR TITLE
[v3] add a generic for `themeConfig` to improve type inference

### DIFF
--- a/.changeset/poor-rings-shop.md
+++ b/.changeset/poor-rings-shop.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+Add a generic for `themeConfig` in `NextraThemeLayoutProps` to improve type inference.

--- a/packages/nextra-theme-blog/src/index.tsx
+++ b/packages/nextra-theme-blog/src/index.tsx
@@ -9,7 +9,7 @@ import { components, HeadingContext } from './mdx-theme'
 import Meta from './meta'
 import Nav from './nav'
 import { PostsLayout } from './posts-layout'
-import type { BlogFrontMatter } from './types'
+import type { BlogFrontMatter, NextraBlogTheme } from './types'
 import { isValidDate } from './utils/date'
 
 const layoutSet = new Set(['post', 'page', 'posts', 'tag'])
@@ -18,7 +18,7 @@ export default function NextraLayout({
   children,
   pageOpts,
   themeConfig
-}: NextraThemeLayoutProps<BlogFrontMatter>) {
+}: NextraThemeLayoutProps<BlogFrontMatter, NextraBlogTheme>) {
   const config = { ...DEFAULT_THEME, ...themeConfig }
 
   const ref = useRef<HTMLHeadingElement>(null)

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -93,10 +93,13 @@ export type Nextra = (
 
 export type ThemeConfig = any | null
 
-export type NextraThemeLayoutProps<F = FrontMatter> = {
-  pageOpts: PageOpts<F>
+export type NextraThemeLayoutProps<
+  TFrontMatter = FrontMatter,
+  TThemeConfig = ThemeConfig
+> = {
+  pageOpts: PageOpts<TFrontMatter>
   pageProps: any
-  themeConfig: ThemeConfig
+  themeConfig: TThemeConfig
   children: ReactNode
 }
 


### PR DESCRIPTION
## Description

I encountered a similar issue to #2971 when I attempted to implement a custom Nextra theme. My idea is to add a generic parameter in `NextraThemeLayoutProps` for `themeConfig`, which would provide better type support for the root layout. If this approach is not suitable, feel free to close it.

`type.ts`

```tsx
import type { NextraThemeLayoutProps } from 'nextra'

export type MyNextraThemeFrontmatter = {
  // ...
}

export type MyNextraThemeConfig = {
  titleSuffix?: string
  // ...
}

export type MyNextraThemeLayoutProps = NextraThemeLayoutProps<
  MyNextraThemeFrontmatter,
  MyNextraThemeConfig
>
```

`theme.tsx`

```tsx
import Head from 'next/head'
import { DEFAULT_THEME_CONFIG } from './constants'
import type { MyNextraThemeLayoutProps } from './types'

export default function Layout({ children, themeConfig }: MyNextraThemeLayoutProps) {
  // Can determine the type of "config" instead of inferring it as any
  const config = {
    ...DEFAULT_THEME_CONFIG,
    ...themeConfig
  }
  
  // Auto complete working with "config.titleSuffix"
  const title = `${pageTitle}${config.titleSuffix || ''}`

  return (
    <div>
      <Head>
        <title>{title}</title>
      </Head>
      {/* ... */}
    </div>
  )
}
```