### PR TITLE
[v4] defer pagefind results update for prioritizing user input state

### DIFF
--- a/.changeset/six-parrots-dream.md
+++ b/.changeset/six-parrots-dream.md
@@ -1,5 +1,5 @@
 ---
-'nextra-theme-docs': patch
+'nextra': patch
 ---
 
 defer pagefind results update for prioritizing the user input state

--- a/.changeset/six-parrots-dream.md
+++ b/.changeset/six-parrots-dream.md
@@ -1,5 +1,7 @@
 ---
 'nextra': patch
+'nextra-theme-docs': patch
+'nextra-theme-blog': patch
 ---
 
 defer pagefind results update for prioritizing the user input state

--- a/.changeset/six-parrots-dream.md
+++ b/.changeset/six-parrots-dream.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+defer pagefind results update for prioritizing the user input state

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -134,6 +134,7 @@ module.exports = {
         projectService: true
       },
       rules: {
+        '@typescript-eslint/await-thenable': 'error',
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/non-nullable-type-assertion-style': 'error',

--- a/examples/swr-site/app/[lang]/[[...mdxPath]]/page.tsx
+++ b/examples/swr-site/app/[lang]/[[...mdxPath]]/page.tsx
@@ -12,10 +12,10 @@ export async function generateMetadata(props: PageProps) {
 }
 
 type PageProps = {
-  params: {
+  params: Promise<{
     mdxPath: string[]
     lang: string
-  }
+  }>
 }
 
 export default async function Page(props: PageProps) {


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

In v4 `<Search>`, when receiving multiple pagefind results, the user input update will also be delayed.

Here are the steps to reproduce:

1. Visit the [preview page](https://nextra-v2-git-v4-31-shud.vercel.app/).
1. Type "to" in the search bar.
1. Press the `Backspace` key to delete "o".

https://github.com/user-attachments/assets/cef0b0b3-d19f-46d2-a113-7ddc6722df4f

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

I separated the `search` and `deferredSearch` for:

- `search`: high-priority state for user input.
- `deferredSearch`: low-priority state for pagefind result calculation.

There might be a better way to solve this. Feel free to close this if it’s not suitable.

https://github.com/user-attachments/assets/357a57c9-dfd9-4b35-bb4c-6997f035fc17

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
