### PR TITLE
Apply user's recmaPlugins first

### DIFF
--- a/.changeset/quick-singers-whisper.md
+++ b/.changeset/quick-singers-whisper.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+apply user's `recmaPlugins` first

--- a/packages/nextra/src/server/compile.ts
+++ b/packages/nextra/src/server/compile.ts
@@ -297,6 +297,7 @@ export async function compileMdx(
         [rehypeExtractTocContent, { isRemoteContent }]
       ].filter(v => !!v),
       recmaPlugins: [
+        ...(recmaPlugins || []),
         (() => (ast: Program, file) => {
           const mdxContentIndex = ast.body.findIndex(node => {
             if (node.type === 'ExportDefaultDeclaration') {
@@ -345,8 +346,7 @@ export async function compileMdx(
             }
           }
         }) satisfies Plugin<[], Program>,
-        isRemoteContent ? recmaRewriteFunctionBody : recmaRewriteJsx,
-        ...(recmaPlugins || [])
+        isRemoteContent ? recmaRewriteFunctionBody : recmaRewriteJsx
       ].filter(v => !!v)
     })
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: #2915

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

Now user provided `recmaPulgins` run first. Same as how `remarkPlugins` and `rehypePlugins` work.

This fixes the integration between Nextra 3 and [Code Hike](https://codehike.org/).

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
