### PR TITLE
[v3] remove focus-visible polyfill

### DIFF
--- a/.changeset/khaki-adults-mix.md
+++ b/.changeset/khaki-adults-mix.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+remove focus-visible polyfill

--- a/examples/swr-site/package.json
+++ b/examples/swr-site/package.json
@@ -16,7 +16,6 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
-    "focus-visible": "^5.1.0",
     "intersection-observer": "^0.10.0",
     "markdown-to-jsx": "^6.11.4",
     "next": "^14.2.5",

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -41,7 +41,6 @@
     "clsx": "^2.0.0",
     "escape-string-regexp": "^5.0.0",
     "flexsearch": "^0.7.43",
-    "focus-visible": "^5.2.0",
     "intersection-observer": "^0.12.2",
     "next-themes": "^0.3.0",
     "scroll-into-view-if-needed": "^3.1.0",

--- a/packages/nextra-theme-docs/src/index.tsx
+++ b/packages/nextra-theme-docs/src/index.tsx
@@ -1,4 +1,3 @@
-import 'focus-visible'
 import './polyfill'
 import { ThemeProvider } from 'next-themes'
 import type { NextraThemeLayoutProps } from 'nextra'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: file:packages/nextra(@types/react@18.3.3)(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.4)
       nextra-theme-blog:
         specifier: workspace:*
-        version: file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.31)(react-dom@18.3.1)(react@18.3.1)
+        version: file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.33)(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -172,7 +172,7 @@ importers:
         version: file:packages/nextra(@types/react@18.3.3)(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.4)
       nextra-theme-docs:
         specifier: workspace:*
-        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.31)(react-dom@18.3.1)(react@18.3.1)
+        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.33)(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -187,9 +187,6 @@ importers:
 
   examples/swr-site:
     dependencies:
-      focus-visible:
-        specifier: ^5.1.0
-        version: 5.2.0
       intersection-observer:
         specifier: ^0.10.0
         version: 0.10.0
@@ -204,7 +201,7 @@ importers:
         version: file:packages/nextra(@types/react@18.3.3)(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.4)
       nextra-theme-docs:
         specifier: workspace:*
-        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.31)(react-dom@18.3.1)(react@18.3.1)
+        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.33)(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -453,9 +450,6 @@ importers:
       flexsearch:
         specifier: ^0.7.43
         version: 0.7.43
-      focus-visible:
-        specifier: ^5.2.0
-        version: 5.2.0
       intersection-observer:
         specifier: ^0.12.2
         version: 0.12.2
@@ -6863,10 +6857,6 @@ packages:
     resolution: {integrity: sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==}
     dev: false
 
-  /focus-visible@5.2.0:
-    resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
-    dev: false
-
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -12432,7 +12422,7 @@ packages:
       - typescript
     dev: false
 
-  file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.31)(react-dom@18.3.1)(react@18.3.1):
+  file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.33)(react-dom@18.3.1)(react@18.3.1):
     resolution: {directory: packages/nextra-theme-blog, type: directory}
     id: file:packages/nextra-theme-blog
     name: nextra-theme-blog
@@ -12453,7 +12443,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.31)(react-dom@18.3.1)(react@18.3.1):
+  file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.33)(react-dom@18.3.1)(react@18.3.1):
     resolution: {directory: packages/nextra-theme-docs, type: directory}
     id: file:packages/nextra-theme-docs
     name: nextra-theme-docs
@@ -12468,7 +12458,6 @@ packages:
       clsx: 2.1.1
       escape-string-regexp: 5.0.0
       flexsearch: 0.7.43
-      focus-visible: 5.2.0
       intersection-observer: 0.12.2
       next: 14.2.5(@babel/core@7.24.9)(react-dom@18.3.1)(react@18.3.1)
       next-themes: 0.3.0(react-dom@18.3.1)(react@18.3.1)


### PR DESCRIPTION
## Description

Following the [focus-visible](https://github.com/WICG/focus-visible) guidelines, I reviewed the codebase and couldn't find any related selectors such as `.js-focus-visible`, `.focus-visible`, or `[data-focus-visible-added]`. Since `:focus-visible` is now supported in all major browsers, the polyfill may no longer be necessary.

If anything is missed or if there are still cases where the polyfill is needed, please feel free to close this PR.

## Screenshots

<details>
 <summary>Chrome 127</summary>
 
  https://github.com/user-attachments/assets/6aec13bf-d557-4312-bc0f-7dbf10a6627f
</details>

<details>
 <summary>Firefox 117</summary>
 
  https://github.com/user-attachments/assets/b54ff8eb-0d0f-43f0-9749-481a66899fe0
</details>

<details>
 <summary>Safari 17.5</summary>
 
  https://github.com/user-attachments/assets/ebbad58e-1876-4a5c-bed6-c4a550094dd3
</details>


I also compared it with the current v2 site, and it seems to behave the same way as before the change.

<details>
 <summary>Chrome</summary>
 
  https://github.com/user-attachments/assets/c4f062b7-fc62-4112-b3b1-b7154ed30bf3
</details>

<details>
 <summary>Safari</summary>
 
  https://github.com/user-attachments/assets/44e7dae8-a0a5-4bae-9ec6-bea241d32e2e
</details>


