### PR TITLE
fix missing title prefix on the cards component page

### DIFF
--- a/docs/pages/docs/guide/built-ins/cards.mdx
+++ b/docs/pages/docs/guide/built-ins/cards.mdx
@@ -70,6 +70,7 @@ ${mdx2}
 ~~~mdx filename="MDX"
 ${mdx2}
 ~~~`)
+  props.__nextra_dynamic_opts.title = 'Cards Component'
   return { props }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: N/A

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/shuding/nextra/issues/new/choose. -->

I noticed the [Card Components](https://nextra.site/docs/guide/built-ins/cards) documentation page is missing a title prefix, so I added `__nextra_dynamic_opts.title: 'Card Components'` to the static props to ensure the page has a proper title.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

**Before**

![image](https://github.com/user-attachments/assets/7161272a-1564-44d8-b513-49ca72df8241)

**After**

![image](https://github.com/user-attachments/assets/19c4fa8d-8d8f-469c-b851-28ba05b04a46)

![image](https://github.com/user-attachments/assets/a5f6ef85-e42f-4be1-9fd3-c2bfa8353640)

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).

  - For content changes, you will also see an automatically generated comment
    with links directly to pages you've modified. The comment won't appear if
    your PR only edits files in the `data` directory.

- [ ] For content changes, I have completed the
      [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
