### PR TITLE
remove extra horizontal margin spacing in toc

### DIFF
--- a/.changeset/green-cheetahs-destroy.md
+++ b/.changeset/green-cheetahs-destroy.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+remove extra horizontal margin spacing in toc

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -58,7 +58,7 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
     <div
       className={cn(
         'nextra-scrollbar _sticky _top-16 _overflow-y-auto _px-4 _pt-6 _text-sm [hyphens:auto]',
-        '_max-h-[calc(100vh-var(--nextra-navbar-height)-env(safe-area-inset-bottom))] ltr:_-mr-4 rtl:_-ml-4'
+        '_max-h-[calc(100vh-var(--nextra-navbar-height)-env(safe-area-inset-bottom))]'
       )}
     >
       {hasHeadings && (


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: #3388

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

I'm not sure of the purpose of `ltr:-_mr-4 rtl:-_ml-4`. Can we remove these to eliminate extra horizontal margin spacing? It seems that after adding `_px-4` in [#3160](https://github.com/shuding/nextra/pull/3160/files#diff-e07f0bc6445c47b38f62eaeb0655948798c2bbb38e87db5123c5c891fcfa49caR60), we no longer need to consider the ltr or rtl direction.

**ltr**

![image](https://github.com/user-attachments/assets/35deab68-f9bd-478d-b8a1-0a1d29a44703)

![image](https://github.com/user-attachments/assets/53fbd4c8-1152-4694-9fc4-62bb8d2ea01e)

**rtl**

![image](https://github.com/user-attachments/assets/dc25c4c7-535b-4567-a169-97323a93ba99)


<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
