### PR TITLE
feat(nextra-theme-docs): primary color.lightness theme config

### DIFF
--- a/.changeset/big-years-agree.md
+++ b/.changeset/big-years-agree.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": feat
+---
+
+feat(nextra-theme-docs): add new theme config option `color.lightness`

--- a/docs/components/_slider.tsx
+++ b/docs/components/_slider.tsx
@@ -43,3 +43,25 @@ export function Saturation() {
     </div>
   )
 }
+
+export function Lightness() {
+  return (
+    <div className="flex h-6 items-center gap-2">
+      <input
+        type="range"
+        min="0"
+        max="100"
+        step="1"
+        onChange={e => {
+          const value = `${e.target.value}%`
+          e.target.nextSibling!.textContent = value
+          document.documentElement.style.setProperty(
+            '--nextra-primary-lightness',
+            value
+          )
+        }}
+      />
+      <label className="text-sm text-gray-500 w-14" />
+    </div>
+  )
+}

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -146,26 +146,48 @@ Customize the theme behavior of the website.
 
 ### Theme Color
 
-You can adjust the theme color of the website by setting primary hue and
-saturation values for light and dark themes.
+You can adjust the theme color of the website by setting primary hue, saturation
+and lightness (HSL) values for light and dark themes.
 
 <Table>
 
-|                       |                                             |                                           |
-| --------------------- | ------------------------------------------- | ----------------------------------------- |
-| color.hue             | `number \| { dark: number; light: number }` | The hue of the primary theme color        |
-| color.saturation      | `number \| { dark: number; light: number }` | The saturation of the primary theme color |
-| color.lightness       | `number \| { dark: number; light: number }` | The lightness of the primary theme color  |
-| backgroundColor.dark  | `string` in format `RRR,GGG,BBB`            | Background color for light theme          |
-| backgroundColor.light | `string` in format `RRR,GGG,BBB`            | Background color for dark theme           |
+|                       |                                             |                                                     |
+| --------------------- | ------------------------------------------- | --------------------------------------------------- |
+| color.hue             | `number \| { dark: number; light: number }` | The hue of the primary theme color (0 - 360)        |
+| color.saturation      | `number \| { dark: number; light: number }` | The saturation of the primary theme color (0 - 100) |
+| color.lightness       | `number \| { dark: number; light: number }` | The lightness of the primary theme color (0 - 100)  |
+| backgroundColor.dark  | `string` in format `RRR,GGG,BBB`            | Background color for light theme                    |
+| backgroundColor.light | `string` in format `RRR,GGG,BBB`            | Background color for dark theme                     |
 
 </Table>
 
 Try it out for this website:
 
-| Hue     | Saturation     | Lightness    |
-| ------- | -------------- | ------------ |
-| <Hue /> | <Saturation /> | <Lightness/> |
+| Hue (H) | Saturation (S) | Lightness (L) |
+| ------- | -------------- | ------------- |
+| <Hue /> | <Saturation /> | <Lightness/>  |
+
+<Callout>
+
+You can adjust the lightness independently for dark or light mode to increase
+legibility. For example, to have a neutral primary color you can set the primary
+colour to be white `HSL(0, 0%, 100%)` on dark theme and gray `HSL(0, 0%, 50%)`
+for light theme.
+
+```jsx filename="theme.config.jsx"
+export default {
+  color: {
+    hue: 0,
+    saturation: 0,
+    lightness: {
+      dark: 100,
+      light: 50
+    }
+  }
+}
+```
+
+</Callout>
 
 ## Navbar
 

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -1,4 +1,4 @@
-import { Hue, Saturation, Lightness } from '@components/_slider'
+import { Hue, Lightness, Saturation } from '@components/_slider'
 import { Screenshot } from 'components/screenshot'
 import { Callout } from 'nextra/components'
 import logoImage from 'public/assets/docs/logo.png'

--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -1,4 +1,4 @@
-import { Hue, Saturation } from '@components/_slider'
+import { Hue, Saturation, Lightness } from '@components/_slider'
 import { Screenshot } from 'components/screenshot'
 import { Callout } from 'nextra/components'
 import logoImage from 'public/assets/docs/logo.png'
@@ -155,6 +155,7 @@ saturation values for light and dark themes.
 | --------------------- | ------------------------------------------- | ----------------------------------------- |
 | color.hue             | `number \| { dark: number; light: number }` | The hue of the primary theme color        |
 | color.saturation      | `number \| { dark: number; light: number }` | The saturation of the primary theme color |
