### PR TITLE
[v3] fix `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /path/to/project/node_modules/nextra/package.json` when using `next.config.ts`

### DIFF
--- a/.changeset/happy-poems-boil.md
+++ b/.changeset/happy-poems-boil.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+fix `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /path/to/project/node_modules/nextra/package.json` when using `next.config.ts`

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -21,7 +21,7 @@ export default withNextra({
     // ESLint behaves weirdly in this monorepo.
     ignoreDuringBuilds: true
   },
-  redirects: () => [
+  redirects: async () => [
     {
       source: '/docs/guide/:slug(typescript|latex|tailwind-css|mermaid)',
       destination: '/docs/guide/advanced/:slug',

--- a/examples/swr-site/next.config.ts
+++ b/examples/swr-site/next.config.ts
@@ -54,7 +54,7 @@ export default withBundleAnalyzer(
       defaultLocale: 'en'
     }, // basePath: "/some-base-path",
     distDir: './.next', // Nextra supports custom `nextConfig.distDir`
-    redirects: () => [
+    redirects: async () => [
       // {
       //   source: "/docs.([a-zA-Z-]+)",
       //   destination: "/docs/getting-started",

--- a/packages/nextra/package.json
+++ b/packages/nextra/package.json
@@ -11,8 +11,9 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.js",
-      "types": "./dist/server/index.d.ts"
+      "require": "./dist/server/index.js"
     },
     "./loader": "./loader.cjs",
     "./components": {


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/3583