### PR TITLE
RTL support for the steps component

### DIFF
--- a/.changeset/plenty-boxes-buy.md
+++ b/.changeset/plenty-boxes-buy.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+RTL support for the `<Steps>` component.

--- a/examples/swr-site/pages/es/docs/getting-started.mdx
+++ b/examples/swr-site/pages/es/docs/getting-started.mdx
@@ -1,4 +1,4 @@
-import { Callout } from 'nextra/components'
+import { Callout, Steps } from 'nextra/components'
 
 # Comienza
 
@@ -17,17 +17,21 @@ import { Callout } from 'nextra/components'
 
 ## Instalación
 
-Dentro del directorio de su proyecto React, ejecute lo siguiente:
+<Steps>
+
+### Dentro del directorio de su proyecto React, ejecute lo siguiente:
 
 ```bash
 yarn add swr
 ```
 
-O con npm
+### O con npm
 
 ```bash
 npm install swr
 ```
+
+</Steps>
 
 ## Inicio rápido
 

--- a/packages/nextra-theme-blog/postcss.config.js
+++ b/packages/nextra-theme-blog/postcss.config.js
@@ -5,7 +5,7 @@ module.exports = {
     'tailwindcss/nesting': {},
     tailwindcss: {},
     'postcss-lightningcss': {
-      browsers: '>= .25%'
+      browsers: '>= .25% and not dead'
     }
   }
 }

--- a/packages/nextra-theme-docs/postcss.config.js
+++ b/packages/nextra-theme-docs/postcss.config.js
@@ -5,7 +5,7 @@ module.exports = {
     'tailwindcss/nesting': {},
     tailwindcss: {},
     'postcss-lightningcss': {
-      browsers: '>= .25%'
+      browsers: '>= .25% and not dead'
     }
   }
 }

--- a/packages/nextra/src/client/components/steps.tsx
+++ b/packages/nextra/src/client/components/steps.tsx
@@ -12,7 +12,7 @@ export function Steps({
   return (
     <div
       className={cn(
-        'nextra-steps _ml-4 _mb-12 _border-l _border-gray-200 _pl-6',
+        'nextra-steps _ms-4 _mb-12 _border-s _border-gray-200 _ps-6',
         'dark:_border-neutral-800',
         className
       )}

--- a/packages/nextra/styles/steps.css
+++ b/packages/nextra/styles/steps.css
@@ -10,7 +10,7 @@
       @apply _absolute _size-[33px];
       @apply _border-4 _border-[rgb(var(--nextra-bg))] _bg-gray-100 dark:_bg-neutral-800;
       @apply _rounded-full _text-neutral-400 _text-base _font-normal _text-center _-indent-px;
-      @apply _mt-[3px] _ml-[-41px];
+      @apply _mt-[3px] _ms-[-41px];
       content: counter(var(--counter-id));
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: N/A

To support RTL direction for the `<Steps>` component in v3, I referenced the approach from v4, utilizing logical properties to simplify RTL support. However, the current configuration of `postcss-lightningcss` with [`browsers: '>= .25%'`](https://browsersl.ist/#q=%3E%3D+.25%25) requires maintaining compatibility with deprecated browsers like IE11, which results in some unexpected transformations of logical properties.

To resolve this, I adjusted the browsers configuration to [`>= .25% and not dead`](https://browsersl.ist/#q=%3E%3D+.25%25+and+not+dead). Below is an example of the differences in Tailwind's generated styles

**browsers: '>= .25%'**

```css
._ps-6:not(:is(:lang(ae),:lang(ar),:lang(arc),:lang(bcc),:lang(bqi),:lang(ckb),:lang(dv),:lang(fa),:lang(glk),:lang(he),:lang(ku),:lang(mzn),:lang(nqo),:lang(pnb),:lang(ps),:lang(sd),:lang(ug),:lang(ur),:lang(yi))) {
    padding-left: 1.5rem;
}
```

**browsers: '>= .25% and not dead'**

```css
._ps-6 {
    padding-inline-start: 1.5rem;
}
```

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/shuding/nextra/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

**theme-docs**

ltr:

<img width="413" alt="image" src="https://github.com/user-attachments/assets/900f4daa-c49e-4aa9-8a53-1a392d95b0b3">

rtl: 

<img width="413" alt="image" src="https://github.com/user-attachments/assets/348e2fe4-fe60-4326-9d0c-cd44c2953a94">


**theme-blog**

ltr:

<img width="413" alt="image" src="https://github.com/user-attachments/assets/cb0707e0-cc13-45cb-a102-2230c5f49ef1">

rtl:

<img width="472" alt="image" src="https://github.com/user-attachments/assets/2d2a298b-0906-49be-9e41-117a25309011">

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).

  - For content changes, you will also see an automatically generated comment
    with links directly to pages you've modified. The comment won't appear if
    your PR only edits files in the `data` directory.

- [x] For content changes, I have completed the
      [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
