### PR TITLE
[v3] consider navbar height for the anchor intersection observer

### DIFF
--- a/.changeset/red-squids-enjoy.md
+++ b/.changeset/red-squids-enjoy.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Consider the navbar height when setting the root margin for the active anchor intersection observer

--- a/packages/nextra-theme-docs/src/components/head.tsx
+++ b/packages/nextra-theme-docs/src/components/head.tsx
@@ -56,7 +56,7 @@ export function Head(): ReactElement {
         name="viewport"
         content="width=device-width, initial-scale=1.0, viewport-fit=cover"
       />
-      <style>{`:root{--nextra-primary-hue:${lightHue}deg;--nextra-primary-saturation:${lightSaturation}%;--nextra-navbar-height:4rem;--nextra-menu-height:3.75rem;--nextra-banner-height:2.5rem;--nextra-bg:${bgColor.light};}.dark{--nextra-primary-hue:${darkHue}deg;--nextra-primary-saturation:${darkSaturation}%;--nextra-bg:${bgColor.dark};}`}</style>
+      <style>{`:root{--nextra-primary-hue:${lightHue}deg;--nextra-primary-saturation:${lightSaturation}%;--nextra-navbar-height:64px;--nextra-menu-height:3.75rem;--nextra-banner-height:2.5rem;--nextra-bg:${bgColor.light};}.dark{--nextra-primary-hue:${darkHue}deg;--nextra-primary-saturation:${darkSaturation}%;--nextra-bg:${bgColor.dark};}`}</style>
       {head}
     </NextHead>
   )

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -17,8 +17,6 @@ import { getGitIssueUrl, useGitEditUrl } from './utils'
 
 export const DEFAULT_LOCALE = 'en-US'
 
-export const IS_BROWSER = typeof window !== 'undefined'
-
 export type DocsThemeConfig = z.infer<typeof themeSchema>
 export type PartialDocsThemeConfig = z.infer<typeof publicThemeSchema>
 

--- a/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
+++ b/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
@@ -11,12 +11,12 @@ type ActiveAnchor = Record<
   }
 >
 
-const ActiveAnchorContext = createContext<ActiveAnchor>({})
+const ActiveAnchorContext = createContext<ActiveAnchor>(null!)
 ActiveAnchorContext.displayName = 'ActiveAnchor'
 
 const SetActiveAnchorContext = createContext<
   Dispatch<SetStateAction<ActiveAnchor>>
->(v => v)
+>(null!)
 SetActiveAnchorContext.displayName = 'SetActiveAnchor'
 
 const IntersectionObserverContext = createContext<IntersectionObserver | null>(
@@ -41,14 +41,12 @@ export const ActiveAnchorProvider = ({
   children: ReactNode
 }): ReactElement => {
   const [activeAnchor, setActiveAnchor] = useState<ActiveAnchor>({})
-  const observerRef = useRef<IntersectionObserver | null>(null)
+  const observerRef = useRef<IntersectionObserver>(null!)
 
   useEffect(() => {
-    if (observerRef.current) return
-    const nextraContentEl = document.querySelector<HTMLElement>('.nextra-content')
-    const rootMarginTop = nextraContentEl
-      ? `${0 - nextraContentEl.offsetTop}px`
-      : '0px'
+    const navbarHeight = getComputedStyle(document.body).getPropertyValue(
+      '--nextra-navbar-height'
+    )
     observerRef.current = new IntersectionObserver(
       entries => {
         setActiveAnchor(f => {
@@ -96,14 +94,13 @@ export const ActiveAnchorProvider = ({
         })
       },
       {
-        rootMargin: `${rootMarginTop} 0px -50%`,
+        rootMargin: `-${navbarHeight} 0px -50%`,
         threshold: [0, 1]
       }
     )
 
     return () => {
-      observerRef.current?.disconnect()
-      observerRef.current = null
+      observerRef.current.disconnect()
     }
   }, [])
   return (

--- a/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
+++ b/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
@@ -1,6 +1,5 @@
 import type { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react'
-import { createContext, useContext, useRef, useState } from 'react'
-import { IS_BROWSER } from '../constants'
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
 
 type ActiveAnchor = Record<
   string,
@@ -43,7 +42,13 @@ export const ActiveAnchorProvider = ({
 }): ReactElement => {
   const [activeAnchor, setActiveAnchor] = useState<ActiveAnchor>({})
   const observerRef = useRef<IntersectionObserver | null>(null)
-  if (IS_BROWSER && !observerRef.current) {
+
+  useEffect(() => {
+    if (observerRef.current) return
+    const nextraContentEl = document.querySelector<HTMLElement>('.nextra-content')
+    const rootMarginTop = nextraContentEl
+      ? `${0 - nextraContentEl.offsetTop}px`
+      : 0
     observerRef.current = new IntersectionObserver(
       entries => {
         setActiveAnchor(f => {
@@ -91,11 +96,16 @@ export const ActiveAnchorProvider = ({
         })
       },
       {
-        rootMargin: '0px 0px -50%',
+        rootMargin: `${rootMarginTop} 0px -50%`,
         threshold: [0, 1]
       }
     )
-  }
+
+    return () => {
+      observerRef.current?.disconnect()
+      observerRef.current = null
+    }
+  }, [])
   return (
     <ActiveAnchorContext.Provider value={activeAnchor}>
       <SetActiveAnchorContext.Provider value={setActiveAnchor}>

--- a/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
+++ b/packages/nextra-theme-docs/src/contexts/active-anchor.tsx
@@ -48,7 +48,7 @@ export const ActiveAnchorProvider = ({
     const nextraContentEl = document.querySelector<HTMLElement>('.nextra-content')
     const rootMarginTop = nextraContentEl
       ? `${0 - nextraContentEl.offsetTop}px`
-      : 0
+      : '0px'
     observerRef.current = new IntersectionObserver(
       entries => {
         setActiveAnchor(f => {

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -44,14 +44,13 @@ const createHeading = (
     const obRef = useRef<HTMLAnchorElement>(null)
 
     useEffect(() => {
-      if (!id) return
       const heading = obRef.current
-      if (!heading) return
+      if (!id || !observer || !heading) return
+      observer.observe(heading)
       slugs.set(heading, [id, (context.index += 1)])
-      observer?.observe(heading)
 
       return () => {
-        observer?.disconnect()
+        observer.disconnect()
         slugs.delete(heading)
         setActiveAnchor(f => {
           const ret = { ...f }


### PR DESCRIPTION
## Description

This change aims to resolve the issue shown below the image:
1. When I click the `href=“#two”` link in the table of contents (TOC),
1. The URL updates, and the page scrolls to the corresponding anchor,
1. However, the active style in the TOC stays on the link before `href=“#two”`.

![image](https://github.com/user-attachments/assets/b4137aec-f7b9-4e85-b743-8d695f67c1e4)

## How

I think the intersection area should be restricted to below the navbar height, aligning it more closely with the user's visible area.

The current implementation in this PR uses `document.querySelector('.nextra-content')`, which may not be the best approach. If we could move the `<ActiveAnchorProvider>` into the `<NextraWrapper>` in the MDX components and obtain the corresponding DOM reference for `.nextra-content` through a ref, it might provide better consistency and more closely align with its actual scope of effect.

Feel free to close this if I missed something obvious.

**After this change**

https://github.com/user-attachments/assets/5aaa6e5e-7af6-4c4a-a241-8f227c36022e

