### PR TITLE
[v4] include `document.referrer` in link in `<NotFoundPage>` component

### DIFF
--- a/.changeset/honest-falcons-brush.md
+++ b/.changeset/honest-falcons-brush.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+include `document.referrer` in link in `<NotFoundPage>` component

--- a/packages/nextra-theme-docs/src/components/404/index.client.tsx
+++ b/packages/nextra-theme-docs/src/components/404/index.client.tsx
@@ -14,12 +14,15 @@ export const NotFoundLink: FC<{
   const config = useThemeConfig()
   const pathname = usePathname()
   const mounted = useMounted()
+  const ref = mounted && document.referrer
+  const referrer = ref ? ` from "${ref}"` : ''
 
   return (
     <Link
+      className="_mt-6"
       href={getGitIssueUrl({
         repository: config.docsRepositoryBase,
-        title: `Found broken \`${mounted ? pathname : ''}\` link. Please fix!`,
+        title: `Found broken "${mounted ? pathname : ''}" link${referrer}. Please fix!`,
         labels
       })}
     >

--- a/packages/nextra-theme-docs/src/components/404/index.tsx
+++ b/packages/nextra-theme-docs/src/components/404/index.tsx
@@ -1,3 +1,4 @@
+import cn from 'clsx'
 import type { FC, ReactNode } from 'react'
 import { H1 } from '../../mdx-components/heading'
 import { NotFoundLink } from './index.client'
@@ -6,15 +7,22 @@ type NotFoundPageProps = {
   content?: ReactNode
   labels?: string
   children?: ReactNode
+  className?: string
 }
 
 export const NotFoundPage: FC<NotFoundPageProps> = ({
   content = 'Submit an issue about broken link',
   labels = 'bug',
-  children = <H1>404: Page Not Found</H1>
+  children = <H1>404: Page Not Found</H1>,
+  className
 }) => {
   return (
-    <div className="_flex _flex-col _justify-center _items-center _gap-6 _h-[calc(100dvh-var(--nextra-navbar-height))]">
+    <div
+      className={cn(
+        '_flex _flex-col _justify-center _items-center _h-[calc(100dvh-var(--nextra-navbar-height))]',
+        className
+      )}
+    >
       {children}
       <NotFoundLink labels={labels}>{content}</NotFoundLink>
     </div>


### PR DESCRIPTION
inspired from https://github.com/graphql/graphql.github.io/pull/1810