### PR TITLE
add `nextra/locales` middleware which can be exported from `root/middleware.{js,ts}` file to detect and redirect to the user-selected language for i18n websites

### DIFF
--- a/.changeset/large-feet-tell.md
+++ b/.changeset/large-feet-tell.md
@@ -2,4 +2,4 @@
 'nextra': patch
 ---
 
-add `nextra/locales` middleware which can be exported from `root/middleware.{js,ts}` file to detect and redirect to the user-selected language for i18n websites
+add `nextra/locales` middleware which can be exported from `root-of-your-project/middleware.{js,ts}` file to detect and redirect to the user-selected language for i18n websites

--- a/.changeset/large-feet-tell.md
+++ b/.changeset/large-feet-tell.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+add `nextra/locales` middleware which can be exported from `root/middleware.{js,ts}` file to detect and redirect to the user-selected language for i18n websites

--- a/docs/pages/docs/guide/i18n.mdx
+++ b/docs/pages/docs/guide/i18n.mdx
@@ -53,6 +53,26 @@ i18n: [
 ]
 ```
 
+## Automatically Detect and Redirect to the User-Selected Language (Optional)
+
+It's possible to automatically detect the user's preferred language and redirect to the corresponding language version of the site.
+To do this, create `middleware.js` file in the root of your project and export Nextra's `middleware` function from `nextra/locales`:
+
+```js filename="middleware.js"
+export { middleware } from 'nextra/locales'
+
+export const config = {
+  // Matcher ignoring `/_next/` and `/api/`
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg|apple-icon.png|manifest).*)'
+  ]
+}
+```
+
+<Callout type="warning">
+  **Note**: this will not work for i18n sites which is statically exported via `output: "export"`.
+</Callout>
+
 </Steps>
 
 ## Custom 404 Page

--- a/docs/pages/docs/guide/i18n.mdx
+++ b/docs/pages/docs/guide/i18n.mdx
@@ -57,7 +57,7 @@ i18n: [
 
 You can automatically detect the user's preferred language and redirect them to
 the corresponding version of the site. To achieve this, create a `middleware.js`
-file in the root of your project and export Nextra’s middleware function from
+file in the root of your project and export Nextra's middleware function from
 `nextra/locales`:
 
 ```js filename="middleware.js" {1}

--- a/docs/pages/docs/guide/i18n.mdx
+++ b/docs/pages/docs/guide/i18n.mdx
@@ -53,12 +53,14 @@ i18n: [
 ]
 ```
 
-## Automatically Detect and Redirect to the User-Selected Language (Optional)
+## Automatically Detect and Redirect to User-Selected Language (Optional)
 
-It's possible to automatically detect the user's preferred language and redirect to the corresponding language version of the site.
-To do this, create `middleware.js` file in the root of your project and export Nextra's `middleware` function from `nextra/locales`:
+You can automatically detect the user's preferred language and redirect them to
+the corresponding version of the site. To achieve this, create a `middleware.js`
+file in the root of your project and export Nextra’s middleware function from
+`nextra/locales`:
 
-```js filename="middleware.js"
+```js filename="middleware.js" {1}
 export { middleware } from 'nextra/locales'
 
 export const config = {
@@ -70,7 +72,8 @@ export const config = {
 ```
 
 <Callout type="warning">
-  **Note**: this will not work for i18n sites which is statically exported via `output: "export"`.
+  **Note**: This approach will not work for i18n sites that are statically
+  exported with `output: "export"` in `nextConfig`.
 </Callout>
 
 </Steps>

