### PR TITLE
[v4] migrate to zustand v5

### DIFF
--- a/.changeset/ninety-birds-teach.md
+++ b/.changeset/ninety-birds-teach.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+migrate to zustand v5

--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -36,7 +36,7 @@
     "scroll-into-view-if-needed": "^3.1.0",
     "zod": "^3.22.3",
     "zod-validation-error": "^3.0.0",
-    "zustand": "^4.5.5"
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",

--- a/packages/nextra-theme-docs/src/stores/config.tsx
+++ b/packages/nextra-theme-docs/src/stores/config.tsx
@@ -6,9 +6,8 @@ import { normalizePages } from 'nextra/normalize-pages'
 import type { FC, ReactElement, ReactNode } from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
 import type { StoreApi } from 'zustand'
-import { createStore } from 'zustand/vanilla'
 import { useStore } from 'zustand/react'
-import { useShallow } from 'zustand/react/shallow'
+import { createStore } from 'zustand/vanilla'
 
 type Config = {
   hideSidebar: boolean
@@ -17,19 +16,13 @@ type Config = {
 
 const ConfigContext = createContext<StoreApi<Config> | null>(null)
 
-function useConfigStore<T>(selector: (state: Config) => T) {
+export function useConfig() {
   const store = useContext(ConfigContext)
   if (!store) {
     throw new Error('Missing ConfigContext.Provider')
   }
-  return useStore(store, selector)
+  return useStore(store)
 }
-
-export const useConfig = () =>
-  useConfigStore(useShallow(state => ({
-    hideSidebar: state.hideSidebar,
-    normalizePagesResult: state.normalizePagesResult
-  })))
 
 function getStore(list: PageMapItem[], route: string) {
   const normalizePagesResult = normalizePages({ list, route })

--- a/packages/nextra-theme-docs/src/stores/config.tsx
+++ b/packages/nextra-theme-docs/src/stores/config.tsx
@@ -5,10 +5,10 @@ import { useFSRoute } from 'nextra/hooks'
 import { normalizePages } from 'nextra/normalize-pages'
 import type { FC, ReactElement, ReactNode } from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
-import { createStore } from 'zustand'
 import type { StoreApi } from 'zustand'
-import { shallow } from 'zustand/shallow'
-import { useStoreWithEqualityFn } from 'zustand/traditional'
+import { createStore } from 'zustand/vanilla'
+import { useStore } from 'zustand/react'
+import { useShallow } from 'zustand/react/shallow'
 
 type Config = {
   hideSidebar: boolean
@@ -22,14 +22,14 @@ function useConfigStore<T>(selector: (state: Config) => T) {
   if (!store) {
     throw new Error('Missing ConfigContext.Provider')
   }
-  return useStoreWithEqualityFn(store, selector, shallow)
+  return useStore(store, selector)
 }
 
 export const useConfig = () =>
-  useConfigStore(state => ({
+  useConfigStore(useShallow(state => ({
     hideSidebar: state.hideSidebar,
     normalizePagesResult: state.normalizePagesResult
-  }))
+  })))
 
 function getStore(list: PageMapItem[], route: string) {
   const normalizePagesResult = normalizePages({ list, route })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,8 +462,8 @@ importers:
         specifier: ^3.0.0
         version: 3.4.0(zod@3.23.8)
       zustand:
-        specifier: ^4.5.5
-        version: 4.5.5(@types/react@18.3.12)(react@18.3.1)
+        specifier: ^5.0.1
+        version: 5.0.1(@types/react@18.3.12)(react@18.3.1)
     devDependencies:
       '@tailwindcss/nesting':
         specifier: ^0.0.0-insiders.565cd3e
@@ -12250,14 +12250,6 @@ packages:
       punycode: 2.3.1
     dev: true
 
-  /use-sync-external-store@1.2.2(react@18.3.1):
-    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.3.1
-    dev: false
-
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -12751,13 +12743,14 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
     dev: false
 
-  /zustand@4.5.5(@types/react@18.3.12)(react@18.3.1):
-    resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
-    engines: {node: '>=12.7.0'}
+  /zustand@5.0.1(@types/react@18.3.12)(react@18.3.1):
+    resolution: {integrity: sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==}
+    engines: {node: '>=12.20.0'}
     peerDependencies:
-      '@types/react': '>=16.8'
+      '@types/react': '>=18.0.0'
       immer: '>=9.0.6'
-      react: '>=16.8'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12765,10 +12758,11 @@ packages:
         optional: true
       react:
         optional: true
+      use-sync-external-store:
+        optional: true
     dependencies:
       '@types/react': 18.3.12
       react: 18.3.1
-      use-sync-external-store: 1.2.2(react@18.3.1)
     dev: false
 
   /zwitch@2.0.4:


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

Since v5 is the current major version of Zustand, I think it would be appropriate to upgrade to v5 in `nextra-theme-docs` as well.

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

I reviewed the current usage of `useConfig` and found that using a `selector` and `shallow` is unnecessary. I simplified the implementation so that each call to `useConfig` returns the current state directly and ensures reference consistency, so `useStoreWithEqualityFn` and `shallow` are no longer needed. With this change, migration to v5 is successful.

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
