### PR TITLE
chore: add parent key for custom 404 page

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -623,8 +623,8 @@ Options to configure report of broken link on not found page.
 
 <Table>
 
-|         |                   |                                                |
-| ------- | ----------------- | ---------------------------------------------- |
+|                  |                   |                                                |
+| ---------------- | ----------------- | ---------------------------------------------- |
 | notFound.content | `ReactNode \| FC` | Default: `Submit an issue about broken link →` |
 | notFound.labels  | `string`          | Default: `bug`                                 |
 

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -625,8 +625,8 @@ Options to configure report of broken link on not found page.
 
 |         |                   |                                                |
 | ------- | ----------------- | ---------------------------------------------- |
-| content | `ReactNode \| FC` | Default: `Submit an issue about broken link →` |
-| labels  | `string`          | Default: `bug`                                 |
+| notFound.content | `ReactNode \| FC` | Default: `Submit an issue about broken link →` |
+| notFound.labels  | `string`          | Default: `bug`                                 |
 
 </Table>
 


### PR DESCRIPTION
## Why:

The documentation is missing the parent key `notFound`.
Without it, users won't know how to edit the theme.config file correctly.

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
