### PR TITLE
[v4] move pagefind output to public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ out/
 
 tsup.config.bundled*
 tsconfig.tsbuildinfo
-pagefind/
+_pagefind/

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next",
-    "postbuild": "pagefind --site .next/server/app --output-path .next/static/chunks/pagefind",
+    "postbuild": "pagefind --site .next/server/app --output-path './public/_pagefind'",
     "start": "next start"
   },
   "dependencies": {

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "clean": "rimraf .next .turbo",
     "dev": "next",
-    "postbuild": "pagefind --site .next/server/app --output-path .next/static/chunks/pagefind",
+    "postbuild": "pagefind --site .next/server/app --output-path './public/_pagefind'",
     "start": "next start"
   },
   "dependencies": {

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "clean": "rimraf .next .turbo",
     "dev": "next",
-    "postbuild": "pagefind --site .next/server/app --output-path .next/static/chunks/pagefind",
+    "postbuild": "pagefind --site .next/server/app --output-path './public/_pagefind'",
     "start": "next start"
   },
   "dependencies": {

--- a/examples/swr-site/middleware.ts
+++ b/examples/swr-site/middleware.ts
@@ -3,6 +3,6 @@ export { middleware } from 'nextra/locales'
 export const config = {
   // Matcher ignoring `/_next/` and `/api/`
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg|apple-icon.png|manifest).*)'
+    '/((?!api|_next/static|_next/image|favicon.ico|icon.svg|apple-icon.png|manifest|_pagefind).*)'
   ]
 }

--- a/examples/swr-site/package.json
+++ b/examples/swr-site/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf .next .turbo",
     "debug": "NODE_OPTIONS='--inspect' next dev",
     "dev": "next",
-    "postbuild": "pagefind --site .next/server/app --output-path .next/static/chunks/pagefind",
+    "postbuild": "pagefind --site .next/server/app --output-path './public/_pagefind'",
     "prebuild": "node nextra-remote-filepaths/fetch.js",
     "predev": "pnpm prebuild",
     "start": "next start",

--- a/packages/nextra/src/client/components/search.tsx
+++ b/packages/nextra/src/client/components/search.tsx
@@ -93,7 +93,7 @@ export const Search: FC<SearchProps> = ({
       try {
         window.pagefind = await import(
           // @ts-expect-error pagefind.js generated after build
-          /* webpackIgnore: true */ './pagefind/pagefind.js'
+          /* webpackIgnore: true */ '/_pagefind/pagefind.js'
         )
         await window.pagefind.options({
           baseUrl: '/'


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

This change aims to preserve the previous Pagefind output for reuse when running `next dev`. It could slightly improve the DX  and simplify the steps in `DEV_SEARCH_NOTICE`.

I haven’t updated `DEV_SEARCH_NOTICE` yet and would like to check if this approach is suitable. Feel free to close this if I’ve missed something obvious.

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

After this change:

```bash
pnpm build:all
# search is available in development mode after running `next build`
pnpm dev:website
```

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