+| color.lightness       | `number \| { dark: number; light: number }` | The lightness of the primary theme color  |
 | backgroundColor.dark  | `string` in format `RRR,GGG,BBB`            | Background color for light theme          |
 | backgroundColor.light | `string` in format `RRR,GGG,BBB`            | Background color for dark theme           |
 
@@ -162,9 +163,9 @@ saturation values for light and dark themes.
 
 Try it out for this website:
 
-| Hue     | Saturation     |
-| ------- | -------------- |
-| <Hue /> | <Saturation /> |
+| Hue     | Saturation     | Lightness    |
+| ------- | -------------- | ------------ |
+| <Hue /> | <Saturation /> | <Lightness/> |
 
 ## Navbar
 

--- a/packages/nextra-theme-docs/src/components/head.tsx
+++ b/packages/nextra-theme-docs/src/components/head.tsx
@@ -15,13 +15,17 @@ export function Head(): ReactElement {
     typeof themeConfig.head === 'function'
       ? themeConfig.head({})
       : themeConfig.head
-  const { hue, saturation } = themeConfig.color
+  const { hue, saturation, lightness } = themeConfig.color
   const { dark: darkHue, light: lightHue } =
     typeof hue === 'number' ? { dark: hue, light: hue } : hue
   const { dark: darkSaturation, light: lightSaturation } =
     typeof saturation === 'number'
       ? { dark: saturation, light: saturation }
       : saturation
+  const { dark: darkLightness, light: lightLightness } =
+    typeof lightness === 'number'
+      ? { dark: lightness, light: lightness }
+      : lightness
 
   const bgColor = themeConfig.backgroundColor
 
@@ -56,7 +60,7 @@ export function Head(): ReactElement {
         name="viewport"
         content="width=device-width, initial-scale=1.0, viewport-fit=cover"
       />
-      <style>{`:root{--nextra-primary-hue:${lightHue}deg;--nextra-primary-saturation:${lightSaturation}%;--nextra-navbar-height:64px;--nextra-menu-height:3.75rem;--nextra-banner-height:2.5rem;--nextra-bg:${bgColor.light};}.dark{--nextra-primary-hue:${darkHue}deg;--nextra-primary-saturation:${darkSaturation}%;--nextra-bg:${bgColor.dark};}`}</style>
+      <style>{`:root{--nextra-primary-hue:${lightHue}deg;--nextra-primary-saturation:${lightSaturation}%;--nextra-primary-lightness:${lightLightness}%;--nextra-navbar-height:64px;--nextra-menu-height:3.75rem;--nextra-banner-height:2.5rem;--nextra-bg:${bgColor.light};}.dark{--nextra-primary-hue:${darkHue}deg;--nextra-primary-saturation:${darkSaturation}%;--nextra-primary-lightness:${darkLightness}%;--nextra-bg:${bgColor.dark};}`}</style>
       {head}
     </NextHead>
   )

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -42,7 +42,11 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       dark: 204,
       light: 212
     },
-    saturation: 100
+    saturation: 100,
+    lightness: {
+      dark: 55,
+      light: 45
+    },
   },
   darkMode: true,
   direction: 'ltr',

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -46,7 +46,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     lightness: {
       dark: 55,
       light: 45
-    },
+    }
   },
   darkMode: true,
   direction: 'ltr',

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -42,11 +42,11 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       dark: 204,
       light: 212
     },
-    saturation: 100,
     lightness: {
       dark: 55,
       light: 45
-    }
+    },
+    saturation: 100
   },
   darkMode: true,
   direction: 'ltr',

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -98,6 +98,12 @@ export const themeSchema = /* @__PURE__ */ (() =>
           dark: z.number(),
           light: z.number()
         })
