### PR TITLE
[v4] simplify the class-name of the sidebar file item

### DIFF
--- a/.changeset/fast-poets-hear.md
+++ b/.changeset/fast-poets-hear.md
@@ -2,4 +2,4 @@
 'nextra-theme-docs': patch
 ---
 
-simplify-the-class-name-of-the-sidebar-file-item
+Simplify the class-name of the sidebar file item

--- a/.changeset/fast-poets-hear.md
+++ b/.changeset/fast-poets-hear.md
@@ -2,4 +2,6 @@
 'nextra-theme-docs': patch
 ---
 
-Simplify the class-name of the sidebar file item
+- Simplify the class-name of the sidebar file item
+- fix unclosable active folder when it's `<button>` element and not `<a>`
+- improve `<Collapse>` to add inner `<div>` only if children != 1

--- a/.changeset/fast-poets-hear.md
+++ b/.changeset/fast-poets-hear.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+simplify-the-class-name-of-the-sidebar-file-item

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -41,11 +41,11 @@ const classes = {
     '_bg-primary-100 _font-semibold _text-primary-800 dark:_bg-primary-400/10 dark:_text-primary-600',
     'contrast-more:_border-primary-500 contrast-more:dark:_border-primary-500'
   ),
-  list: cn('_flex _flex-col _gap-1'),
+  list: cn('_grid _gap-1'),
   border: cn(
     '_relative before:_absolute before:_inset-y-1',
     'before:_w-px before:_bg-gray-200 before:_content-[""] dark:before:_bg-neutral-800',
-    '_ps-3 before:_start-0'
+    '_ps-3 before:_start-0 _pt-1 _ms-3'
   ),
   aside: cn(
     'nextra-sidebar _flex _flex-col',
@@ -163,18 +163,8 @@ function Folder({ item, anchors, onFocus, level }: FolderProps): ReactElement {
           if (clickedToggleIcon) {
             event.preventDefault()
           }
-          if (isLink) {
-            // If it's focused, we toggle it. Otherwise, always open it.
-            if (active || clickedToggleIcon) {
-              TreeState[item.route] = !open
-            } else {
-              TreeState[item.route] = true
-            }
-            rerender({})
-            return
-          }
-          if (active) return
-          TreeState[item.route] = !open
+          // If it's focused, we toggle it. Otherwise, always open it.
+          TreeState[item.route] = active || clickedToggleIcon ? !open : true
           rerender({})
         }}
         onFocus={onFocus}
@@ -193,7 +183,7 @@ function Folder({ item, anchors, onFocus, level }: FolderProps): ReactElement {
       {Array.isArray(item.children) && (
         <Collapse isOpen={open}>
           <Menu
-            className={cn(classes.border, '_pt-1 _ms-3')}
+            className={classes.border}
             directories={item.children}
             base={item.route}
             anchors={anchors}
@@ -236,7 +226,7 @@ function File({
   onFocus: FocusEventHandler
 }): ReactElement {
   const route = useFSRoute()
-  // It is possible that the item doesn't have any route - for example an external link.
+  // It is possible that the item doesn't have any route - for example, an external link.
   const active = item.route && [route, route + '/'].includes(item.route + '/')
   const activeSlug = useActiveAnchor()
 
@@ -255,7 +245,7 @@ function File({
         {item.title}
       </Anchor>
       {active && anchors.length > 0 && (
-        <ul className={cn(classes.list, classes.border, '_ms-3 _mt-1')}>
+        <ul className={cn(classes.list, classes.border)}>
           {anchors.map(({ id, value }) => (
             <li key={id}>
               <a

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -245,7 +245,7 @@ function File({
   }
 
   return (
-    <li className={cn(classes.list, { active })}>
+    <li className={cn({ active })}>
       <Anchor
         href={(item as PageItem).href || item.route}
         newWindow={(item as PageItem).newWindow}
@@ -255,7 +255,7 @@ function File({
         {item.title}
       </Anchor>
       {active && anchors.length > 0 && (
-        <ul className={cn(classes.list, classes.border, '_ms-3')}>
+        <ul className={cn(classes.list, classes.border, '_ms-3 _mt-1')}>
           {anchors.map(({ id, value }) => (
             <li key={id}>
               <a

--- a/packages/nextra/src/client/components/collapse.tsx
+++ b/packages/nextra/src/client/components/collapse.tsx
@@ -2,7 +2,7 @@
 
 import cn from 'clsx'
 import type { ReactElement, ReactNode } from 'react'
-import { useEffect, useRef } from 'react'
+import { Children, useEffect, useMemo, useRef } from 'react'
 
 export function Collapse({
   children,
@@ -60,7 +60,11 @@ export function Collapse({
   useEffect(() => {
     initialRender.current = false
   }, [])
-
+  // Add inner <div> only if children.length != 1
+  const newChildren = useMemo(
+    () => (Children.count(children) === 1 ? children : <div>{children}</div>),
+    [children]
+  )
   return (
     <div
       ref={containerRef}
@@ -73,7 +77,7 @@ export function Collapse({
         transitionDuration: (isOpen ? openDuration : closeDuration) + 'ms'
       }}
     >
-      <div>{children}</div>
+      {newChildren}
     </div>
   )
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

This PR aims to simplify the class name of the sidebar file item. Since the file item only needs `_flex _flex-col _gap-1` when `active && props.anchors.length > 0`, I added `_mt-1` to the anchor list to achieve the same effect.

![image](https://github.com/user-attachments/assets/dbe70a82-81fa-47b1-a053-8fe0c647df14)

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

sidebar

![image](https://github.com/user-attachments/assets/31323c19-4487-41c4-a1c6-696c7e16511d)

mobile nav

![image](https://github.com/user-attachments/assets/e806c24d-424f-47d9-b478-ccdb13e4d91d)

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
