### PR TITLE
[v3] update the back-to-top option to support i18n

### DIFF
--- a/.changeset/slimy-vans-rush.md
+++ b/.changeset/slimy-vans-rush.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Update the `backToTop` option in the docs theme configuration to support i18n

--- a/.changeset/wild-windows-grow.md
+++ b/.changeset/wild-windows-grow.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+keep `loading`, `placeholder` and `themeSwitch.useOptions` default theme options only for `en` lang

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -534,7 +534,11 @@ navigating between headings.
       'React.ReactNode | React.FC',
       'Title of the TOC sidebar. By default it’s “On This Page”.'
     ],
-    ['toc.backToTop', 'boolean', 'Add `Scroll to top` link.']
+    [
+      'toc.backToTop',
+      'React.ReactNode | React.FC',
+      'Text of `Scroll to top` button.'
+    ]
   ]}
 />
 

--- a/examples/swr-site/next-env.d.ts
+++ b/examples/swr-site/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -195,7 +195,7 @@ const config: DocsThemeConfig = {
       return {
         en: 'Scroll to top',
         es: 'Desplazarse hacia arriba',
-        ru: 'Перейти наверх',
+        ru: 'Перейти наверх'
       }[locale!]
     },
     extraContent: (

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -190,12 +190,12 @@ const config: DocsThemeConfig = {
     toggleButton: true
   },
   toc: {
-    backToTop() {
+    backToTop: function BackToTop() {
       const { locale } = useRouter()
       return {
-        ru: 'Перейти наверх',
+        en: 'Scroll to top',
         es: 'Desplazarse hacia arriba',
-        en: 'Scroll to top'
+        ru: 'Перейти наверх',
       }[locale!]
     },
     extraContent: (

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -62,18 +62,6 @@ const FOOTER_LINK_TEXT = {
 }
 
 const config: DocsThemeConfig = {
-  backToTop: {
-    text: (locale: string) => {
-      switch (locale) {
-        case 'ru':
-          return 'Перейти наверх'
-        case 'es':
-          return 'Desplazarse hacia arriba'
-        default:
-          return 'Scroll to top'
-      }
-    }
-  },
   backgroundColor: {
     dark: '15,23,42',
     light: '254,252,232'
@@ -202,6 +190,14 @@ const config: DocsThemeConfig = {
     toggleButton: true
   },
   toc: {
+    backToTop() {
+      const { locale } = useRouter()
+      return {
+        ru: 'Перейти наверх',
+        es: 'Desplazarse hacia arriba',
+        en: 'Scroll to top'
+      }[locale!]
+    },
     extraContent: (
       <img alt="placeholder cat" src="https://placecats.com/300/200" />
     ),

--- a/examples/swr-site/theme.config.tsx
+++ b/examples/swr-site/theme.config.tsx
@@ -62,6 +62,18 @@ const FOOTER_LINK_TEXT = {
 }
 
 const config: DocsThemeConfig = {
+  backToTop: {
+    text: (locale: string) => {
+      switch (locale) {
+        case 'ru':
+          return 'Перейти наверх'
+        case 'es':
+          return 'Desplazarse hacia arriba'
+        default:
+          return 'Scroll to top'
+      }
+    }
+  },
   backgroundColor: {
     dark: '15,23,42',
     light: '254,252,232'

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -1,5 +1,6 @@
 import cn from 'clsx'
 import { Button } from 'nextra/components'
+import { ArrowRightIcon } from 'nextra/icons'
 import type { ComponentProps, ReactElement, ReactNode } from 'react'
 
 const SCROLL_TO_OPTIONS = { top: 0, behavior: 'smooth' } as const
@@ -22,7 +23,7 @@ export function BackToTop({
   hidden
 }: {
   children: ReactNode
-  className: string
+  className?: string
   hidden: boolean
 }): ReactElement {
   return (
@@ -40,6 +41,10 @@ export function BackToTop({
       }
     >
       {children}
+      <ArrowRightIcon
+        height="16"
+        className="_-rotate-90 _border _rounded-full _border-current"
+      />
     </Button>
   )
 }

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -1,7 +1,6 @@
 import cn from 'clsx'
 import { Button } from 'nextra/components'
-import { ArrowRightIcon } from 'nextra/icons'
-import type { ComponentProps, ReactElement } from 'react'
+import type { ComponentProps, ReactElement, ReactNode } from 'react'
 
 const SCROLL_TO_OPTIONS = { top: 0, behavior: 'smooth' } as const
 
@@ -18,10 +17,12 @@ const scrollToTop: ComponentProps<'button'>['onClick'] = event => {
 }
 
 export function BackToTop({
+  children,
   className,
   hidden
 }: {
-  className?: string
+  children: ReactNode
+  className: string
   hidden: boolean
 }): ReactElement {
   return (
@@ -38,11 +39,7 @@ export function BackToTop({
         )
       }
     >
-      Scroll to top
-      <ArrowRightIcon
-        height="16"
-        className="_-rotate-90 _border _rounded-full _border-current"
-      />
+      {children}
     </Button>
   )
 }

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -31,7 +31,7 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
     themeConfig.feedback.content ||
       themeConfig.editLink.component ||
       themeConfig.toc.extraContent ||
-      themeConfig.backToTop.content
+      themeConfig.toc.backToTop
   )
 
   const activeSlug = Object.entries(activeAnchor).find(
@@ -121,9 +121,9 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
 
           {renderComponent(themeConfig.toc.extraContent)}
 
-          {themeConfig.backToTop.content && (
+          {themeConfig.toc.backToTop && (
             <BackToTop className={linkClassName} hidden={activeIndex < 2}>
-              {renderComponent(themeConfig.backToTop.content)}
+              {renderComponent(themeConfig.toc.backToTop)}
             </BackToTop>
           )}
         </div>

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -31,7 +31,7 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
     themeConfig.feedback.content ||
       themeConfig.editLink.component ||
       themeConfig.toc.extraContent ||
-      themeConfig.toc.backToTop
+      themeConfig.backToTop.content
   )
 
   const activeSlug = Object.entries(activeAnchor).find(
@@ -121,8 +121,10 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
 
           {renderComponent(themeConfig.toc.extraContent)}
 
-          {themeConfig.toc.backToTop && (
-            <BackToTop className={linkClassName} hidden={activeIndex < 2} />
+          {themeConfig.backToTop.content && (
+            <BackToTop className={linkClassName} hidden={activeIndex < 2}>
+              {renderComponent(themeConfig.backToTop.content)}
+            </BackToTop>
           )}
         </div>
       )}

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -25,28 +25,13 @@ export const DEFAULT_LOCALE = 'en-US'
 export type DocsThemeConfig = z.infer<typeof themeSchema>
 export type PartialDocsThemeConfig = z.infer<typeof publicThemeSchema>
 
-const LOADING_LOCALES: Record<string, string> = {
-  'en-US': 'Loading',
-  fr: 'Сhargement',
-  ru: 'Загрузка',
-  'zh-CN': '正在加载'
-}
-
-const PLACEHOLDER_LOCALES: Record<string, string> = {
-  'en-US': 'Search documentation',
-  fr: 'Rechercher documents',
-  ru: 'Поиск документации',
-  'zh-CN': '搜索文档'
-}
-
 export const DEFAULT_THEME: DocsThemeConfig = {
   backToTop: {
     content: function BackToTopContent() {
       const themeConfig = useThemeConfig()
-      const { locale = '' } = useRouter()
       return (
         <>
-          {renderString(themeConfig.backToTop.text, locale)}
+          {renderString(themeConfig.backToTop.text)}
           {renderComponent(themeConfig.backToTop.icon)}
         </>
       )
@@ -188,22 +173,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       </span>
     ),
     error: 'Failed to load search index.',
-    loading: function useLoading() {
-      const { locale, defaultLocale = DEFAULT_LOCALE } = useRouter()
-      const text =
-        (locale && LOADING_LOCALES[locale]) ||
-        LOADING_LOCALES[defaultLocale] ||
-        LOADING_LOCALES[DEFAULT_LOCALE]
-      return `${text}…`
-    },
-    placeholder: function usePlaceholder() {
-      const { locale, defaultLocale = DEFAULT_LOCALE } = useRouter()
-      const text =
-        (locale && PLACEHOLDER_LOCALES[locale]) ||
-        PLACEHOLDER_LOCALES[defaultLocale] ||
-        PLACEHOLDER_LOCALES[DEFAULT_LOCALE]
-      return `${text}…`
-    }
+    loading: 'Loading…',
+    placeholder: 'Search documentation…'
   },
   sidebar: {
     defaultMenuCollapseLevel: 2,
@@ -211,14 +182,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   },
   themeSwitch: {
     component: ThemeSwitch,
-    useOptions() {
-      const { locale } = useRouter()
-
-      if (locale === 'zh-CN') {
-        return { dark: '深色主题', light: '浅色主题', system: '系统默认' }
-      }
-      return { dark: 'Dark', light: 'Light', system: 'System' }
-    }
+    useOptions: { dark: 'Dark', light: 'Light', system: 'System' }
   },
   toc: {
     component: TOC,

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -1,6 +1,6 @@
 /* eslint sort-keys: error */
 import { useRouter } from 'nextra/hooks'
-import { ArrowRightIcon, DiscordIcon, GitHubIcon } from 'nextra/icons'
+import { DiscordIcon, GitHubIcon } from 'nextra/icons'
 import { isValidElement } from 'react'
 import type { z } from 'zod'
 import {
@@ -26,24 +26,6 @@ export type DocsThemeConfig = z.infer<typeof themeSchema>
 export type PartialDocsThemeConfig = z.infer<typeof publicThemeSchema>
 
 export const DEFAULT_THEME: DocsThemeConfig = {
-  backToTop: {
-    content: function BackToTopContent() {
-      const themeConfig = useThemeConfig()
-      return (
-        <>
-          {renderString(themeConfig.backToTop.text)}
-          {renderComponent(themeConfig.backToTop.icon)}
-        </>
-      )
-    },
-    icon: (
-      <ArrowRightIcon
-        height="16"
-        className="_-rotate-90 _border _rounded-full _border-current"
-      />
-    ),
-    text: 'Scroll to top'
-  },
   backgroundColor: {
     dark: '17,17,17',
     light: '250,250,250'
@@ -185,6 +167,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     useOptions: { dark: 'Dark', light: 'Light', system: 'System' }
   },
   toc: {
+    backToTop: 'Scroll to top',
     component: TOC,
     float: true,
     title: 'On This Page'

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -13,12 +13,7 @@ import {
 } from './components'
 import { useConfig, useThemeConfig } from './contexts'
 import type { publicThemeSchema, themeSchema } from './schemas'
-import {
-  getGitIssueUrl,
-  renderComponent,
-  renderString,
-  useGitEditUrl
-} from './utils'
+import { getGitIssueUrl, useGitEditUrl } from './utils'
 
 export const DEFAULT_LOCALE = 'en-US'
 

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -191,14 +191,17 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     loading: function useLoading() {
       const { locale, defaultLocale = DEFAULT_LOCALE } = useRouter()
       const text =
-        (locale && LOADING_LOCALES[locale]) || LOADING_LOCALES[defaultLocale]
-      return <>{text}…</>
+        (locale && LOADING_LOCALES[locale]) ||
+        LOADING_LOCALES[defaultLocale] ||
+        LOADING_LOCALES[DEFAULT_LOCALE]
+      return `${text}…`
     },
     placeholder: function usePlaceholder() {
       const { locale, defaultLocale = DEFAULT_LOCALE } = useRouter()
       const text =
         (locale && PLACEHOLDER_LOCALES[locale]) ||
-        PLACEHOLDER_LOCALES[defaultLocale]
+        PLACEHOLDER_LOCALES[defaultLocale] ||
+        PLACEHOLDER_LOCALES[DEFAULT_LOCALE]
       return `${text}…`
     }
   },

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -40,10 +40,6 @@ const PLACEHOLDER_LOCALES: Record<string, string> = {
 }
 
 export const DEFAULT_THEME: DocsThemeConfig = {
-  backgroundColor: {
-    dark: '17,17,17',
-    light: '250,250,250'
-  },
   backToTop: {
     content: function BackToTopContent() {
       const themeConfig = useThemeConfig()
@@ -55,13 +51,17 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         </>
       )
     },
-    text: 'Scroll to top',
     icon: (
       <ArrowRightIcon
         height="16"
         className="_-rotate-90 _border _rounded-full _border-current"
       />
-    )
+    ),
+    text: 'Scroll to top'
+  },
+  backgroundColor: {
+    dark: '17,17,17',
+    light: '250,250,250'
   },
   banner: {
     dismissible: true,

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -1,6 +1,6 @@
 /* eslint sort-keys: error */
-import { useRouter } from 'next/router'
-import { DiscordIcon, GitHubIcon } from 'nextra/icons'
+import { useRouter } from 'nextra/hooks'
+import { ArrowRightIcon, DiscordIcon, GitHubIcon } from 'nextra/icons'
 import { isValidElement } from 'react'
 import type { z } from 'zod'
 import {
@@ -13,7 +13,12 @@ import {
 } from './components'
 import { useConfig, useThemeConfig } from './contexts'
 import type { publicThemeSchema, themeSchema } from './schemas'
-import { getGitIssueUrl, useGitEditUrl } from './utils'
+import {
+  getGitIssueUrl,
+  renderComponent,
+  renderString,
+  useGitEditUrl
+} from './utils'
 
 export const DEFAULT_LOCALE = 'en-US'
 
@@ -38,6 +43,25 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   backgroundColor: {
     dark: '17,17,17',
     light: '250,250,250'
+  },
+  backToTop: {
+    content: function BackToTopContent() {
+      const themeConfig = useThemeConfig()
+      const { locale = '' } = useRouter()
+      return (
+        <>
+          {renderString(themeConfig.backToTop.text, locale)}
+          {renderComponent(themeConfig.backToTop.icon)}
+        </>
+      )
+    },
+    text: 'Scroll to top',
+    icon: (
+      <ArrowRightIcon
+        height="16"
+        className="_-rotate-90 _border _rounded-full _border-current"
+      />
+    )
   },
   banner: {
     dismissible: true,
@@ -194,7 +218,6 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     }
   },
   toc: {
-    backToTop: true,
     component: TOC,
     float: true,
     title: 'On This Page'

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -27,14 +27,6 @@ export const themeSchema = /* @__PURE__ */ (() =>
       dismissible: z.boolean(),
       key: z.string()
     }),
-    backToTop: z.strictObject({
-      content: z.custom<ReactNode | FC>(...reactNode).optional(),
-      text: z
-        .string()
-        .or(z.function().args(z.string()).returns(z.string()))
-        .optional(),
-      icon: z.custom<ReactNode | FC>(...reactNode).optional()
-    }),
     backgroundColor: z.strictObject({
       dark: z.string(),
       light: z.string()
@@ -134,6 +126,7 @@ export const themeSchema = /* @__PURE__ */ (() =>
       )
     }),
     toc: z.strictObject({
+      backToTop: z.custom<ReactNode | FC>(...reactNode),
       component: z.custom<ReactNode | FC<TOCProps>>(...reactNode),
       extraContent: z.custom<ReactNode | FC>(...reactNode),
       float: z.boolean(),

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -27,6 +27,14 @@ export const themeSchema = /* @__PURE__ */ (() =>
       dismissible: z.boolean(),
       key: z.string()
     }),
+    backToTop: z.strictObject({
+      content: z.custom<ReactNode | FC>(...reactNode).optional(),
+      text: z
+        .string()
+        .or(z.function().args(z.string()).returns(z.string()))
+        .optional(),
+      icon: z.custom<ReactNode | FC>(...reactNode).optional()
+    }),
     backgroundColor: z.strictObject({
       dark: z.string(),
       light: z.string()
@@ -126,7 +134,6 @@ export const themeSchema = /* @__PURE__ */ (() =>
       )
     }),
     toc: z.strictObject({
-      backToTop: z.boolean(),
       component: z.custom<ReactNode | FC<TOCProps>>(...reactNode),
       extraContent: z.custom<ReactNode | FC>(...reactNode),
       float: z.boolean(),


### PR DESCRIPTION
## Description

[#2308](https://github.com/shuding/nextra/issues/2308) seems to be planned for v3, but it hasn't been addressed yet (currently, there is  a PR #2895  for v2), so I would like to try to help.

I referenced the implementation of the `feedback` option and decided not to expose the `backToTop.component` option, as the `className` and `hidden` props might not be necessary for users.

Here's how the implementation allows users to control the text through `backToTop.text`, for example:

```ts
const themeConfig = {
  backToTop: {
    text: (locale: string) => {
      switch (locale) {
        case 'ru': return 'Перейти наверх'
        case 'es': return 'Desplazarse hacia arriba'
        default: return 'Scroll to top'
      }
    }
  }
}
```

Feel free to close this if it is not suitable.

## Screenshots

`locale: es`

![image](https://github.com/user-attachments/assets/c1ec92e8-42d2-4d9b-a4df-7aaf9588d88e)

`locale: en`

![image](https://github.com/user-attachments/assets/ecfd4684-e085-45c2-8c87-5b6820aa4c83)

