### PR TITLE
update the documentation for the steps component

### DIFF
--- a/docs/pages/docs/guide/advanced/customize-the-cascade-layers.mdx
+++ b/docs/pages/docs/guide/advanced/customize-the-cascade-layers.mdx
@@ -10,7 +10,7 @@ CSS into a specified cascade layer:
 
 <Steps>
 
-### Install `postcss-import`
+## Install `postcss-import`
 
 Install `postcss-import` and add it to `postcss.config.js`:
 
@@ -23,7 +23,7 @@ module.exports = {
 }
 ```
 
-### Disable Automatic Import of the Nextra Official Theme CSS
+## Disable Automatic Import of the Nextra Official Theme CSS
 
 Nextra by default automatically imports the official theme CSS. You can disable
 this behavior by setting `autoImportThemeStyle: false` in the Nextra
@@ -37,7 +37,7 @@ const withNextra = nextra({
 })
 ```
 
-### Set Up the Cascade Layers
+## Set Up the Cascade Layers
 
 In your CSS file (e.g. `styles.css`), import the `nextra-docs-theme` CSS and
 specify the layers:
@@ -52,7 +52,7 @@ specify the layers:
 }
 ```
 
-### Import Your CSS File
+## Import Your CSS File
 
 Create a `pages/_app.jsx` file and import your CSS files there:
 

--- a/docs/pages/docs/guide/built-ins/steps.mdx
+++ b/docs/pages/docs/guide/built-ins/steps.mdx
@@ -25,24 +25,15 @@ This is the third step description.
 
 ## Usage
 
-Wrap a set of markdown h3 headings with the `Steps` component to turn them into
-visual steps.
-
-<Steps>
-
-### Step 1
-
-Content for step 1.
-
-### Step 2
-
-Contents for step 2.
-
-</Steps>
+Wrap a set of markdown headings with the `<Steps>` component to turn them into visual steps. It supports `<h2>`, `<h3>`, and `<h4>` headings. You can choose the appropriate heading level based on the content hierarchy on the page.
 
 {/* prettier-ignore */}
-```mdx
+```mdx filename="MDX" {7-15}
 import { Steps } from 'nextra/components'
+
+## Getting Started
+
+Here is some description.
 
 <Steps>
 ### Step 1
@@ -55,14 +46,14 @@ Contents for step 2.
 </Steps>
 ```
 
-### Excluding Headings from Table of Contents
+## Excluding Headings from Table of Contents
 
 To exclude the headings from the `<Steps>` component (or any other headings) to
 appear in the Table of Contents, replace the Markdown headings `### ...` with
 `<h3>` HTML element wrapped in curly braces.
 
 {/* prettier-ignore */}
-```diff
+```diff filename="MDX"
 <Steps>
 - ### Step 1
 + {<h3>Step 1</h3>}

--- a/docs/pages/docs/guide/built-ins/steps.mdx
+++ b/docs/pages/docs/guide/built-ins/steps.mdx
@@ -25,7 +25,9 @@ This is the third step description.
 
 ## Usage
 
-Wrap a set of markdown headings with the `<Steps>` component to turn them into visual steps. It supports `<h2>`, `<h3>`, and `<h4>` headings. You can choose the appropriate heading level based on the content hierarchy on the page.
+Wrap a set of markdown headings with the `<Steps>` component to turn them into
+visual steps. It supports `<h2>`, `<h3>`, and `<h4>` headings. You can choose
+the appropriate heading level based on the content hierarchy on the page.
 
 {/* prettier-ignore */}
 ```mdx filename="MDX" {7-15}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: N/A

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/shuding/nextra/issues/new/choose. -->

In v3, the steps component supports h2, h3, and h4, so I updated part of the documentation.

I also adjusted the heading level for the steps component in `customize-the-cascade-layers.mdx`, as it only supported h3 at the time.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).

  - For content changes, you will also see an automatically generated comment
    with links directly to pages you've modified. The comment won't appear if
    your PR only edits files in the `data` directory.

- [ ] For content changes, I have completed the
      [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
