### PR TITLE
fix(nextra-theme-docs): incorrect makePrimaryColor relative value for tailwind primary-900

### DIFF
--- a/.changeset/loud-kids-attack.md
+++ b/.changeset/loud-kids-attack.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+fix(nextra-theme-docs): incorrect makePrimaryColor relative value for tailwind primary.900

--- a/packages/nextra-theme-docs/tailwind.config.ts
+++ b/packages/nextra-theme-docs/tailwind.config.ts
@@ -62,7 +62,7 @@ export default {
         700: makePrimaryColor(-6),
         750: makePrimaryColor(-10),
         800: makePrimaryColor(-13),
-        900: makePrimaryColor(-11)
+        900: makePrimaryColor(-21)
       }
     }
   },


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Made a typo in https://github.com/shuding/nextra/pull/3592

<img width="647" alt="image" src="https://github.com/user-attachments/assets/39f7f32e-24e0-46e0-a574-5d004a793c98">


Closes:

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
