### PR TITLE
fix(mdx-components): link no underline hover

### DIFF
--- a/packages/nextra-theme-docs/src/mdx-components.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components.tsx
@@ -212,7 +212,7 @@ export const Link = ({ href = '', className, ...props }: AnchorProps) => (
     href={href}
     newWindow={EXTERNAL_HREF_REGEX.test(href)}
     className={cn(
-      '_text-primary-600 _underline _decoration-from-font [text-underline-position:from-font]',
+      '_text-primary-600 _underline hover:_no-underline _decoration-from-font [text-underline-position:from-font]',
       className
     )}
     {...props}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Current link behaviours for nextra-theme-docs : 

| | default | hover |
| ---- | ---- | ---- | 
| mdx | primary colour + underline | primary colour + underline | 
| article : typeset | primary colour | primary colour + underline | 

From an accessibility POV ([WCAG G13](https://www.w3.org/WAI/WCAG21/Techniques/general/G183)) there's a need of additional visual differentiation factor for hovers. Article achieves this but mdx doesn't. 

Closes: N/A

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

changing the mdx link behaviour so on hover the underline disappears 

| | default | hover |
| ---- | ---- | ---- | 
| mdx | primary colour + underline | **primary colour ~+ underline~** | 
| article : typeset | primary colour | primary colour + underline | 

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