--- a/docs/pages/docs/guide/i18n.mdx
+++ b/docs/pages/docs/guide/i18n.mdx
@@ -76,9 +76,7 @@ export const config = {
   exported with `output: "export"` in `nextConfig`.
 </Callout>
 
-</Steps>
-
-## Custom 404 Page
+## Custom 404 Page (Optional)
 
 In **Nextra 3**, it's not possible to create a `404.mdx` page for an i18n
 website that uses a shared theme layout. However, you can implement a `404.jsx`
@@ -90,3 +88,5 @@ In **Nextra 4**, you can have a custom `not-found.jsx` with translations for an
 i18n website that uses a shared theme layout. For guidance on implementing this,
 you can check out the
 [SWR i18n example](https://github.com/shuding/nextra/blob/c9d0ffc8687644401412b8adc34af220cccddf82/examples/swr-site/app/%5Blang%5D/not-found.ts).
+
+</Steps>

--- a/examples/swr-site/middleware.ts
+++ b/examples/swr-site/middleware.ts
@@ -1,0 +1,8 @@
+export { middleware } from 'nextra/locales'
+
+export const config = {
+  // Matcher ignoring `/_next/` and `/api/`
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg|apple-icon.png|manifest).*)'
+  ]
+}

--- a/examples/swr-site/next.config.js
+++ b/examples/swr-site/next.config.js
@@ -99,11 +99,6 @@ export default withBundleAnalyzer(
         source: '/examples',
         destination: '/examples/basic',
         statusCode: 302
-      },
-      {
-        source: '/',
-        destination: '/en',
-        permanent: true
       }
     ],
     reactStrictMode: true

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -43,6 +43,10 @@
       "import": "./dist/server/schemas.js",
       "types": "./dist/server/schemas.d.ts"
     },
