### PR TITLE
docs: literal table with built-in components

### DIFF
--- a/docs/pages/docs/docs-theme/_meta.ts
+++ b/docs/pages/docs/docs-theme/_meta.ts
@@ -2,5 +2,5 @@ export default {
   start: 'Get Started',
   'page-configuration': '',
   'theme-configuration': '',
-  'built-ins': 'Built-ins Components'
+  'built-ins': 'Built-in Components'
 }

--- a/docs/pages/docs/guide/_meta.ts
+++ b/docs/pages/docs/guide/_meta.ts
@@ -9,6 +9,6 @@ export default {
   'custom-css': '',
   'static-exports': '',
   search: '',
-  'built-ins': 'Built-ins Components',
+  'built-ins': 'Built-in Components',
   advanced: ''
 }

--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -33,8 +33,8 @@ table will be unstyled because
 elements with
 [components provided by `useMDXComponents(){:js}`](https://mdxjs.com/packages/vue/#usemdxcomponentscomponents).
 
-<Callout type="info">
-  Instead, use the [built-in `<Table>`, `<Tr>`, `<Th>`, and `<Td>` components](/docs/guide/built-ins/table)
+<Callout>
+  Instead, use the [built-in `<Table>`, `<Th>`, `<Tr>`, and `<Td>` components](/docs/guide/built-ins/table)
   available via `nextra/components`.
 </Callout>
 

--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -1,4 +1,4 @@
-import { Steps } from 'nextra/components'
+import { Steps, Table, Td, Th, Tr } from 'nextra/components'
 
 # Rendering Tables
 
@@ -33,51 +33,53 @@ table will be unstyled because
 elements with
 [components provided by `useMDXComponents(){:js}`](https://mdxjs.com/packages/vue/#usemdxcomponentscomponents).
 
+Instead, use the built-in `<Table>`, `<Tr>`, `<Th>`, and `<Td>` components instead:
+
 ### Usage
 
 ```mdx filename="MDX"
-<table>
+import { Table, Td, Th, Tr } from 'nextra/components'
+
+<Table>
   <thead>
-    <tr>
-      <th>Country</th>
-      <th>Flag</th>
-    </tr>
+    <Tr>
+      <Th>Country</Th>
+      <Th>Flag</Th>
+    </Tr>
   </thead>
   <tbody>
-    <tr>
-      <td>France</td>
-      <td>🇫🇷</td>
-    </tr>
-    <tr>
-      <td>Ukraine</td>
-      <td>🇺🇦</td>
-    </tr>
+    <Tr>
+      <Td>France</Td>
+      <Td>🇫🇷</Td>
+    </Tr>
+    <Tr>
+      <Td>Ukraine</Td>
+      <Td>🇺🇦</Td>
+    </Tr>
   </tbody>
-</table>
+</Table>
 ```
 
 ### Example
 
-<br />
-
-<table>
+<Table>
   <thead>
-    <tr>
-      <th>Country</th>
-      <th>Flag</th>
-    </tr>
+    <Tr>
+      <Th>Country</Th>
+      <Th>Flag</Th>
+    </Tr>
   </thead>
   <tbody>
-    <tr>
-      <td>France</td>
-      <td>🇫🇷</td>
-    </tr>
-    <tr>
-      <td>Ukraine</td>
-      <td>🇺🇦</td>
-    </tr>
+    <Tr>
+      <Td>France</Td>
+      <Td>🇫🇷</Td>
+    </Tr>
+    <Tr>
+      <Td>Ukraine</Td>
+      <Td>🇺🇦</Td>
+    </Tr>
   </tbody>
-</table>
+</Table>
 
 ## Changing Default Behaviour
 

--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -33,53 +33,7 @@ table will be unstyled because
 elements with
 [components provided by `useMDXComponents(){:js}`](https://mdxjs.com/packages/vue/#usemdxcomponentscomponents).
 
-Instead, use the built-in `<Table>`, `<Tr>`, `<Th>`, and `<Td>` components instead:
-
-### Usage
-
-```mdx filename="MDX"
-import { Table, Td, Th, Tr } from 'nextra/components'
-
-<Table>
-  <thead>
-    <Tr>
-      <Th>Country</Th>
-      <Th>Flag</Th>
-    </Tr>
-  </thead>
-  <tbody>
-    <Tr>
-      <Td>France</Td>
-      <Td>🇫🇷</Td>
-    </Tr>
-    <Tr>
-      <Td>Ukraine</Td>
-      <Td>🇺🇦</Td>
-    </Tr>
-  </tbody>
-</Table>
-```
-
-### Example
-
-<Table>
-  <thead>
-    <Tr>
-      <Th>Country</Th>
-      <Th>Flag</Th>
-    </Tr>
-  </thead>
-  <tbody>
-    <Tr>
-      <Td>France</Td>
-      <Td>🇫🇷</Td>
-    </Tr>
-    <Tr>
-      <Td>Ukraine</Td>
-      <Td>🇺🇦</Td>
-    </Tr>
-  </tbody>
-</Table>
+Instead, use the [built-in `<Table>`, `<Tr>`, `<Th>`, and `<Td>` components](/docs/guide/built-ins/table) available via `nextra/components`.
 
 ## Changing Default Behaviour
 

--- a/docs/pages/docs/guide/advanced/table.mdx
+++ b/docs/pages/docs/guide/advanced/table.mdx
@@ -1,4 +1,4 @@
-import { Steps, Table, Td, Th, Tr } from 'nextra/components'
+import { Callout, Steps, Table, Td, Th, Tr } from 'nextra/components'
 
 # Rendering Tables
 
@@ -33,7 +33,10 @@ table will be unstyled because
 elements with
 [components provided by `useMDXComponents(){:js}`](https://mdxjs.com/packages/vue/#usemdxcomponentscomponents).
 
-Instead, use the [built-in `<Table>`, `<Tr>`, `<Th>`, and `<Td>` components](/docs/guide/built-ins/table) available via `nextra/components`.
+<Callout type="info">
+  Instead, use the [built-in `<Table>`, `<Tr>`, `<Th>`, and `<Td>` components](/docs/guide/built-ins/table)
+  available via `nextra/components`.
+</Callout>
 
 ## Changing Default Behaviour
 

--- a/docs/pages/docs/guide/built-ins.mdx
+++ b/docs/pages/docs/guide/built-ins.mdx
@@ -3,8 +3,8 @@ import {
   FolderTreeIcon,
   IdCardIcon,
   OneIcon,
-  WarningIcon,
-  TableIcon
+  TableIcon,
+  WarningIcon
 } from '@components/icons'
 import { Cards } from 'nextra/components'
 
@@ -25,7 +25,7 @@ your content:
     href="/docs/guide/built-ins/cards"
   />
   <Cards.Card
-    icon={<FolderTreeIcon className="size-5" />}
+    icon={<FolderTreeIcon />}
     title="FileTree"
     href="/docs/guide/built-ins/filetree"
   />
@@ -35,13 +35,13 @@ your content:
     href="/docs/guide/built-ins/steps"
   />
   <Cards.Card
-    icon={<CardsIcon />}
-    title="Tabs"
-    href="/docs/guide/built-ins/tabs"
-  />
-  <Cards.Card
     icon={<TableIcon />}
     title="Table"
     href="/docs/guide/built-ins/table"
+  />
+  <Cards.Card
+    icon={<CardsIcon />}
+    title="Tabs"
+    href="/docs/guide/built-ins/tabs"
   />
 </Cards>

--- a/docs/pages/docs/guide/built-ins.mdx
+++ b/docs/pages/docs/guide/built-ins.mdx
@@ -4,7 +4,7 @@ import {
   IdCardIcon,
   OneIcon,
   WarningIcon,
-  RowsIcon
+  TableIcon
 } from '@components/icons'
 import { Cards } from 'nextra/components'
 
@@ -40,7 +40,7 @@ your content:
     href="/docs/guide/built-ins/tabs"
   />
   <Cards.Card
-    icon={<RowsIcon />}
+    icon={<TableIcon />}
     title="Table"
     href="/docs/guide/built-ins/table"
   />

--- a/docs/pages/docs/guide/built-ins.mdx
+++ b/docs/pages/docs/guide/built-ins.mdx
@@ -3,7 +3,8 @@ import {
   FolderTreeIcon,
   IdCardIcon,
   OneIcon,
-  WarningIcon
+  WarningIcon,
+  RowsIcon
 } from '@components/icons'
 import { Cards } from 'nextra/components'
 
@@ -19,14 +20,14 @@ your content:
     href="/docs/guide/built-ins/callout"
   />
   <Cards.Card
-    icon={<CardsIcon />}
-    title="Tabs"
-    href="/docs/guide/built-ins/tabs"
-  />
-  <Cards.Card
     icon={<IdCardIcon />}
     title="Cards"
     href="/docs/guide/built-ins/cards"
+  />
+  <Cards.Card
+    icon={<FolderTreeIcon className="size-5" />}
+    title="FileTree"
+    href="/docs/guide/built-ins/filetree"
   />
   <Cards.Card
     icon={<OneIcon />}
@@ -34,8 +35,13 @@ your content:
     href="/docs/guide/built-ins/steps"
   />
   <Cards.Card
-    icon={<FolderTreeIcon className="size-5" />}
-    title="FileTree"
-    href="/docs/guide/built-ins/filetree"
+    icon={<CardsIcon />}
+    title="Tabs"
+    href="/docs/guide/built-ins/tabs"
+  />
+  <Cards.Card
+    icon={<RowsIcon />}
+    title="Table"
+    href="/docs/guide/built-ins/table"
   />
 </Cards>

--- a/docs/pages/docs/guide/built-ins/_meta.ts
+++ b/docs/pages/docs/guide/built-ins/_meta.ts
@@ -4,5 +4,5 @@ export default {
   filetree: 'FileTree',
   steps: '',
   table: '',
-  tabs: '',
+  tabs: ''
 }

--- a/docs/pages/docs/guide/built-ins/_meta.ts
+++ b/docs/pages/docs/guide/built-ins/_meta.ts
@@ -1,7 +1,8 @@
 export default {
   callout: '',
-  tabs: '',
   cards: '',
+  filetree: 'FileTree',
   steps: '',
-  filetree: 'FileTree'
+  table: '',
+  tabs: '',
 }

--- a/docs/pages/docs/guide/built-ins/table.mdx
+++ b/docs/pages/docs/guide/built-ins/table.mdx
@@ -1,0 +1,54 @@
+import { Table, Td, Th, Tr } from 'nextra/components'
+
+# Table Component
+
+A collection of built-in components meant to handle a need to use non-markdown (i.e. literal) HTML tables.
+
+## Example
+
+<br />
+
+<Table>
+  <thead>
+    <Tr>
+      <Th>Country</Th>
+      <Th>Flag</Th>
+    </Tr>
+  </thead>
+  <tbody>
+    <Tr>
+      <Td>France</Td>
+      <Td>🇫🇷</Td>
+    </Tr>
+    <Tr>
+      <Td>Ukraine</Td>
+      <Td>🇺🇦</Td>
+    </Tr>
+  </tbody>
+</Table>
+
+## Usage
+
+{/* prettier-ignore */}
+```mdx
+import { Table, Td, Th, Tr } from 'nextra/components'
+
+<Table>
+  <thead>
+    <Tr>
+      <Th>Country</Th>
+      <Th>Flag</Th>
+    </Tr>
+  </thead>
+  <tbody>
+    <Tr>
+      <Td>France</Td>
+      <Td>🇫🇷</Td>
+    </Tr>
+    <Tr>
+      <Td>Ukraine</Td>
+      <Td>🇺🇦</Td>
+    </Tr>
+  </tbody>
+</Table>
+```

--- a/docs/pages/docs/guide/built-ins/table.mdx
+++ b/docs/pages/docs/guide/built-ins/table.mdx
@@ -2,13 +2,12 @@ import { Table, Td, Th, Tr } from 'nextra/components'
 
 # Table Component
 
-A collection of built-in components meant to handle a need to use non-markdown (i.e. literal) HTML tables.
+A collection of built-in components designed to create styled, non-markdown
+(i.e., literal) HTML tables.
 
 ## Example
 
-<br />
-
-<Table>
+<Table className="mt-6">
   <thead>
     <Tr>
       <Th>Country</Th>
@@ -29,7 +28,6 @@ A collection of built-in components meant to handle a need to use non-markdown (
 
 ## Usage
 
-{/* prettier-ignore */}
 ```mdx
 import { Table, Td, Th, Tr } from 'nextra/components'
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Performs the suggested docs update proposed in https://github.com/shuding/nextra/issues/3530

The issue being that the latest changes to MDX no longer render literal `<table>` and its associated elements correctly. The documentation should be updated to point users to consume the existing built-in components: `<Table>`, `<Td>`, `<Th>`, and `<Tr>`.

## What's being changed (if available, include any code snippets, screenshots, or gifs):

The non-working example under Advanced → Rendering Tables has been removed, and instead point users to the new built-in component page created for `<Table>` components under Built-in components → Table.

### Changes

The cards are ordered alphabetically + a new card for `<Table>` has been added:

<img width="875" alt="Screenshot 2024-11-02 at 15 44 48" src="https://github.com/user-attachments/assets/1240d374-446b-49d4-a77c-e25c022be844">

Advanced table usage page now has a callout linking to built-in table component:

<img width="869" alt="Screenshot 2024-11-02 at 15 47 00" src="https://github.com/user-attachments/assets/c8ccb973-de89-40ec-ac1c-e0d6e2a6e63d">

A new built-in component page for `<Table>` has been created, following a similar structure of other built-in component doc pages:

<img width="885" alt="Screenshot 2024-11-02 at 15 45 27" src="https://github.com/user-attachments/assets/638017f4-92e1-4742-9b65-8af6be250a6b">

## Check off the following:

- [x] I have manually verified my changes by running `pnpm dev:website` and checking the pages that I have touched
- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
