### PR TITLE
Fix Docs: Link to MDX 3 Instead of MDX 2

### DIFF
--- a/docs/components/index-page/index.tsx
+++ b/docs/components/index-page/index.tsx
@@ -381,7 +381,7 @@ export const IndexPage = () => (
                 textShadow: '0 2px 4px rgb(0 0 0 / 20%)'
               }}
             >
-              <Link href="https://mdxjs.com/blog/v2" className="text-current">
+              <Link href="https://mdxjs.com/blog/v3" className="text-current">
                 MDX 3
               </Link>{' '}
               lets you use Components inside Markdown,{' '}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The link to MDX 3 opens the [blog post for MDX 2](https://mdxjs.com/blog/v2).

Closes #3323

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/shuding/nextra/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Correctly links `MDX 3` to the [MDX 3 blog post](https://mdxjs.com/blog/v3) instead of the [MDX 2 blog post](https://mdxjs.com/blog/v2).

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).

  - For content changes, you will also see an automatically generated comment
    with links directly to pages you've modified. The comment won't appear if
    your PR only edits files in the `data` directory.

- [x] For content changes, I have completed the
      [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