+    "./locales": {
+      "import": "./dist/server/locales.js",
+      "types": "./dist/server/locales.d.ts"
+    },
     "./fetch-filepaths-from-github": {
       "import": "./dist/server/fetch-filepaths-from-github.js",
       "types": "./dist/server/fetch-filepaths-from-github.d.ts"
@@ -73,6 +77,9 @@
       ],
       "schemas": [
         "./dist/server/schemas.d.ts"
+      ],
+      "locales": [
+        "./dist/server/locales.d.ts"
       ],
       "catch-all": [
         "./dist/client/catch-all.d.ts"
@@ -120,6 +127,7 @@
     "react-dom": ">=18"
   },
   "dependencies": {
+    "@formatjs/intl-localematcher": "^0.5.4",
     "@headlessui/react": "^2.1.2",
     "@mdx-js/mdx": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
@@ -136,6 +144,7 @@
     "gray-matter": "^4.0.3",
     "hast-util-to-estree": "^3.1.0",
     "katex": "^0.16.9",
+    "negotiator": "^0.6.3",
     "p-limit": "^6.0.0",
     "rehype-katex": "^7.0.0",
     "rehype-pretty-code": "0.14.0",
@@ -161,6 +170,7 @@
     "@types/graceful-fs": "^4.1.9",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
+    "@types/negotiator": "^0.6.3",
     "@types/react": "^18.3.3",
     "@types/webpack": "^5.28.5",
     "@vitejs/plugin-react": "^4.3.1",

--- a/packages/nextra/src/server/index.ts
+++ b/packages/nextra/src/server/index.ts
@@ -88,7 +88,8 @@ const nextra: Nextra = nextraConfig => {
         ...nextConfig.env,
         ...(hasI18n && {
           NEXTRA_DEFAULT_LOCALE:
-            nextConfig.i18n?.defaultLocale || DEFAULT_LOCALE
+            nextConfig.i18n?.defaultLocale || DEFAULT_LOCALE,
+          NEXTRA_LOCALES: JSON.stringify(nextConfig.i18n?.locales)
         }),
         NEXTRA_SEARCH: String(!!loaderOptions.search)
       },

--- a/packages/nextra/src/server/locales.ts
+++ b/packages/nextra/src/server/locales.ts
@@ -1,0 +1,50 @@
+import { match as matchLocale } from '@formatjs/intl-localematcher'
+import Negotiator from 'negotiator'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const locales = JSON.parse(process.env.NEXTRA_LOCALES!) as string[]
+
+const defaultLocale = process.env.NEXTRA_DEFAULT_LOCALE!
+
+const HAS_LOCALE_RE = new RegExp(`^\\/(${locales.join('|')})(\\/|$)`)
+
+const COOKIE_NAME = 'NEXT_LOCALE'
+
+function getHeadersLocale(request: NextRequest): string {
+  const headers = Object.fromEntries(
+    // @ts-expect-error -- this works
+    request.headers.entries()
+  )
+
+  // Use negotiator and intl-localematcher to get best locale
+  const languages = new Negotiator({ headers }).languages(locales)
+  const locale = matchLocale(languages, locales, defaultLocale)
+
+  return locale
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Check if there is any supported locale in the pathname
+  const pathnameHasLocale = HAS_LOCALE_RE.test(pathname)
+  const cookieLocale = request.cookies.get(COOKIE_NAME)?.value
+
+  // Redirect if there is no locale
+  if (!pathnameHasLocale) {
+    const locale = cookieLocale || getHeadersLocale(request)
+
+    // e.g. incoming request is /products
+    // The new URL is now /en-US/products
+    return NextResponse.redirect(new URL(`/${locale}${pathname}`, request.url))
+  }
+
+  const requestLocale = pathname.split('/', 2)[1]
+
+  if (requestLocale !== cookieLocale) {
+    const response = NextResponse.next()
+    response.cookies.set(COOKIE_NAME, requestLocale)
+    return response
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
 
   packages/nextra:
     dependencies:
+      '@formatjs/intl-localematcher':
+        specifier: ^0.5.4
+        version: 0.5.5
       '@headlessui/react':
         specifier: ^2.1.2
         version: 2.1.10(react-dom@18.3.1)(react@18.3.1)
@@ -287,6 +290,9 @@ importers:
       katex:
         specifier: ^0.16.9
         version: 0.16.11
+      negotiator:
+        specifier: ^0.6.3
+        version: 0.6.3
       p-limit:
         specifier: ^6.0.0
         version: 6.1.0
@@ -357,6 +363,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
+      '@types/negotiator':
+        specifier: ^0.6.3
+        version: 0.6.3
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.11
@@ -3981,6 +3990,12 @@ packages:
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
     dev: false
 
+  /@formatjs/intl-localematcher@0.5.5:
+    resolution: {integrity: sha512-t5tOGMgZ/i5+ALl2/offNqAQq/lfUnKLEw0mXQI4N4bqpedhrSE+fyKLpwnd22sK0dif6AV+ufQcTsKShB9J1g==}
+    dependencies:
+      tslib: 2.7.0
+    dev: false
+
   /@headlessui/react@2.1.10(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-6mLa2fjMDAFQi+/R10B+zU3edsUk/MDtENB2zHho0lqKU1uzhAfJLUduWds4nCo8wbl3vULtC5rJfZAQ1yqIng==}
     engines: {node: '>=10'}
@@ -5639,6 +5654,10 @@ packages:
   /@types/ms@0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: false
+
+  /@types/negotiator@0.6.3:
+    resolution: {integrity: sha512-JkXTOdKs5MF086b/pt8C3+yVp3iDUwG635L7oCH6HvJvvr6lSUU5oe/gLXnPEfYRROHjJIPgCV6cuAg8gGkntQ==}
+    dev: true
 
   /@types/nlcst@2.0.3:
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
@@ -10888,6 +10907,11 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
+  /negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
@@ -14134,6 +14158,7 @@ packages:
       react: '>=18'
       react-dom: '>=18'
     dependencies:
+      '@formatjs/intl-localematcher': 0.5.5
       '@headlessui/react': 2.1.3(react-dom@18.3.1)(react@18.3.1)
       '@mdx-js/mdx': 3.0.1
       '@mdx-js/react': 3.0.1(@types/react@18.3.11)(react@18.3.1)
@@ -14150,6 +14175,7 @@ packages:
       gray-matter: 4.0.3
       hast-util-to-estree: 3.1.0
       katex: 0.16.11
+      negotiator: 0.6.3
       next: 14.2.15(@babel/core@7.25.2)(react-dom@18.3.1)(react@18.3.1)
       p-limit: 6.1.0
       react: 18.3.1


### PR DESCRIPTION
closes https://github.com/shuding/nextra/issues/3406 https://github.com/shuding/nextra/issues/3398