### PR TITLE
Add `.nextra-search-results` class back to v3

### DIFF
--- a/.changeset/light-shirts-warn.md
+++ b/.changeset/light-shirts-warn.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+Add `.nextra-search-results` class back

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -152,7 +152,8 @@ module.exports = {
             'nextra-breadcrumb',
             'nextra-bleed',
             'nextra-menu-desktop',
-            'nextra-menu-mobile'
+            'nextra-menu-mobile',
+            'nextra-search-results'
           ]
         }
       },

--- a/packages/nextra-theme-docs/src/components/search.tsx
+++ b/packages/nextra-theme-docs/src/components/search.tsx
@@ -173,6 +173,7 @@ export function Search({
         anchor={{ to: 'top end', gap: 10, padding: 16 }}
         className={({ open }) =>
           cn(
+            'nextra-search-results', // for userspace styling
             'nextra-scrollbar max-md:_h-full',
             '_border _border-gray-200 _text-gray-100 dark:_border-neutral-800',
             '_z-20 _rounded-xl _py-2.5 _shadow-xl',


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

In previous major version, Nextra had a `nextra-search-results` class on the search results panel, that was pretty handy for styling: I have a green hero section on a landing page, so I was using `.nextra-search-results` to remove the backdrop-blur and transparency of the background, preserving legibility of the text.

Closes: (Sorry, I didn't create an issue 😓 )

## What's being changed (if available, include any code snippets, screenshots, or gifs):

I'm adding the class back to the place it fits the most.

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
