### PR TITLE
[v4] add aria attrs to the sidebar collapse button

### DIFF
--- a/.changeset/four-fans-reply.md
+++ b/.changeset/four-fans-reply.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+Add aria attrs to the sidebar toggle button

--- a/.changeset/four-fans-reply.md
+++ b/.changeset/four-fans-reply.md
@@ -2,4 +2,4 @@
 'nextra-theme-docs': patch
 ---
 
-Add aria attrs to the sidebar toggle button
+Add aria attrs to the sidebar collapse button

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -407,7 +407,7 @@ export function MobileNav() {
 
 export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
   const { normalizePagesResult, hideSidebar } = useConfig()
-  const [showSidebar, setSidebar] = useState(true)
+  const [isExpanded, setIsExpanded] = useState(true)
   const [showToggleAnimation, setToggleAnimation] = useState(false)
   const sidebarRef = useRef<HTMLDivElement>(null)
   const anchors = useMemo(() => toc.filter(v => v.depth === 2), [toc])
@@ -443,20 +443,20 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
           classes.aside,
           'max-md:_hidden',
           '_top-[--nextra-navbar-height] _shrink-0',
-          showSidebar ? '_w-64' : '_w-20',
+          isExpanded ? '_w-64' : '_w-20',
           hideSidebar ? '_hidden' : '_sticky _self-start'
         )}
       >
         <div
           className={cn(
             classes.wrapper,
-            showSidebar ? 'nextra-scrollbar' : 'no-scrollbar'
+            isExpanded ? 'nextra-scrollbar' : 'no-scrollbar'
           )}
           ref={sidebarRef}
         >
           {/* without asPopover check <Collapse />'s inner.clientWidth on `layout: "raw"` will be 0 and element will not have width on initial loading */}
