### PR TITLE
hide `<summary>` marker on Safari

### DIFF
--- a/.changeset/nasty-experts-smile.md
+++ b/.changeset/nasty-experts-smile.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+hide `<summary>` marker on Safari

--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -184,6 +184,7 @@ function Summary({
       className={cn(
         'nextra-focus',
         '_flex _items-center _cursor-pointer _p-1 _transition-colors hover:_bg-gray-100 dark:hover:_bg-neutral-800',
+        '[&::-webkit-details-marker]:_hidden', // Safari
         // display: flex removes whitespace when `<summary>` contains text with other elements, like `foo <strong>bar</strong>`
         '_whitespace-pre-wrap',
         '_select-none',


### PR DESCRIPTION
![IMG_2737](https://github.com/user-attachments/assets/3a66a4c9-baca-414a-83f0-b31436049289)
