### PR TITLE
update the documentation for rendering tables in v3

### DIFF
--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -138,14 +138,12 @@ will be rendered as:
 Table looks different compared to [GFM syntax table](#gfm-syntax):
 
 1. only children of table body `<tbody />{:jsx}` is styled
-
-2. table header is unstyled
-
-3. table doesn't have margin top
+1. table header is unstyled
+1. table doesn't have margin top
 
 ### Why This Happens
 
-MDX2 doesn't replace literal HTML elements with `<MDXProvider />{:jsx}`.
+Currently, [MDX](https://mdxjs.com/docs/using-mdx/#components) doesn't replace literal HTML elements with `<MDXProvider />{:jsx}`.
 
 Adam Wathan, creator of Tailwind CSS submitted
 [an issue](https://github.com/mdx-js/mdx/issues/821) in MDX2 to have some _an
@@ -160,8 +158,6 @@ margin-top aka `mt-6`.
 
 ### Ways to Fix It
 
-#### One-Time Fix
-
 Just wrap your table with curly braces `{` and `}`, e.g.
 
 {/* prettier-ignore */}
@@ -171,7 +167,28 @@ Just wrap your table with curly braces `{` and `}`, e.g.
 </table>}
 ```
 
-#### Changing Default Behaviour
+Alternatively, you can define a custom table component to use in your MDX file:
+
+```mdx filename="MDX"
+export function Table({ columns, data }) {
+  return (
+    <table>
+      {/* ... */}
+    </table>
+  )
+}
+
+<Table
+  columns={...}
+  data={...}
+/>
+```
+
+{/**
+ * Currently, remark-mdx-disable-explicit-jsx seems to be no longer maintained,
+ * and I'm not sure if it's compatible with MDX3."
+*/}
+{/* #### Changing Default Behaviour
 
 If this thing is still confusing for you, and you want to use regular literal
 HTML elements for your tables, do the following:
@@ -207,4 +224,4 @@ const withNextra = nextra({
 export default withNextra()
 ```
 
-</Steps>
+</Steps> */}

--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -160,7 +160,9 @@ components `<tr />{:jsx}`, `<th />{:jsx}` and `<td />{:jsx}`, for the same
 reason `<table />{:jsx}` literal is not replaced and doesn't have default
 margin-top aka `mt-6`.
 
-### Ways to Fix It
+## Ways to Fix It
+
+### One-Time Fix
 
 Just wrap your table with curly braces `{` and `}`, e.g.
 
@@ -181,20 +183,19 @@ export function Table({ columns, data }) {
 <Table columns={...} data={...} />
 ```
 
-{/* prettier-ignore */}
-{/* #### Changing Default Behaviour
+### Changing Default Behaviour
 
 If this thing is still confusing for you, and you want to use regular literal
 HTML elements for your tables, do the following:
 
 <Steps>
-### Install `remark-mdx-disable-explicit-jsx` package
+#### Install `remark-mdx-disable-explicit-jsx` package
 
 ```sh npm2yarn
 npm i remark-mdx-disable-explicit-jsx
 ```
 
-### Setup
+#### Setup
 
 Configure plugin in `nextra` function inside `next.config.mjs` file
 
@@ -218,4 +219,4 @@ const withNextra = nextra({
 export default withNextra()
 ```
 
-</Steps> */}
+</Steps>

--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -2,6 +2,9 @@ import { Callout, Steps } from 'nextra/components'
 
 # Rendering Tables
 
+This guide covers different ways to render tables in MDX, including GFM syntax,
+literal HTML tag, and dynamic JavaScript expressions.
+
 ## GFM syntax
 
 In Markdown, it is preferable to write tables via
@@ -143,7 +146,8 @@ Table looks different compared to [GFM syntax table](#gfm-syntax):
 
 ### Why This Happens
 
-Currently, [MDX](https://mdxjs.com/docs/using-mdx/#components) doesn't replace literal HTML elements with `<MDXProvider />{:jsx}`.
+[MDX](https://mdxjs.com/docs/using-mdx/#components) doesn't replace literal HTML
+elements with `<MDXProvider />{:jsx}`.
 
 Adam Wathan, creator of Tailwind CSS submitted
 [an issue](https://github.com/mdx-js/mdx/issues/821) in MDX2 to have some _an
@@ -167,27 +171,17 @@ Just wrap your table with curly braces `{` and `}`, e.g.
 </table>}
 ```
 
-Alternatively, you can define a custom table component to use in your MDX file:
+Alternatively, create a reusable table component:
 
 ```mdx filename="MDX"
 export function Table({ columns, data }) {
-  return (
-    <table>
-      {/* ... */}
-    </table>
-  )
+  return <table>{/* ... */}</table>
 }
 
-<Table
-  columns={...}
-  data={...}
-/>
+<Table columns={...} data={...} />
 ```
 
-{/**
- * Currently, remark-mdx-disable-explicit-jsx seems to be no longer maintained,
- * and I'm not sure if it's compatible with MDX3."
-*/}
+{/* prettier-ignore */}
 {/* #### Changing Default Behaviour
 
 If this thing is still confusing for you, and you want to use regular literal


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: N/A

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/shuding/nextra/issues/new/choose. -->

Due to the upgrade from v3 to MDX3, the content related to [`remark-mdx-disable-explicit-jsx`](https://github.com/iAdramelk/remark-mdx-disable-explicit-jsx) may no longer be applicable, so I have commented it out. Additionally, I have supplemented the documentation by creating a table component, using a similar approach as seen in [theme-configuration.mdx](https://github.com/shuding/nextra/blob/main/docs/pages/docs/docs-theme/theme-configuration.mdx?plain=1#L31-L46).

Feel free to close this if is unnecessary.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).

  - For content changes, you will also see an automatically generated comment
    with links directly to pages you've modified. The comment won't appear if
    your PR only edits files in the `data` directory.

- [ ] For content changes, I have completed the
      [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