-          {(!hideSidebar || !showSidebar) && (
-            <Collapse isOpen={showSidebar} horizontal>
+          {(!hideSidebar || !isExpanded) && (
+            <Collapse isOpen={isExpanded} horizontal>
               <Menu
                 className="nextra-menu-desktop"
                 // The sidebar menu, shows only the docs directories.
@@ -475,28 +475,28 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
           <div
             className={cn(
               classes.bottomMenu,
-              showSidebar
+              isExpanded
                 ? [hasI18n && '_justify-end', '_border-t']
                 : '_py-4 _flex-wrap _justify-center',
               showToggleAnimation && [
                 '*:_opacity-0',
-                showSidebar
+                isExpanded
                   ? '*:_animate-[nextra-fadein_1s_ease_.2s_forwards]'
                   : '*:_animate-[nextra-fadein2_1s_ease_.2s_forwards]'
               ]
             )}
           >
             <LocaleSwitch
-              lite={!showSidebar}
-              className={showSidebar ? '_grow' : 'max-md:_grow'}
+              lite={!isExpanded}
+              className={isExpanded ? '_grow' : 'max-md:_grow'}
             />
             <ThemeSwitch
-              lite={!showSidebar || hasI18n}
-              className={!showSidebar || hasI18n ? '' : '_grow'}
+              lite={!isExpanded || hasI18n}
+              className={!isExpanded || hasI18n ? '' : '_grow'}
             />
             {themeConfig.sidebar.toggleButton && (
               <Button
-                title={showSidebar ? 'Hide sidebar' : 'Show sidebar'}
+                title={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
                 className={({ hover }) =>
                   cn(
                     '_rounded-md _p-2',
@@ -506,14 +506,14 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
                   )
                 }
                 onClick={() => {
-                  setSidebar(prev => !prev)
+                  setIsExpanded(prev => !prev)
                   setToggleAnimation(true)
                 }}
               >
                 <ExpandIcon
                   height="12"
                   className={cn(
-                    !showSidebar && 'first:*:_origin-[35%] first:*:_rotate-180'
+                    !isExpanded && 'first:*:_origin-[35%] first:*:_rotate-180'
                   )}
                 />
               </Button>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -410,7 +410,6 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
   const [isExpanded, setIsExpanded] = useState(true)
   const [showToggleAnimation, setToggleAnimation] = useState(false)
   const sidebarRef = useRef<HTMLDivElement>(null)
-  const anchors = useMemo(() => toc.filter(v => v.depth === 2), [toc])
 
   const { docsDirectories, activeThemeContext } = normalizePagesResult
   const includePlaceholder = activeThemeContext.layout === 'default'
@@ -429,6 +428,11 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
   }, [])
 
   const themeConfig = useThemeConfig()
+  const anchors = useMemo(() => (
+    // When the viewport size is larger than `md`, hide the anchors in
+    // the sidebar when `floatTOC` is enabled.
+    themeConfig.toc.float ? [] : toc.filter(v => v.depth === 2)
+  ), [themeConfig.toc.float, toc])
   const hasI18n = themeConfig.i18n.length > 0
   const hasMenu =
     themeConfig.darkMode || hasI18n || themeConfig.sidebar.toggleButton
@@ -461,9 +465,7 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
                 className="nextra-menu-desktop"
                 // The sidebar menu, shows only the docs directories.
                 directories={docsDirectories}
-                // When the viewport size is larger than `md`, hide the anchors in
-                // the sidebar when `floatTOC` is enabled.
-                anchors={themeConfig.toc.float ? [] : anchors}
+                anchors={anchors}
                 onlyCurrentDocs
                 level={0}
               />

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -8,7 +8,7 @@ import { useFSRoute } from 'nextra/hooks'
 import { ArrowRightIcon, ExpandIcon } from 'nextra/icons'
 import type { Item, MenuItem, PageItem } from 'nextra/normalize-pages'
 import type { FocusEventHandler, ReactElement } from 'react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, useId } from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import {
   setFocusedRoute,
@@ -410,6 +410,7 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
   const [isExpanded, setIsExpanded] = useState(true)
   const [showToggleAnimation, setToggleAnimation] = useState(false)
   const sidebarRef = useRef<HTMLDivElement>(null)
+  const sidebarControlsId = useId()
 
   const { docsDirectories, activeThemeContext } = normalizePagesResult
   const includePlaceholder = activeThemeContext.layout === 'default'
@@ -443,6 +444,7 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
         <div className="max-xl:_hidden _h-0 _w-64 _shrink-0" />
       )}
       <aside
+        id={sidebarControlsId}
         className={cn(
           classes.aside,
           'max-md:_hidden',
@@ -498,6 +500,8 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
             />
             {themeConfig.sidebar.toggleButton && (
               <Button
+                aria-expanded={isExpanded}
+                aria-controls={sidebarControlsId}
                 title={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
                 className={({ hover }) =>
                   cn(

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -8,7 +8,7 @@ import { useFSRoute } from 'nextra/hooks'
 import { ArrowRightIcon, ExpandIcon } from 'nextra/icons'
 import type { Item, MenuItem, PageItem } from 'nextra/normalize-pages'
 import type { FocusEventHandler, ReactElement } from 'react'
-import { useEffect, useMemo, useRef, useState, useId } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import {
   setFocusedRoute,
@@ -429,11 +429,13 @@ export function Sidebar({ toc }: { toc: Heading[] }): ReactElement {
   }, [])
 
   const themeConfig = useThemeConfig()
-  const anchors = useMemo(() => (
-    // When the viewport size is larger than `md`, hide the anchors in
-    // the sidebar when `floatTOC` is enabled.
-    themeConfig.toc.float ? [] : toc.filter(v => v.depth === 2)
-  ), [themeConfig.toc.float, toc])
+  const anchors = useMemo(
+    () =>
+      // When the viewport size is larger than `md`, hide the anchors in
+      // the sidebar when `floatTOC` is enabled.
+      themeConfig.toc.float ? [] : toc.filter(v => v.depth === 2),
+    [themeConfig.toc.float, toc]
+  )
   const hasI18n = themeConfig.i18n.length > 0
   const hasMenu =
     themeConfig.darkMode || hasI18n || themeConfig.sidebar.toggleButton


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

<!-- If there's an existing issue for your change, please link to it above. -->

This pull request introduces the following:

- Add `aria-expanded` and `aria-controls` attrs to the sidebar collapse button.
- Rename the `showSidebar` to `isExpanded` for better clarity, making it easier to distinguish between `useConfig().hideSidebar` and `!showSidebar`.
- Update the `aria-label` of the collapse button to  "Expand sidebar" or "Collapse sidebar".
- Colocate the sidebar anchors calculation.

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

expanded

![image](https://github.com/user-attachments/assets/21fbc9f9-ce19-4261-856c-8f287c47d604)

collapsed

![image](https://github.com/user-attachments/assets/9b886a32-5ba9-4f69-83ce-2b5264f7ba99)

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
