### PR TITLE
fix `Could not find a declaration file for module 'nextra'`

### DIFF
--- a/.changeset/spotty-dingos-pretend.md
+++ b/.changeset/spotty-dingos-pretend.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+fix `Could not find a declaration file for module 'nextra'`

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -10,7 +10,10 @@
   },
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/server/index.js",
+    ".": {
+      "import": "./dist/server/index.js",
+      "types": "./dist/server/index.d.ts"
+    },
     "./loader": "./loader.cjs",
     "./components": {
       "import": "./dist/client/components/index.js",


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/2948 https://github.com/shuding/nextra/issues/2603