### PR TITLE
[ISSUE-3476] style: narrow css specificity for code elements

### DIFF
--- a/.changeset/fifty-birds-invite.md
+++ b/.changeset/fifty-birds-invite.md
@@ -1,0 +1,5 @@
+---
+"nextra": patch
+---
+
+update css selectors for `code`, use `code.nextra-code`

--- a/packages/nextra/styles/code-block.css
+++ b/packages/nextra/styles/code-block.css
@@ -3,7 +3,7 @@
   @apply dark:_bg-[--shiki-dark-bg] dark:_text-[--shiki-dark];
 }
 
-code:not([class*='twoslash-']) {
+code.nextra-code:not([class*='twoslash-']) {
   box-decoration-break: slice;
   font-feature-settings:
     'rlig' 1,

--- a/packages/nextra/styles/code-block.css
+++ b/packages/nextra/styles/code-block.css
@@ -16,7 +16,7 @@ code.nextra-code:not([class*='twoslash-']) {
   }
 }
 
-pre code:not([class*='twoslash-']) {
+pre code.nextra-code:not([class*='twoslash-']) {
   @apply _grid _text-sm;
 
   &[data-line-numbers] > span {


### PR DESCRIPTION
## Why:
All code elements written as markdown in mdx files via backticks will automatically have the `nextra-code` class.

Any other code elements that could come from custom components, might not want the default nextra style applied to it.

In fact, if you have tailwind applied to your custom `<code>` elements, it will be overwritten by the global `code:not([class*='twoslash-'])` specifier since it has a higher specificity.

If someone prefers the global css for custom `<code>` elements, they can add the class `nextra-code` to get it applied still.

Closes:
https://github.com/shuding/nextra/issues/3476

## What's being changed (if available, include any code snippets, screenshots, or gifs):
css specifier

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
