### PR TITLE
[v3] remove explicit `ZodError` type assertion

### DIFF
--- a/.changeset/long-islands-report.md
+++ b/.changeset/long-islands-report.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+remove explicit `ZodError` assertion

--- a/packages/nextra/src/server/index.ts
+++ b/packages/nextra/src/server/index.ts
@@ -2,7 +2,6 @@
 import { createRequire } from 'node:module'
 import { sep } from 'node:path'
 import type { NextConfig } from 'next'
-import type { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 import type { Nextra } from '../types'
 import {
@@ -25,11 +24,10 @@ const require = createRequire(import.meta.url)
 const AGNOSTIC_PAGE_MAP_PATH = `.next${sep}static${sep}chunks${sep}nextra-page-map`
 
 const nextra: Nextra = nextraConfig => {
-  try {
-    nextraConfigSchema.parse(nextraConfig)
-  } catch (error) {
+  const { error } = nextraConfigSchema.safeParse(nextraConfig)
+  if (error) {
     logger.error('Error validating nextraConfig')
-    throw fromZodError(error as ZodError)
+    throw fromZodError(error)
   }
 
   return function withNextra(nextConfig = {}) {


### PR DESCRIPTION
## Description

This change allows TypeScript to infer the `ZodError` type, so we don't need to import it for explicit assertion. Feel free to close this if the approach is not suitable.