### PR TITLE
[v4] adjust RegEx for folder groups in app router

### DIFF
--- a/.changeset/new-pumpkins-joke.md
+++ b/.changeset/new-pumpkins-joke.md
@@ -1,0 +1,5 @@
+---
+"nextra": patch
+---
+
+adjust RegEx for folder groups in app router

--- a/packages/nextra/src/server/page-map/to-page-map.ts
+++ b/packages/nextra/src/server/page-map/to-page-map.ts
@@ -54,7 +54,7 @@ export function convertToPageMap({
           //
           // will be normalized to:
           // app/posts/aaron-swartz-a-programmable-web/page.mdx
-          dir.replaceAll(/\(.*?\)\//g, '')
+          dir.replaceAll(/\(.*?\)(\/|$)/g, '')
         : [dir, name !== 'index' && name].filter(Boolean).join('/')
       pages[key] = filePath
     }


### PR DESCRIPTION
can't be normalized for `(folder)/page.tsx` 
<img width="393" alt="image" src="https://github.com/user-attachments/assets/c27fab93-6106-4a7a-ba77-4bc70a127428" />
