### PR TITLE
ensure jump link behavior is consistent in markdown

### DIFF
--- a/.changeset/quiet-carpets-sit.md
+++ b/.changeset/quiet-carpets-sit.md
@@ -1,0 +1,6 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+Ensure the jump link behavior is consistent in Markdown.

--- a/packages/nextra-theme-blog/src/mdx-theme.tsx
+++ b/packages/nextra-theme-blog/src/mdx-theme.tsx
@@ -56,7 +56,6 @@ function HeadingLink({
 }
 
 const EXTERNAL_HREF_REGEX = /https?:\/\//
-const ID_HREF_REGEX = /^#/
 
 const A = ({ children, href = '', ...props }: ComponentProps<'a'>) => {
   if (EXTERNAL_HREF_REGEX.test(href)) {
@@ -66,7 +65,7 @@ const A = ({ children, href = '', ...props }: ComponentProps<'a'>) => {
       </a>
     )
   }
-  const ComponentToUse = ID_HREF_REGEX.test(href) ? 'a' : Link
+  const ComponentToUse = href.startsWith('#') ? 'a' : Link
   return (
     <ComponentToUse href={href} {...props}>
       {children}

--- a/packages/nextra-theme-blog/src/mdx-theme.tsx
+++ b/packages/nextra-theme-blog/src/mdx-theme.tsx
@@ -56,6 +56,7 @@ function HeadingLink({
 }
 
 const EXTERNAL_HREF_REGEX = /https?:\/\//
+const ID_HREF_REGEX = /^#/
 
 const A = ({ children, href = '', ...props }: ComponentProps<'a'>) => {
   if (EXTERNAL_HREF_REGEX.test(href)) {
@@ -65,10 +66,11 @@ const A = ({ children, href = '', ...props }: ComponentProps<'a'>) => {
       </a>
     )
   }
+  const ComponentToUse = ID_HREF_REGEX.test(href) ? 'a' : Link
   return (
-    <Link href={href} {...props}>
+    <ComponentToUse href={href} {...props}>
       {children}
-    </Link>
+    </ComponentToUse>
   )
 }
 

--- a/packages/nextra-theme-docs/src/components/anchor.tsx
+++ b/packages/nextra-theme-docs/src/components/anchor.tsx
@@ -4,8 +4,6 @@ import NextLink from 'next/link'
 import type { ComponentProps, ReactElement } from 'react'
 import { forwardRef } from 'react'
 
-const ID_HREF_REGEX = /^#/
-
 export type AnchorProps = ComponentProps<'a'> & {
   newWindow?: boolean
 }
@@ -16,8 +14,7 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
     // ref is used in <NavbarMenu />
     forwardedRef
   ): ReactElement => {
-    const ComponentToUse =
-      newWindow || ID_HREF_REGEX.test(href) ? 'a' : NextLink
+    const ComponentToUse = newWindow || href.startsWith('#') ? 'a' : NextLink
     return (
       <ComponentToUse
         {...props}

--- a/packages/nextra-theme-docs/src/components/anchor.tsx
+++ b/packages/nextra-theme-docs/src/components/anchor.tsx
@@ -4,6 +4,8 @@ import NextLink from 'next/link'
 import type { ComponentProps, ReactElement } from 'react'
 import { forwardRef } from 'react'
 
+const ID_HREF_REGEX = /^#/
+
 export type AnchorProps = ComponentProps<'a'> & {
   newWindow?: boolean
 }
@@ -14,7 +16,8 @@ export const Anchor = forwardRef<HTMLAnchorElement, AnchorProps>(
     // ref is used in <NavbarMenu />
     forwardedRef
   ): ReactElement => {
-    const ComponentToUse = newWindow ? 'a' : NextLink
+    const ComponentToUse =
+      newWindow || ID_HREF_REGEX.test(href) ? 'a' : NextLink
     return (
       <ComponentToUse
         {...props}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: N/A

In theme-docs, when using markdown to create a jump link like `[My content](#my-content)`, clicking the link to jump to specific content causes that content to be covered by the navbar, It can be reproduced by clicking on the `GFM syntax table:` [here](https://nextra.site/docs/guide/advanced/table#unexpected-result), and this behavior is inconsistent with clicking on TOC links and sub-heading anchors.

The jump link created via markdown syntax is converted into a next-link. When clicking it, the `activeElement` remains on the link, which causes the following CSS not to be applied:

```css
html:not(:has(*:focus)) {
  @apply _scroll-pt-[--nextra-navbar-height];
}
```

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/shuding/nextra/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

To resolve this, I added a check on the MDX anchor component to see if the href starts with `#`. If true, it uses `<a>`

https://github.com/user-attachments/assets/24e8abc3-ceee-49c2-bfee-259cfe5d2393

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).

  - For content changes, you will also see an automatically generated comment
    with links directly to pages you've modified. The comment won't appear if
    your PR only edits files in the `data` directory.

- [ ] For content changes, I have completed the
      [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
