### PR TITLE
add helpful error message about not available search on development mode

### DIFF
--- a/.changeset/calm-dolphins-swim.md
+++ b/.changeset/calm-dolphins-swim.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+add helpful error message about not available search on development mode

--- a/examples/swr-site/next-env.d.ts
+++ b/examples/swr-site/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/packages/nextra/src/client/components/search.tsx
+++ b/packages/nextra/src/client/components/search.tsx
@@ -42,20 +42,20 @@ const DEV_SEARCH_NOTICE = (
   <>
     Search is not available in development because Nextra&nbsp;4 uses Pagefind
     package which indexes built .html files rather than .md/.mdx content.
-    <div className="_mt-2">
+    <p className="_mt-2">
       If you really need to test search during development, follow these steps:
-      <ol className="_mt-2 _list-decimal">
-        <li>Build your app with `next build`</li>
-        <li>
-          Copy `.next/static/chunks/pagefind` folder to a different location
-        </li>
-        <li>Start your app in dev mode using `next dev`</li>
-        <li>
-          Copy `pagefind` folder into `.next/static/chunks/<b>app</b>` or
-          `.next/static/chunks/<b>app/[lang]</b>` for i18n website
-        </li>
-      </ol>
-    </div>
+    </p>
+    <ol className="_mt-2 _list-decimal">
+      <li>Build your app with `next build`</li>
+      <li>
+        Copy `.next/static/chunks/pagefind` folder to a different location
+      </li>
+      <li>Start your app in dev mode using `next dev`</li>
+      <li>
+        Copy `pagefind` folder into `.next/static/chunks/<b>app</b>` or
+        `.next/static/chunks/<b>app/[lang]</b>` for i18n website
+      </li>
+    </ol>
   </>
 )
 
@@ -254,7 +254,7 @@ export function Search({
             open ? '_opacity-100' : '_opacity-0',
             error || isLoading || !results.length
               ? [
-                  'md:_min-h-24 _grow _flex _justify-center _text-sm _gap-2 _px-8',
+                  'md:_min-h-28 _grow _flex _justify-center _text-sm _gap-2 _px-8',
                   error ? '_text-red-500' : '_text-gray-400 _items-center'
                 ]
               : // headlessui adds max-height as style, use !important to override


### PR DESCRIPTION
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/16c944fb-02cc-42ad-9129-93106eab3a9a">

fixes https://github.com/shuding/nextra/issues/3441 https://github.com/shuding/nextra/issues/2450 https://github.com/shuding/nextra/issues/3405

cc @87xie wdyt 😅

Postbuild script will be mentioned in docs, so no need to add here I guess

```json
"postbuild": "pagefind --site .next/server/app --output-path .next/static/chunks/pagefind",
```