### PR TITLE
[v3] Avoid the sidebar collapse having unintended animations when `sidebar.autoCollapse` is set to `true`

### DIFF
--- a/.changeset/fair-hounds-watch.md
+++ b/.changeset/fair-hounds-watch.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Avoid the sidebar collapse having unintended animations when `sidebar.autoCollapse` is set to `true`.

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -191,7 +191,7 @@ const config: DocsThemeConfig = {
   },
   toc: {
     extraContent: (
-      <img alt="placeholder cat" src="https://placekitten.com/g/300/200" />
+      <img alt="placeholder cat" src="https://placecats.com/300/200" />
     ),
     float: true
   }

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -216,7 +216,7 @@ export function Search({
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement> | CompositionEvent<HTMLInputElement>) => {
       if (!compositionStateRef.current.compositioning) {
-        const { value } = e.target as HTMLInputElement
+        const { value } = e.currentTarget
         onChangeProp(value)
         setShow(Boolean(value))
         compositionStateRef.current.emitted = true

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -66,16 +66,17 @@ const classes = {
 type FolderProps = {
   item: PageItem | MenuItem | Item
   anchors: Heading[]
+  onFocus: FocusEventHandler
 }
 
-function FolderImpl({ item, anchors }: FolderProps): ReactElement {
+function FolderImpl({ item, anchors, onFocus }: FolderProps): ReactElement {
   const routeOriginal = useFSRoute()
   const [route] = routeOriginal.split('#')
   const active = [route, route + '/'].includes(item.route + '/')
   const activeRouteInside = active || route.startsWith(item.route + '/')
 
   const focusedRoute = useContext(FocusedItemContext)
-  const focusedRouteInside = !!focusedRoute?.startsWith(item.route + '/')
+  const focusedRouteInside = focusedRoute.startsWith(item.route + '/')
   const level = useContext(FolderLevelContext)
 
   const { setMenu } = useMenu()
@@ -95,18 +96,20 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
   const rerender = useState({})[1]
 
   useEffect(() => {
-    const updateTreeState = () => {
+    function updateTreeState() {
       if (activeRouteInside || focusedRouteInside) {
         TreeState[item.route] = true
       }
     }
-    const updateAndPruneTreeState = () => {
+
+    function updateAndPruneTreeState() {
       if (activeRouteInside && focusedRouteInside) {
         TreeState[item.route] = true
       } else {
         delete TreeState[item.route]
       }
     }
+
     if (themeConfig.sidebar.autoCollapse) {
       updateAndPruneTreeState()
     } else {
@@ -145,6 +148,7 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
     <li className={cn({ open, active })}>
       <ComponentToUse
         href={isLink ? item.route : undefined}
+        data-href={isLink ? undefined : item.route}
         className={cn(
           '_items-center _justify-between _gap-2',
           !isLink && '_text-left _w-full',
@@ -173,6 +177,7 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
           TreeState[item.route] = !open
           rerender({})
         }}
+        onFocus={onFocus}
       >
         {item.title}
         <ArrowRightIcon
@@ -183,15 +188,15 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
           )}
         />
       </ComponentToUse>
-      <Collapse className="ltr:_pr-0 rtl:_pl-0 _pt-1" isOpen={open}>
-        {Array.isArray(item.children) ? (
+      <Collapse className="_pt-1" isOpen={open}>
+        {Array.isArray(item.children) && (
           <Menu
             className={cn(classes.border, 'ltr:_ml-3 rtl:_mr-3')}
             directories={item.children}
             base={item.route}
             anchors={anchors}
           />
-        ) : null}
+        )}
       </Collapse>
     </li>
   )
@@ -218,13 +223,14 @@ function Separator({ title }: { title: string }): ReactElement {
 
 function File({
   item,
-  anchors
+  anchors,
+  onFocus
 }: {
   item: PageItem | Item
   anchors: Heading[]
+  onFocus: FocusEventHandler
 }): ReactElement {
   const route = useFSRoute()
-  const onFocus = useContext(OnFocusItemContext)
 
   // It is possible that the item doesn't have any route - for example an external link.
   const active = item.route && [route, route + '/'].includes(item.route + '/')
@@ -244,12 +250,7 @@ function File({
         onClick={() => {
           setMenu(false)
         }}
-        onFocus={() => {
-          onFocus?.(item.route)
-        }}
-        onBlur={() => {
-          onFocus?.(null)
-        }}
+        onFocus={onFocus}
       >
         {item.title}
       </Anchor>
@@ -324,7 +325,7 @@ export function Sidebar({
   includePlaceholder
 }: SideBarProps): ReactElement {
   const { menu, setMenu } = useMenu()
-  const [focused, setFocused] = useState<null | string>(null)
+  const [focused, setFocused] = useState('')
   const [showSidebar, setSidebar] = useState(true)
   const [showToggleAnimation, setToggleAnimation] = useState(false)
 
@@ -400,11 +401,7 @@ export function Sidebar({
           </div>
         )}
         <FocusedItemContext.Provider value={focused}>
-          <OnFocusItemContext.Provider
-            value={item => {
-              setFocused(item)
-            }}
-          >
+          <OnFocusItemContext.Provider value={setFocused}>
             <div
               className={cn(
                 '_overflow-y-auto _overflow-x-hidden',

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -96,17 +96,19 @@ function FolderImpl({ item, anchors, onFocus }: FolderProps): ReactElement {
   const rerender = useState({})[1]
 
   useEffect(() => {
+    const route = item.route
+
     function updateTreeState() {
       if (activeRouteInside || focusedRouteInside) {
-        TreeState[item.route] = true
+        TreeState[route] = true
       }
     }
 
     function updateAndPruneTreeState() {
       if (activeRouteInside && focusedRouteInside) {
-        TreeState[item.route] = true
+        TreeState[route] = true
       } else {
-        delete TreeState[item.route]
+        delete TreeState[route]
       }
     }
 

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -3,10 +3,12 @@ import type { Heading } from 'nextra'
 import { useFSRoute, useMounted } from 'nextra/hooks'
 import { ArrowRightIcon, ExpandIcon } from 'nextra/icons'
 import type { Item, MenuItem, PageItem } from 'nextra/normalize-pages'
-import type { ReactElement } from 'react'
 import {
   createContext,
+  FocusEventHandler,
   memo,
+  ReactElement,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -22,11 +24,9 @@ import { LocaleSwitch } from './locale-switch'
 
 const TreeState: Record<string, boolean> = Object.create(null)
 
-const FocusedItemContext = createContext<null | string>(null)
+const FocusedItemContext = createContext('')
 FocusedItemContext.displayName = 'FocusedItem'
-const OnFocusItemContext = createContext<null | ((item: string | null) => any)>(
-  null
-)
+const OnFocusItemContext = createContext<(route: string) => void>(() => {})
 OnFocusItemContext.displayName = 'OnFocusItem'
 const FolderLevelContext = createContext(0)
 FolderLevelContext.displayName = 'FolderLevel'

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -3,11 +3,10 @@ import type { Heading } from 'nextra'
 import { useFSRoute, useMounted } from 'nextra/hooks'
 import { ArrowRightIcon, ExpandIcon } from 'nextra/icons'
 import type { Item, MenuItem, PageItem } from 'nextra/normalize-pages'
+import type { FocusEventHandler, ReactElement } from 'react'
 import {
   createContext,
-  FocusEventHandler,
   memo,
-  ReactElement,
   useCallback,
   useContext,
   useEffect,
@@ -96,19 +95,17 @@ function FolderImpl({ item, anchors, onFocus }: FolderProps): ReactElement {
   const rerender = useState({})[1]
 
   useEffect(() => {
-    const route = item.route
-
     function updateTreeState() {
       if (activeRouteInside || focusedRouteInside) {
-        TreeState[route] = true
+        TreeState[item.route] = true
       }
     }
 
     function updateAndPruneTreeState() {
       if (activeRouteInside && focusedRouteInside) {
-        TreeState[route] = true
+        TreeState[item.route] = true
       } else {
-        delete TreeState[route]
+        delete TreeState[item.route]
       }
     }
 
@@ -297,13 +294,16 @@ function Menu({
 }: MenuProps): ReactElement {
   const onFocus = useContext(OnFocusItemContext)
 
-  const handleFocus: FocusEventHandler = useCallback(event => {
-    const route =
-      event.target.getAttribute('href') ||
-      event.target.getAttribute('data-href') ||
-      ''
-    onFocus(route)
-  }, [])
+  const handleFocus: FocusEventHandler = useCallback(
+    event => {
+      const route =
+        event.target.getAttribute('href') ||
+        event.target.getAttribute('data-href') ||
+        ''
+      onFocus(route)
+    },
+    [onFocus]
+  )
 
   return (
     <ul className={cn(classes.list, className)}>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -293,18 +293,36 @@ function Menu({
   className,
   onlyCurrentDocs
 }: MenuProps): ReactElement {
+  const onFocus = useContext(OnFocusItemContext)
+
+  const handleFocus: FocusEventHandler = useCallback(event => {
+    const route =
+      event.target.getAttribute('href') ||
+      event.target.getAttribute('data-href') ||
+      ''
+    onFocus(route)
+  }, [])
+
   return (
     <ul className={cn(classes.list, className)}>
-      {directories.map(item =>
-        !onlyCurrentDocs || item.isUnderCurrentDocsTree ? (
+      {directories.map(item => {
+        if (onlyCurrentDocs && !item.isUnderCurrentDocsTree) return
+
+        const ComponentToUse =
           item.type === 'menu' ||
-          (item.children && (item.children.length || !item.withIndexPage)) ? (
-            <Folder key={item.name} item={item} anchors={anchors} />
-          ) : (
-            <File key={item.name} item={item} anchors={anchors} />
-          )
-        ) : null
-      )}
+          (item.children && (item.children.length || !item.withIndexPage))
+            ? Folder
+            : File
+
+        return (
+          <ComponentToUse
+            key={item.name}
+            item={item}
+            anchors={anchors}
+            onFocus={handleFocus}
+          />
+        )
+      })}
     </ul>
   )
 }


### PR DESCRIPTION
another approach to fix https://github.com/shuding/nextra/pull/3150 because I think adding `sidebarEl.addEventListener` / `sidebarEl.removeEventListener` makes things complex – we can ignore the case when the folder will not be closed when switching to the locale switch for example

cc @87xie wdyt

https://github.com/user-attachments/assets/71730838-90d8-4de7-aeff-78f654aa4b04


