### PR TITLE
[v4] feat(theme): Content width css variable for easier customization

### DIFF
--- a/.changeset/afraid-foxes-deny.md
+++ b/.changeset/afraid-foxes-deny.md
@@ -1,0 +1,5 @@
+---
+'nextra-theme-docs': minor
+---
+
+Moved content width to a dedicated css variable.

--- a/.changeset/afraid-foxes-deny.md
+++ b/.changeset/afraid-foxes-deny.md
@@ -2,4 +2,4 @@
 'nextra-theme-docs': minor
 ---
 
-Moved content width to a dedicated css variable.
+content width could be configured via CSS `--nextra-content-width` variable

--- a/docs/app/page.css
+++ b/docs/app/page.css
@@ -1,5 +1,5 @@
 .content-container {
-  max-width: 90rem;
+  max-width: var(--nextra-content-width);
   padding-left: max(env(safe-area-inset-left), 1.5rem);
   padding-right: max(env(safe-area-inset-right), 1.5rem);
   margin: 0 auto;

--- a/packages/nextra-theme-docs/src/components/footer/index.tsx
+++ b/packages/nextra-theme-docs/src/components/footer/index.tsx
@@ -12,7 +12,7 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
   return (
     <div className="x:bg-gray-100 x:pb-[env(safe-area-inset-bottom)] x:dark:bg-neutral-900 x:print:bg-transparent">
       <Switchers>
-        <div className="x:mx-auto x:flex x:max-w-[90rem] x:gap-2 x:py-2 x:px-4">
+        <div className="x:mx-auto x:flex x:max-w-[var(--nextra-content-width)] x:gap-2 x:py-2 x:px-4">
           <LocaleSwitch />
           <ThemeSwitch />
         </div>
@@ -20,7 +20,7 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
       <hr className="nextra-border" />
       <footer
         className={cn(
-          'x:mx-auto x:flex x:max-w-[90rem] x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
+          'x:mx-auto x:flex x:max-w-[var(--nextra-content-width)] x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
           'x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]',
           className
         )}

--- a/packages/nextra-theme-docs/src/components/footer/index.tsx
+++ b/packages/nextra-theme-docs/src/components/footer/index.tsx
@@ -20,7 +20,7 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
       <hr className="nextra-border" />
       <footer
         className={cn(
-          'x:mx-auto x:flex x:max-w-[var(--nextra-content-width)] x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
+          'x:mx-auto x:flex x:max-w-(--nextra-content-width) x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
           'x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]',
           className
         )}

--- a/packages/nextra-theme-docs/src/components/footer/index.tsx
+++ b/packages/nextra-theme-docs/src/components/footer/index.tsx
@@ -12,7 +12,7 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
   return (
     <div className="x:bg-gray-100 x:pb-[env(safe-area-inset-bottom)] x:dark:bg-neutral-900 x:print:bg-transparent">
       <Switchers>
-        <div className="x:mx-auto x:flex x:max-w-[var(--nextra-content-width)] x:gap-2 x:py-2 x:px-4">
+        <div className="x:mx-auto x:flex x:max-w-(--nextra-content-width) x:gap-2 x:py-2 x:px-4">
           <LocaleSwitch />
           <ThemeSwitch />
         </div>

--- a/packages/nextra-theme-docs/src/components/navbar/index.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar/index.tsx
@@ -52,7 +52,7 @@ export const Navbar: FC<NavbarProps> = props => {
       />
       <nav
         style={{ height: 'var(--nextra-navbar-height)' }}
-        className="x:mx-auto x:flex x:max-w-[var(--nextra-content-width)] x:items-center x:justify-end x:gap-4 x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]"
+        className="x:mx-auto x:flex x:max-w-(--nextra-content-width) x:items-center x:justify-end x:gap-4 x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]"
       >
         {logoLink ? (
           <NextLink

--- a/packages/nextra-theme-docs/src/components/navbar/index.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar/index.tsx
@@ -52,7 +52,7 @@ export const Navbar: FC<NavbarProps> = props => {
       />
       <nav
         style={{ height: 'var(--nextra-navbar-height)' }}
-        className="x:mx-auto x:flex x:max-w-[90rem] x:items-center x:justify-end x:gap-4 x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]"
+        className="x:mx-auto x:flex x:max-w-[var(--nextra-content-width)] x:items-center x:justify-end x:gap-4 x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]"
       >
         {logoLink ? (
           <NextLink

--- a/packages/nextra-theme-docs/src/mdx-components/index.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components/index.tsx
@@ -89,7 +89,7 @@ const DEFAULT_COMPONENTS = getNextraMDXComponents({
       value: removeLinks(item.value)
     }))
     return (
-      <div className="x:mx-auto x:flex x:max-w-[90rem]">
+      <div className="x:mx-auto x:flex x:max-w-[var(--nextra-content-width)]">
         <Sidebar toc={toc} />
 
         <ClientWrapper toc={toc} {...props}>

--- a/packages/nextra-theme-docs/src/mdx-components/index.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components/index.tsx
@@ -89,7 +89,7 @@ const DEFAULT_COMPONENTS = getNextraMDXComponents({
       value: removeLinks(item.value)
     }))
     return (
-      <div className="x:mx-auto x:flex x:max-w-[var(--nextra-content-width)]">
+      <div className="x:mx-auto x:flex x:max-w-(--nextra-content-width)">
         <Sidebar toc={toc} />
 
         <ClientWrapper toc={toc} {...props}>

--- a/packages/nextra/src/client/components/head.tsx
+++ b/packages/nextra/src/client/components/head.tsx
@@ -72,6 +72,7 @@ const Head_: FC<HeadProps> = ({ children, ...props }) => {
   --nextra-primary-saturation: ${color.saturation.light}%;
   --nextra-primary-lightness: ${color.lightness.light}%;
   --nextra-bg: ${backgroundColor.light};
+  --nextra-content-width: 90rem;
 }
 .dark {
   --nextra-primary-hue: ${color.hue.dark}deg;


### PR DESCRIPTION
This moves the content width that was used throughout nextra `max-w-[90rem]` to a css variable. This way the changing the value in the future should be easier, but it also makes it possible to customize the max width of the content for people using nextra without needing to overload a tailwind class in a hacky way.

<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

I have several screenshots in my docs that are a pretty consistent 1280x720, due to the max width of the content view being limited to `90rem` these images are always scaled down quite a bit. I was hoping to make the max width a bit wider for this reason but didn't see an easy way to do so without overloading the `_max-w-[90rem]` tailwind CSS class; which didn't seem like a good idea.

## What's being changed (if available, include any code snippets, screenshots, or gifs):

I've simply lifted the value passed to max width to a css variable similar to the other css variables already being managed by nextra. This way I can simply overwrite that css variable in my own styles.

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
