### PR TITLE
[v3] remove intersection-observer polyfill

### DIFF
--- a/.changeset/clever-dots-unite.md
+++ b/.changeset/clever-dots-unite.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Remove intersection-observer polyfill

--- a/examples/swr-site/components/video.tsx
+++ b/examples/swr-site/components/video.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useInView } from 'react-intersection-observer'
-import 'intersection-observer'
 
 export default function Video({ src, caption, ratio }) {
   const [inViewRef, inView] = useInView({ threshold: 1 })

--- a/examples/swr-site/package.json
+++ b/examples/swr-site/package.json
@@ -16,7 +16,6 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
-    "intersection-observer": "^0.10.0",
     "markdown-to-jsx": "^6.11.4",
     "next": "^14.2.5",
     "nextra": "workspace:*",

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -41,7 +41,6 @@
     "clsx": "^2.0.0",
     "escape-string-regexp": "^5.0.0",
     "flexsearch": "^0.7.43",
-    "intersection-observer": "^0.12.2",
     "next-themes": "^0.3.0",
     "scroll-into-view-if-needed": "^3.1.0",
     "zod": "^3.22.3"

--- a/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
+++ b/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
@@ -1,5 +1,4 @@
 import type { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react'
-import 'intersection-observer'
 import { createContext, useContext, useRef, useState } from 'react'
 import { IS_BROWSER } from '../constants'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         version: file:packages/nextra(@types/react@18.3.5)(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.4)
       nextra-theme-blog:
         specifier: workspace:*
-        version: file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.34)(react-dom@18.3.1)(react@18.3.1)
+        version: file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.35)(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -173,7 +173,7 @@ importers:
         version: file:packages/nextra(@types/react@18.3.5)(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.4)
       nextra-theme-docs:
         specifier: workspace:*
-        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.34)(react-dom@18.3.1)(react@18.3.1)
+        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.35)(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -188,9 +188,6 @@ importers:
 
   examples/swr-site:
     dependencies:
-      intersection-observer:
-        specifier: ^0.10.0
-        version: 0.10.0
       markdown-to-jsx:
         specifier: ^6.11.4
         version: 6.11.4(react@18.3.1)
@@ -202,7 +199,7 @@ importers:
         version: file:packages/nextra(@types/react@18.3.5)(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.4)
       nextra-theme-docs:
         specifier: workspace:*
-        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.34)(react-dom@18.3.1)(react@18.3.1)
+        version: file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.35)(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -451,9 +448,6 @@ importers:
       flexsearch:
         specifier: ^0.7.43
         version: 0.7.43
-      intersection-observer:
-        specifier: ^0.12.2
-        version: 0.12.2
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1)(react@18.3.1)
@@ -8733,14 +8727,6 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /intersection-observer@0.10.0:
-    resolution: {integrity: sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==}
-    dev: false
-
-  /intersection-observer@0.12.2:
-    resolution: {integrity: sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==}
-    dev: false
-
   /is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
     dev: false
@@ -13601,7 +13587,7 @@ packages:
       - typescript
     dev: false
 
-  file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.34)(react-dom@18.3.1)(react@18.3.1):
+  file:packages/nextra-theme-blog(next@14.2.5)(nextra@3.0.0-alpha.35)(react-dom@18.3.1)(react@18.3.1):
     resolution: {directory: packages/nextra-theme-blog, type: directory}
     id: file:packages/nextra-theme-blog
     name: nextra-theme-blog
@@ -13622,7 +13608,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.34)(react-dom@18.3.1)(react@18.3.1):
+  file:packages/nextra-theme-docs(next@14.2.5)(nextra@3.0.0-alpha.35)(react-dom@18.3.1)(react@18.3.1):
     resolution: {directory: packages/nextra-theme-docs, type: directory}
     id: file:packages/nextra-theme-docs
     name: nextra-theme-docs
@@ -13637,7 +13623,6 @@ packages:
       clsx: 2.1.1
       escape-string-regexp: 5.0.0
       flexsearch: 0.7.43
-      intersection-observer: 0.12.2
       next: 14.2.5(@babel/core@7.24.3)(react-dom@18.3.1)(react@18.3.1)
       next-themes: 0.3.0(react-dom@18.3.1)(react@18.3.1)
       nextra: file:packages/nextra(@types/react@18.3.5)(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)(typescript@5.5.4)


### PR DESCRIPTION
## Description

Nextra v3 requires Next.js >= 13. Based on the [Supported Browsers](https://github.com/vercel/next.js/pull/41529/files#diff-7e079a6684a14ec2884b491ffdb0ae0f1a61e68e8127b4e00e71acf214f4a98d) for Next.js 13, it seems that most users don't need `intersection-observer` polyfill.

Is it a good opportunity to remove this dependency in v3? If users require support for older browsers, we can suggest they import it in `_app.tsx`.