### PR TITLE
fix(nextra/server): Prevent overwriting of transformer

### DIFF
--- a/.changeset/thirty-seahorses-bathe.md
+++ b/.changeset/thirty-seahorses-bathe.md
@@ -1,0 +1,5 @@
+---
+"nextra": patch
+---
+
+fix(loader): Prevent overwriting of `rehypePrettyCodeOptions.transformer`

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -160,13 +160,14 @@ ${themeConfigImport && '__nextra_internal__.themeConfig = __themeConfig'}`
       outputFormat: 'program',
       format: 'detect',
       rehypePrettyCodeOptions: {
+        ...mdxOptions?.rehypePrettyCodeOptions,
         transformers: [
           transformerTwoslash({
             renderer: twoslashRenderer(),
             explicitTrigger: true
-          })
-        ],
-        ...mdxOptions?.rehypePrettyCodeOptions
+          }),
+          ...(mdxOptions?.rehypePrettyCodeOptions?.transformers || [])
+        ]
       }
     },
     readingTime: _readingTime,


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes:

`mdxOptions.rehypePrettyCodeOptions.transformers`overrides pre-existing twoslash transformer. 

```js
const withNextra = nextra({
  theme: 'nextra-theme-docs',
  themeConfig: './theme.config.tsx',
  mdxOptions: {
    rehypePrettyCodeOptions: {
      transformers: [...] // <---
    }
  }
})
```






<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