+      ),
+      lightness: z.number().or(
+        z.strictObject({
+          dark: z.number(),
+          light: z.number()
+        })
       )
     }),
     project: z.strictObject({

--- a/packages/nextra-theme-docs/tailwind.config.ts
+++ b/packages/nextra-theme-docs/tailwind.config.ts
@@ -5,7 +5,7 @@ const makePrimaryColor: any =
   (l: number) =>
   ({ opacityValue }: { opacityValue?: string }) => {
     return (
-      `hsl(var(--nextra-primary-hue) var(--nextra-primary-saturation) ${l}%` +
+      `hsl(var(--nextra-primary-hue) var(--nextra-primary-saturation) calc(var(--nextra-primary-lightness) + ${l}%)` +
       (opacityValue ? ` / ${opacityValue})` : ')')
     )
   }
@@ -52,17 +52,17 @@ export default {
       blue: colors.blue,
       yellow: colors.yellow,
       primary: {
-        50: makePrimaryColor(97),
-        100: makePrimaryColor(94),
-        200: makePrimaryColor(86),
-        300: makePrimaryColor(77),
-        400: makePrimaryColor(66),
-        500: makePrimaryColor(50),
-        600: makePrimaryColor(45),
-        700: makePrimaryColor(39),
-        750: makePrimaryColor(35),
-        800: makePrimaryColor(32),
-        900: makePrimaryColor(24)
+        50: makePrimaryColor(52),
+        100: makePrimaryColor(49),
+        200: makePrimaryColor(41),
+        300: makePrimaryColor(32),
+        400: makePrimaryColor(21),
+        500: makePrimaryColor(5),
+        600: makePrimaryColor(0),
+        700: makePrimaryColor(-6),
+        750: makePrimaryColor(-10),
+        800: makePrimaryColor(-13),
+        900: makePrimaryColor(-11)
       }
     }
   },


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

within theme config, we currently support tweaking color.hue and color.saturation 
this PR comples by adding color.lightness support 

for some hue/sat combos lightness needs to be tweaked independantly on light and dark mode for readability, ie. : 

| light | dark | 
| ---- | ---- | 
| ![CleanShot 2024-10-30 at 12  28 05@2x](https://github.com/user-attachments/assets/b209558a-e08d-4040-b501-f094737132eb) | ![CleanShot 2024-10-30 at 12  28 21@2x](https://github.com/user-attachments/assets/4c21e671-729b-4974-8668-8402a3db551d) |
| ![CleanShot 2024-10-30 at 12  29 26@2x](https://github.com/user-attachments/assets/854e8005-15d6-40fe-a4db-3b196883b507) | ![CleanShot 2024-10-30 at 12  29 59@2x](https://github.com/user-attachments/assets/5f1b8b2c-524a-4fec-9079-9d4bf0c629bc) |
| ![CleanShot 2024-10-30 at 12  29 45@2x](https://github.com/user-attachments/assets/b615295a-dcab-49b6-886e-0b0491483213) | ![CleanShot 2024-10-30 at 12  30 10@2x](https://github.com/user-attachments/assets/0a8ee9f2-e37a-480a-92b9-819bfac471d2) |

^ some edge case scenarios 

Closes #2815 
Closes #2786

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):


https://github.com/user-attachments/assets/2d7756c7-f026-4d35-b859-c7697d6291c4

TAKE NOTE FOR THE FOLLOWING : 

I've set the default constant as 

```js
    lightness: {
      dark: 55,     // tweaked to make it slightly lighter for legibility
      light: 45     // current default value (primary-600)
    },
```

and in the tailwind config file. instead of hard coding the L for all the 50~900 range. what I've done is we'll use the defined primary color.lightness + variable L 

``` diff
      primary: {
-       50: makePrimaryColor(97),
-       ...
-       500: makePrimaryColor(50),
-       600: makePrimaryColor(45),
-       ...
-       900: makePrimaryColor(24)
+       50: makePrimaryColor(52),   // = 97 - 45
+       ...
+       500: makePrimaryColor(5),   // = 50 - 45
+       600: makePrimaryColor(0),   // = 45 - 45
+       ...
+       900: makePrimaryColor(-11)  // = 24 - 45
      }
```

using the same 'why' edge case examples, we can now override the lightness for dark/light mode -- take note of the TOC active highlight 

| light | dark | 
| ---- | ---- |
| 56 ![CleanShot 2024-10-30 at 12  53 36@2x](https://github.com/user-attachments/assets/0572be5a-3e49-4206-a3a9-75e8857c2ab5) | 75 ![CleanShot 2024-10-30 at 12  52 19@2x](https://github.com/user-attachments/assets/0f2d0cdf-d986-4a81-948b-69877f221a68) | 
| 34 ![CleanShot 2024-10-30 at 12  54 53@2x](https://github.com/user-attachments/assets/971b06fa-b1ab-4d06-bea1-e10fd6c49a2e) | 59 ![CleanShot 2024-10-30 at 12  55 18@2x](https://github.com/user-attachments/assets/599c3c9c-9b40-45da-97f7-fdd03fa39fd0) |

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
