### PR TITLE
use 3 nextra's webpack loaders instead of 4 to improve performance

### DIFF
--- a/.changeset/big-adults-remain.md
+++ b/.changeset/big-adults-remain.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+use 3 nextra's webpack loaders instead of 4

--- a/packages/nextra/src/server/constants.ts
+++ b/packages/nextra/src/server/constants.ts
@@ -41,10 +41,6 @@ export const EXTERNAL_URL_REGEX = /^https?:\/\//
 
 export const DEFAULT_LOCALES = ['']
 
-// Experimental, need to deep dive why bundle becomes bigger and there is full
-// reload while navigating between pages every time
-export const IMPORT_FRONTMATTER = false
-
 export const DEFAULT_PROPERTY_PROPS = {
   type: 'Property',
   kind: 'init',

--- a/packages/nextra/src/server/index.ts
+++ b/packages/nextra/src/server/index.ts
@@ -165,11 +165,10 @@ const nextra: Nextra = nextraConfig => {
               },
               {
                 // Match Markdown imports from non-pages. These imports have an
-                // issuer, which can be anything as long as it's not empty.
-                // When the issuer is null, it means that it can be imported via a
+                // issuer, which can be anything as long as it's not empty string.
+                // When the issuer is `null`, it means that it can be imported via a
                 // runtime import call such as `import('...')`.
-                issuer: request =>
-                  request === null || !request.includes(AGNOSTIC_PAGE_MAP_PATH),
+                issuer: request => !request?.includes(AGNOSTIC_PAGE_MAP_PATH),
                 use: defaultLoaderOptions
               }
             ]

--- a/packages/nextra/src/server/index.ts
+++ b/packages/nextra/src/server/index.ts
@@ -169,9 +169,7 @@ const nextra: Nextra = nextraConfig => {
                 // When the issuer is null, it means that it can be imported via a
                 // runtime import call such as `import('...')`.
                 issuer: request =>
-                  request
-                    ? !request.includes(AGNOSTIC_PAGE_MAP_PATH)
-                    : request === null,
+                  request === null || !request.includes(AGNOSTIC_PAGE_MAP_PATH),
                 use: defaultLoaderOptions
               }
             ]

--- a/packages/nextra/src/server/index.ts
+++ b/packages/nextra/src/server/index.ts
@@ -1,13 +1,13 @@
 /* eslint-env node */
 import { join, sep } from 'node:path'
 import type { NextConfig } from 'next'
+import type { RuleSetRule } from 'webpack'
 import { fromZodError } from 'zod-validation-error'
 import type { Nextra } from '../types'
 import {
   DEFAULT_CONFIG,
   DEFAULT_LOCALE,
   DEFAULT_LOCALES,
-  IMPORT_FRONTMATTER,
   MARKDOWN_EXTENSION_REGEX,
   MARKDOWN_EXTENSIONS,
   META_REGEX
@@ -140,20 +140,6 @@ const nextra: Nextra = nextraConfig => {
         }
         const rules = config.module.rules as RuleSetRule[]
 
-        if (IMPORT_FRONTMATTER) {
-          rules.push({
-            test: MARKDOWN_EXTENSION_REGEX,
-            issuer: request => request.includes(AGNOSTIC_PAGE_MAP_PATH),
-            use: [
-              options.defaultLoaders.babel,
-              {
-                loader: 'nextra/loader',
-                options: { ...loaderOptions, isPageMapImport: true }
-              }
-            ]
-          })
-        }
-
         const defaultLoaderOptions = [
           options.defaultLoaders.babel,
           {
@@ -164,25 +150,29 @@ const nextra: Nextra = nextraConfig => {
 
         rules.push(
           {
-            // Match Markdown imports from non-pages. These imports have an
-            // issuer, which can be anything as long as it's not empty.
-            // When the issuer is null, it means that it can be imported via a
-            // runtime import call such as `import('...')`.
             test: MARKDOWN_EXTENSION_REGEX,
-            issuer: request =>
-              (!!request && !request.includes(AGNOSTIC_PAGE_MAP_PATH)) ||
-              request === null,
-            use: defaultLoaderOptions
-          },
-          {
-            // Match pages (imports without an issuer request).
-            test: MARKDOWN_EXTENSION_REGEX,
-            issuer: request => request === '',
-            use: [
-              options.defaultLoaders.babel,
+            oneOf: [
               {
-                loader: 'nextra/loader',
-                options: { ...loaderOptions, isPageImport: true }
+                // Match pages (imports without an issuer request).
+                issuer: request => request === '',
+                use: [
+                  options.defaultLoaders.babel,
+                  {
+                    loader: 'nextra/loader',
+                    options: { ...loaderOptions, isPageImport: true }
+                  }
+                ]
+              },
+              {
+                // Match Markdown imports from non-pages. These imports have an
+                // issuer, which can be anything as long as it's not empty.
+                // When the issuer is null, it means that it can be imported via a
+                // runtime import call such as `import('...')`.
+                issuer: request =>
+                  request
+                    ? !request.includes(AGNOSTIC_PAGE_MAP_PATH)
+                    : request === null,
+                use: defaultLoaderOptions
               }
             ]
           },
@@ -219,13 +209,6 @@ const nextra: Nextra = nextraConfig => {
       }
     }
   }
-}
-
-// TODO: take this type from webpack directly
-type RuleSetRule = {
-  issuer: (value: string) => boolean
-  test: RegExp
-  use: unknown[]
 }
 
 export default nextra

--- a/packages/nextra/src/server/page-map.ts
+++ b/packages/nextra/src/server/page-map.ts
@@ -11,7 +11,6 @@ import {
   CHUNKS_DIR,
   CWD,
   DEFAULT_PROPERTY_PROPS,
-  IMPORT_FRONTMATTER,
   MARKDOWN_EXTENSION_REGEX,
   META_REGEX
 } from './constants.js'
@@ -119,19 +118,11 @@ async function collectFiles({
       // add concurrency because folder can contain a lot of files
       return limit(async () => {
         if (MARKDOWN_EXTENSION_REGEX.test(ext)) {
-          // let frontMatter: Expression
-
-          // if (IMPORT_FRONTMATTER) {
-          // const importName = cleanFileName(filePath)
-          // imports.push({ importName, filePath })
-          // frontMatter = { type: 'Identifier', name: importName }
-          // } else {
           const content = await fs.readFile(filePath, 'utf8')
           const { data } = grayMatter(content)
           if (!data.title) {
             data.sidebarTitle = pageTitleFromFilename(name)
           }
-          // }
 
           return {
             name,
@@ -239,7 +230,7 @@ export async function collectPageMap({
       specifiers: [
         {
           local: { type: 'Identifier', name: importName },
-          ...(IMPORT_FRONTMATTER && MARKDOWN_EXTENSION_REGEX.test(filePath)
+          ...(MARKDOWN_EXTENSION_REGEX.test(filePath)
             ? {
                 type: 'ImportSpecifier',
                 imported: { type: 'Identifier', name: 'frontMatter' }


### PR DESCRIPTION
```
pnpm --filter docs dev

> docs@ dev /Users/dmytro/Desktop/nextra/docs
> next

  ▲ Next.js 14.2.13
  - Local:        http://localhost:3000

 ✓ Starting...
   automatically enabled Fast Refresh for 3 custom loaders
 ✓ Ready in 1072ms
```