### PR TITLE
trigger scrolling when toc item is outside the viewport

### DIFF
--- a/.changeset/neat-onions-unite.md
+++ b/.changeset/neat-onions-unite.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+trigger scrolling when the TOC item is outside the viewport

--- a/packages/nextra-theme-docs/src/components/toc.tsx
+++ b/packages/nextra-theme-docs/src/components/toc.tsx
@@ -48,7 +48,7 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
         behavior: 'smooth',
         block: 'center',
         inline: 'center',
-        scrollMode: 'always',
+        scrollMode: 'if-needed',
         boundary: tocRef.current!.parentElement
       })
     }
@@ -57,12 +57,18 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
   return (
     <div
       className={cn(
-        'nextra-scrollbar _sticky _top-16 _overflow-y-auto _px-4 _pt-6 _text-sm [hyphens:auto]',
+        '_grid _grid-rows-[1fr_min-content]', // 1fr: scrollbar, min-content: toc footer
+        '_sticky _top-16 _pt-6 _text-sm [hyphens:auto]',
         '_max-h-[calc(100vh-var(--nextra-navbar-height)-env(safe-area-inset-bottom))]'
       )}
     >
       {hasHeadings && (
-        <>
+        <div
+          className={cn(
+            'nextra-scrollbar _overflow-y-auto _px-4',
+            '_pb-6' // for toc footer shadow
+          )}
+        >
           <p className="_mb-4 _font-semibold _tracking-tight">
             {renderComponent(themeConfig.toc.title)}
           </p>
@@ -92,15 +98,15 @@ export function TOC({ toc, filePath }: TOCProps): ReactElement {
               </li>
             ))}
           </ul>
-        </>
+        </div>
       )}
 
       {hasMetaInfo && (
         <div
           className={cn(
-            hasHeadings && 'nextra-toc-footer _mt-8 _pt-8',
-            '_sticky _bottom-0 _flex _flex-col _items-start _gap-2 _pb-8',
-            '_-mx-1 _px-1' // to hide focused toc links
+            hasHeadings && 'nextra-toc-footer',
+            '_flex _flex-col _items-start _gap-2 _py-8 _px-1',
+            '_mx-3' // for toc-footer border top width
           )}
         >
           {themeConfig.feedback.content ? (


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

Feel free to close this if it is not suitable.

The current scroll mode of the TOC is `always`. When the active item is updated, the scroll animation may occur even if the active item is within the viewport. This is a little distracting for me while reading.

https://github.com/user-attachments/assets/2ad48e47-5758-4e7b-8f8c-f082a0ff6262

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

https://github.com/user-attachments/assets/00b8e557-7a89-42b3-9684-96241acd8b5c

I tried changing the scroll mode to `if-needed`. If the active TOC item is still within the viewport, the scrollbar will not move.

Here are some changes in this PR:

- Wrap the TOC title and TOC list with a `<div class="nextra-scrollbar">`. The purpose is to improve the scroll boundary for better viewport detection.
- Set a grid layout for the TOC root element to replace the original TOC footer with `_sticky _bottom-0.`

Also checked: 

- Focus-visible styles are not being cut off.
- RTL styles work as expected.
- TOC footer shadow.

![image](https://github.com/user-attachments/assets/1a19d2aa-1f92-4f66-afb9-505fb7a36782)

![image](https://github.com/user-attachments/assets/72f4eab6-2f1d-4c61-96fc-747067372d50)

![image](https://github.com/user-attachments/assets/2c5e72e5-d000-42bd-b659-caa2f726e202)

![image](https://github.com/user-attachments/assets/76803388-c867-4d99-a477-4061f6d726c7)

![image](https://github.com/user-attachments/assets/722fd3ce-ea13-4923-9e5b-0dd72743779c)

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
