### PR TITLE
[v3] avoid focus-visible style being cut off by overflow hidden

### DIFF
--- a/.changeset/warm-glasses-smile.md
+++ b/.changeset/warm-glasses-smile.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+avoid focus-visible style being cut off by overflow-hidden

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -191,7 +191,7 @@ const config: DocsThemeConfig = {
   },
   toc: {
     extraContent: (
-      <img alt="placeholder cat" src="https://placekitten.com/g/300/200" />
+      <img alt="placeholder cat" src="https://placecats.com/300/200" />
     ),
     float: true
   }

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -183,7 +183,7 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
           )}
         />
       </ComponentToUse>
-      <Collapse className="ltr:_pr-0 rtl:_pl-0 _pt-1" isOpen={open}>
+      <Collapse className="_p-1" isOpen={open}>
         {Array.isArray(item.children) ? (
           <Menu
             className={cn(classes.border, 'ltr:_ml-3 rtl:_mr-3')}
@@ -400,22 +400,18 @@ export function Sidebar({
           </div>
         )}
         <FocusedItemContext.Provider value={focused}>
-          <OnFocusItemContext.Provider
-            value={item => {
-              setFocused(item)
-            }}
-          >
+          <OnFocusItemContext.Provider value={setFocused}>
             <div
               className={cn(
                 '_overflow-y-auto _overflow-x-hidden',
-                '_p-4 _grow md:_h-[calc(100vh-var(--nextra-navbar-height)-var(--nextra-menu-height))]',
+                '_grow md:_h-[calc(100vh-var(--nextra-navbar-height)-var(--nextra-menu-height))]',
                 showSidebar ? 'nextra-scrollbar' : 'no-scrollbar'
               )}
               ref={sidebarRef}
             >
               {/* without asPopover check <Collapse />'s inner.clientWidth on `layout: "raw"` will be 0 and element will not have width on initial loading */}
               {(!asPopover || !showSidebar) && (
-                <Collapse isOpen={showSidebar} horizontal>
+                <Collapse isOpen={showSidebar} horizontal className="_p-4">
                   <Menu
                     className="nextra-menu-desktop max-md:_hidden"
                     // The sidebar menu, shows only the docs directories.

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -57,7 +57,7 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
   return (
     <div
       className={cn(
-        'nextra-scrollbar _sticky _top-16 _overflow-y-auto _pr-4 _pt-6 _text-sm [hyphens:auto]',
+        'nextra-scrollbar _sticky _top-16 _overflow-y-auto _px-4 _pt-6 _text-sm [hyphens:auto]',
         '_max-h-[calc(100vh-var(--nextra-navbar-height)-env(safe-area-inset-bottom))] ltr:_-mr-4 rtl:_-ml-4'
       )}
     >

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -370,7 +370,7 @@ const DEFAULT_COMPONENTS: MDXComponents = {
         )
       ) : (
         <nav
-          className={cn(classes.toc, '_pr-4')}
+          className={cn(classes.toc, 'ltr:_pr-4 rtl:_pl-4')}
           aria-label="table of contents"
         >
           {renderComponent(themeConfig.toc.component, {

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -370,7 +370,7 @@ const DEFAULT_COMPONENTS: MDXComponents = {
         )
       ) : (
         <nav
-          className={cn(classes.toc, '_px-4')}
+          className={cn(classes.toc, '_pr-4')}
           aria-label="table of contents"
         >
           {renderComponent(themeConfig.toc.component, {

--- a/packages/nextra/src/client/components/tabs.tsx
+++ b/packages/nextra/src/client/components/tabs.tsx
@@ -90,6 +90,7 @@ function Tabs_({
                 disabled={disabled}
                 className={({ selected }) =>
                   cn(
+                    index === 0 && '_ml-1', // avoid focus-visible style being cut off
                     '_mr-2 _rounded-t _p-2 _font-medium _leading-5 _transition-colors',
                     '_-mb-0.5 _select-none _border-b-2',
                     selected


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/1432

## Description

I noticed some adjustments to the focus-visible style in [Auth.js](https://authjs.dev/) related to Nextra, such as:

- [tab button](https://github.com/nextauthjs/next-auth/blob/538333d86e93e0e4019d117d07741e02f9581c2b/docs/pages/global.css#L177-L180)
- [sidebar](https://github.com/nextauthjs/next-auth/blob/538333d86e93e0e4019d117d07741e02f9581c2b/docs/pages/global.css#L207-L210)

I think these adjustments could be applied more comprehensively within Nextra. For instance, Auth.js only targets the focus-visible style of the first-level sidebar items and the focus-visible style is not working well in the TOC either.

![image](https://github.com/user-attachments/assets/84102d53-bc52-450b-b45a-c52ca38e31dd)

![image](https://github.com/user-attachments/assets/2a7993f3-fa17-4128-8cc8-b8038528d9f5)

![image](https://github.com/user-attachments/assets/d59ae73d-f0f0-40a0-8e40-eaab27393d6e)

## Screenshots

**Sidebar**

![image](https://github.com/user-attachments/assets/a13a79e9-8cb6-42ff-8319-86953c62ea67)

![image](https://github.com/user-attachments/assets/012aa449-e212-44af-9a1c-a255ab08485a)

**Tabs**

![image](https://github.com/user-attachments/assets/9cfb4eac-868d-4cf2-a788-e2cc52ae8406)

**TOC**

![image](https://github.com/user-attachments/assets/19e5628e-1fd9-4eb9-a63c-2475feec0c58)

![image](https://github.com/user-attachments/assets/bef9eae5-aa25-4ecf-acc2-70a7b869ba01)

**Direction: rtl**

![image](https://github.com/user-attachments/assets/72601311-e2b5-49c4-ab89-8e2626ea1956)

![image](https://github.com/user-attachments/assets/c4ae613f-ced7-4670-a377-fcca9829e43e)

