### PR TITLE
[v4] avoid unnecessary updates to config store on initial render

### DIFF
--- a/.changeset/plenty-rabbits-return.md
+++ b/.changeset/plenty-rabbits-return.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': patch
+---
+
+avoid unnecessary updates to the config store on initial render

--- a/packages/nextra-theme-docs/src/stores/config.tsx
+++ b/packages/nextra-theme-docs/src/stores/config.tsx
@@ -18,10 +18,7 @@ export function useConfig() {
   const { activeThemeContext, activeType } = normalizePagesResult
   return {
     normalizePagesResult,
-    hideSidebar:
-      !activeThemeContext.sidebar ||
-      activeType === 'page' ||
-      activeType === undefined /* non mdx pages */
+    hideSidebar: !activeThemeContext.sidebar || activeType === 'page'
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

I noticed that the effect callback updating the store on the initial render in `<ConfigProvider>` is unnecessary, which causes the consumers of `useConfig` to re-render. So, I’d like to fix this.

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

I think Zustand might not be necessary in the current scenario, so I made the following adjustments:

- Memoize the `normalizedPages` and store it in the config context.
- Derive the `hideSidebar` state in the `useConfig` hook.

Feel free the close this if I missed something obvious.

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
