### PR TITLE
[v4] fix external svg icon was added for span in `<Anchor>`

### DIFF
--- a/.changeset/sharp-knives-care.md
+++ b/.changeset/sharp-knives-care.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+fix external svg icon was added for span in `<Anchor>`

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -1,4 +1,3 @@
-@tailwind base;
 @tailwind components;
 @tailwind utilities;
 

--- a/packages/nextra/src/client/mdx-components.tsx
+++ b/packages/nextra/src/client/mdx-components.tsx
@@ -24,7 +24,7 @@ export const Anchor: FC<ComponentProps<'a'>> = ({ href = '', ...props }) => {
     return (
       <a href={href} target="_blank" rel="noreferrer" {...props}>
         {children}
-        {typeof (children as any).type !== 'function' && (
+        {typeof children === 'string' && (
           <>
             &thinsp;
             <LinkArrowIcon height="16" className="_inline _align-baseline" />


### PR DESCRIPTION
it was added for these icons 
<img width="598" alt="image" src="https://github.com/user-attachments/assets/d003d1ca-ecaf-4869-af52-922967708da5">
