### PR TITLE
[v3] remove aria-hidden attr when scroll-to-top button is visible

### DIFF
--- a/.changeset/few-snails-occur.md
+++ b/.changeset/few-snails-occur.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Remove the aria-hidden attribute from scroll-to-top button when it is visible

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -26,6 +26,7 @@ export function BackToTop({
 }): ReactElement {
   return (
     <Button
+      // elements with `aria-hidden: true` must not be focusable or contain focusable elements
       aria-hidden={hidden ? 'true' : undefined}
       onClick={scrollToTop}
       disabled={hidden}

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -26,7 +26,7 @@ export function BackToTop({
 }): ReactElement {
   return (
     <Button
-      aria-hidden="true"
+      aria-hidden={hidden ? 'true' : undefined}
       onClick={scrollToTop}
       disabled={hidden}
       className={({ disabled }) =>


### PR DESCRIPTION
## Description

A small fix to correctly use the `aria-hidden` attribute, as referenced by [this guideline](https://dequeuniversity.com/rules/axe/4.9/aria-hidden-focus): elements with `aria-hidden: true` must not be focusable.