### PR TITLE
navbar items setter

### DIFF
--- a/examples/docs/app/NavTester.tsx
+++ b/examples/docs/app/NavTester.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useConfig } from 'nextra-theme-docs'
+import { useEffect } from 'react'
+
+export const NavTester = () => {
+  const { setTopLevelNavbarItems } = useConfig()
+  const path = usePathname()
+
+  useEffect(() => {
+    console.log(path)
+    if (path === '/docs') {
+      console.log('fires')
+      setTopLevelNavbarItems([
+        {
+          product: {
+            title: 'Product',
+            type: 'menu',
+            items: {
+              about: {
+                href: '/product'
+              },
+              test: {
+                href: '/test'
+              }
+            }
+          }
+        },
+        {
+          name: 'Services',
+          type: 'menu',
+          items: [
+            {
+              service1: {
+                href: '/service1'
+              }
+            },
+            {
+              service2: {
+                href: '/service2'
+              }
+            }
+          ]
+        }
+      ])
+    }
+  }, [path])
+
+  return <div>NAV-TEST</div>
+}

--- a/examples/docs/app/layout.jsx
+++ b/examples/docs/app/layout.jsx
@@ -3,6 +3,7 @@ import { Footer, Layout, Navbar } from 'nextra-theme-docs'
 import { Banner, Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import 'nextra-theme-docs/style.css'
+import { NavTester } from './NavTester'
 
 export const { viewport } = Head
 
@@ -37,7 +38,9 @@ export default async function RootLayout({ children }) {
       }
       // Next.js discord server
       chatLink="https://discord.gg/hEM84NMkRv"
-    />
+    >
+      <NavTester />
+    </Navbar>
   )
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: #3620

My stab at the problem. Trying to make a setter for the store, and expose it in the `useConfig()` hook, but I can't seem to get it to work. Maybe somebody else can build on this or spot the issue? 

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding and exposing a setter for the store related specifically for the `topLevelNavbarItems` in `normalizePagesResult` 

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
