### PR TITLE
Patch build script to always build style.css

### DIFF
--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -17,8 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
-    "build:all": "pnpm build && pnpm build:tailwind",
+    "build": "pnpm build:tailwind && tsup",
     "build:tailwind": "pnpm postcss css/styles.css -o dist/style.css --verbose",
     "clean": "rimraf ./dist ./style.css",
     "dev": "concurrently \"pnpm dev:layout\" \"pnpm dev:tailwind\"",


### PR DESCRIPTION
## Why:

Upon deployment on Vercel, I couldn't build the multirepo, because of an error:

```
./pages/_app.tsx
Module not found: Can't resolve 'nextra-theme-docs/style.css''nextra-theme-docs/style.css' doesn't exist
```

## What's being changed (if available, include any code snippets, screenshots, or gifs):

This patches the build script in nextra-theme-docs to always build:tailwind also. There may be a more elgant solution, but this works for me.

## Check off the following:

- [ X] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
