### PR TITLE
[v4] Cache the result of `repository.getFileLatestModifiedDateAsync` because it can slow down Fast Refresh for uncommitted files.

### DIFF
--- a/.changeset/many-gifts-cough.md
+++ b/.changeset/many-gifts-cough.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+Cache the result of `repository.getFileLatestModifiedDateAsync` because it can slow down Fast Refresh for uncommitted files.

--- a/packages/nextra/tsconfig.json
+++ b/packages/nextra/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2022",
     "module": "ESNext",
     "declaration": true,
     "noEmit": true,

--- a/packages/nextra/tsup.config.ts
+++ b/packages/nextra/tsup.config.ts
@@ -8,7 +8,6 @@ import { CWD, IS_PRODUCTION } from './src/server/constants.js'
 export default defineConfig({
   name: 'nextra',
   entry: [...defaultEntry, '!src/types.ts', 'src/**/*.svg'],
-  target: 'es2020',
   format: 'esm',
   dts: true,
   splitting: IS_PRODUCTION,


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/3675