### PR TITLE
[v3] fix first item in `FileTree` not within permitted parent element

### DIFF
--- a/.changeset/empty-bottles-study.md
+++ b/.changeset/empty-bottles-study.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+Fix first list item in `<FileTree>` not within permitted parent elements

--- a/packages/nextra/src/client/components/file-tree.tsx
+++ b/packages/nextra/src/client/components/file-tree.tsx
@@ -31,9 +31,9 @@ function Tree({ children }: { children: ReactNode }): ReactElement {
         '_not-prose' // for nextra-theme-blog
       )}
     >
-      <div className="_inline-block _rounded-lg _border _px-4 _py-2 dark:_border-neutral-800">
+      <ul className="_inline-block _rounded-lg _border _px-4 _py-2 dark:_border-neutral-800">
         {children}
-      </div>
+      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Description

Currently, `<FileTree>` wraps its children with a `<div>`, while `<FileTree.Folder>` is represented as a list item `<li>`. This results in the list item not being placed within permitted parent elements. This change ensures that `<FileTree.Folder>` is appropriately nested within an `<ul>` element.

**after**

![image](https://github.com/user-attachments/assets/d30e01a1-3e62-494e-93a5-d2fd18c442d2)

![image](https://github.com/user-attachments/assets/3463bce9-54c9-42b4-b392-e1dba612bec2)

Additionally, does the border color of `<FileTree>` in dark mode need better contrast?