### PR TITLE
[v3] enhance focus ring style consistency

### DIFF
--- a/.changeset/shiny-dolphins-walk.md
+++ b/.changeset/shiny-dolphins-walk.md
@@ -1,0 +1,6 @@
+---
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+Enhance focus ring style consistency.

--- a/packages/nextra-theme-docs/css/styles.css
+++ b/packages/nextra-theme-docs/css/styles.css
@@ -30,6 +30,9 @@ body {
 .nextra-focusable,
 .nextra-focus:focus-visible {
   @apply _ring-2 _ring-primary-200 _ring-offset-1 _ring-offset-primary-300 dark:_ring-primary-800 dark:_ring-offset-primary-700;
+  &:is(a, summary) {
+    @apply _rounded;
+  }
 }
 
 .nextra-focusable,

--- a/packages/nextra-theme-docs/src/components/skip-nav.tsx
+++ b/packages/nextra-theme-docs/src/components/skip-nav.tsx
@@ -57,6 +57,7 @@ export const SkipNavLink = forwardRef<HTMLAnchorElement, SkipNavLinkProps>(
         ? styled // Give the user a way to opt-in the default style provided with the theme. Probably remove this option in the next major version (v3.x) and just do a check to use the providedClassName or the default
           ? cn(
               '_sr-only',
+              'nextra-focus',
               'focus:_not-sr-only focus:_fixed focus:_z-50 focus:_m-3 focus:_ml-4 focus:_h-[calc(var(--nextra-navbar-height)-1.5rem)] focus:_rounded-lg focus:_border focus:_px-3 focus:_py-2 focus:_align-middle focus:_text-sm focus:_font-bold',
               'focus:_text-gray-900 focus:dark:_text-gray-100',
               'focus:_bg-white focus:dark:_bg-neutral-900',

--- a/packages/nextra/src/client/components/tabs/tabs.tsx
+++ b/packages/nextra/src/client/components/tabs/tabs.tsx
@@ -101,9 +101,9 @@ export function Tabs({
           <HeadlessTab
             key={index}
             disabled={isTabObjectItem(item) && item.disabled}
-            className={({ selected, disabled, hover, focus }) =>
+            className={({ selected, disabled, hover }) =>
               cn(
-                focus && 'nextra-focusable _ring-inset',
+                'nextra-focus focus:_ring-inset',
                 '_whitespace-nowrap',
                 '_rounded-t _p-2 _font-medium _leading-5 _transition-colors',
                 '_-mb-0.5 _select-none _border-b-2',


### PR DESCRIPTION
## Description

Adjustments made in this PR:

- Apply focus ring style to `<SkipNav>`.
- Apply a `_rounded` style to `a` and `summary` tags when they are focus-visible, making them more consistent with the navbar's menu button. A similar style was present in the previous version [here](https://github.com/shuding/nextra/pull/3248/files#diff-9b96b3afc3b3cf2aa0292d40310cf7848a9f2fe45eeb026eabb34c7ec3a0b82aL41-L44).
- Adjusted the `<Tab>` class name to `nextra-focus focus:_ring` because the `focus` parameter in the `className` callback wasn't updating when `<Tab>` was clicked. This ensures compatibility with both keyboard navigation and click activation.

Feel free to close this If I missed something obvious.

## Screenshots

**Before**

![image](https://github.com/user-attachments/assets/5ff29437-cd19-43a0-b1c9-c9ce0730d74a)

![image](https://github.com/user-attachments/assets/1350d38f-7b3c-4b3a-814c-0a13ba0f345a)

![image](https://github.com/user-attachments/assets/2a7af6a2-09f7-45a0-8cd5-9f95ec3908ee)

https://github.com/user-attachments/assets/3ee62056-0fc1-4118-9b6a-bf24838c641e

**After**

https://github.com/user-attachments/assets/c91e9187-d483-4471-94c9-702e53e20112
