### PR TITLE
[v4] fix mobile nav position

### DIFF
--- a/.changeset/afraid-pens-teach.md
+++ b/.changeset/afraid-pens-teach.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+fix mobile nav position

--- a/packages/nextra-theme-docs/src/components/navbar/index.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar/index.tsx
@@ -36,7 +36,7 @@ export const Navbar: FC<NavbarProps> = ({
     <header
       className={cn(
         'nextra-navbar _sticky _top-0 _z-20 _w-full _bg-transparent print:_hidden',
-        String.raw`max-md:[.nextra-banner:not(.\_hidden)~&]:_top-10`
+        String.raw`max-md:[.nextra-banner:not(.\_hidden)~&]:_top-[var(--nextra-banner-height)]`
       )}
     >
       <div

--- a/packages/nextra-theme-docs/src/components/navbar/index.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar/index.tsx
@@ -36,7 +36,7 @@ export const Navbar: FC<NavbarProps> = ({
     <header
       className={cn(
         'nextra-navbar _sticky _top-0 _z-20 _w-full _bg-transparent print:_hidden',
-        String.raw`max-md:[.nextra-banner:not(.\_hidden)~&]:_top-[var(--nextra-banner-height)]`
+        String.raw`max-md:[.nextra-banner:not(.\_hidden)~&]:_top-[--nextra-banner-height]`
       )}
     >
       <div

--- a/packages/nextra-theme-docs/src/components/navbar/index.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar/index.tsx
@@ -36,7 +36,7 @@ export const Navbar: FC<NavbarProps> = ({
     <header
       className={cn(
         'nextra-navbar _sticky _top-0 _z-20 _w-full _bg-transparent print:_hidden',
-        'max-md:[.nextra-banner:not(.\\_hidden)~&]:_top-10'
+        String.raw`max-md:[.nextra-banner:not(.\_hidden)~&]:_top-10`
       )}
     >
       <div

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -343,7 +343,7 @@ export const MobileNav: FC = () => {
       <aside
         className={cn(
           classes.aside,
-          '_fixed _inset-y-0 _w-full _pt-[--nextra-navbar-height] _z-10 _overscroll-contain',
+          '_fixed _inset-0 _pt-[--nextra-navbar-height] _z-10 _overscroll-contain',
           '_transition-transform _duration-700 _ease-[cubic-bezier(.52,.16,.04,1)] _will-change-[transform,opacity]',
           '[contain:layout_style]',
           'md:_hidden',

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -347,7 +347,7 @@ export const MobileNav: FC = () => {
           '_transition-transform _duration-700 _ease-[cubic-bezier(.52,.16,.04,1)] _will-change-[transform,opacity]',
           '[contain:layout_style]',
           'md:_hidden',
-          String.raw`[&:has(~*~.nextra-banner:not(.\_hidden))]:_pt-[calc(var(--nextra-banner-height)+var(--nextra-navbar-height))]`,
+          String.raw`[.nextra-banner:not(.\_hidden)~&]:_pt-[calc(var(--nextra-banner-height)+var(--nextra-navbar-height))]`,
           '_bg-[rgb(var(--nextra-bg))]',
           menu
             ? '[transform:translate3d(0,0,0)]'

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -343,11 +343,11 @@ export const MobileNav: FC = () => {
       <aside
         className={cn(
           classes.aside,
-          '_fixed _top-[--nextra-navbar-height] _w-full _bottom-0 _z-10 _overscroll-contain',
+          '_fixed _inset-y-0 _w-full _pt-[--nextra-navbar-height] _z-10 _overscroll-contain',
           '_transition-transform _duration-700 _ease-[cubic-bezier(.52,.16,.04,1)] _will-change-[transform,opacity]',
           '[contain:layout_style]',
           'md:_hidden',
-          String.raw`[&:has(~*~.nextra-banner:not(.\_hidden))]:_pt-[--nextra-banner-height]`,
+          String.raw`[&:has(~*~.nextra-banner:not(.\_hidden))]:_pt-[calc(var(--nextra-banner-height)+var(--nextra-navbar-height))]`,
           '_bg-[rgb(var(--nextra-bg))]',
           menu
             ? '[transform:translate3d(0,0,0)]'


### PR DESCRIPTION
Thank you for Nextra v4 prerelease!

## Why:

This PR fixes an issue where the color of the upper part of the screen was incorrect when opening the mobile nav in Nextra 4.
When opening the mobile nav in Light mode, the overlay at the top header section feels transparent and seems off. Just like in Nextra 3, I've adjusted it so that the header color does not change when the mobile nav is opened.


## What's being changed (if available, include any code snippets, screenshots, or gifs):

Attached are the test results from the following example:

https://github.com/shuding/nextra/tree/v4-v2/examples/docs

|    | Without banner   |  With banner  |
|----|----|----|
| Before|  ![before](https://github.com/user-attachments/assets/f8f09165-ef4b-43fa-a7a5-901adb858747)  |  ![before-banner](https://github.com/user-attachments/assets/9f6ecaad-b775-4695-b945-45cdf187bfec) |
| After | ![after](https://github.com/user-attachments/assets/6c300a6e-9755-40f0-ad99-6b2899ec704c) | ![after-banner](https://github.com/user-attachments/assets/3a878f1b-a96f-4752-91ee-06f407735867) |


## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
