### PR TITLE
[v4] add icons for ```javascript and ```typescript langs

### DIFF
--- a/.changeset/itchy-frogs-shop.md
+++ b/.changeset/itchy-frogs-shop.md
@@ -1,0 +1,5 @@
+---
+"nextra": patch
+---
+
+add icons for ```javascript and ```typescript langs

--- a/packages/nextra/src/client/hocs/with-icons.tsx
+++ b/packages/nextra/src/client/hocs/with-icons.tsx
@@ -25,10 +25,12 @@ import type { PreProps } from '../mdx-components/pre/index.js'
 
 function getIcon(language: string) {
   switch (language) {
+    case 'javascript':
     case 'js':
     case 'mjs':
     case 'cjs':
       return JavaScriptIcon
+    case 'typescript':
     case 'ts':
     case 'mts':
     case 'cts':


### PR DESCRIPTION
noticed icons were not appears in https://github.com/dotansimha/graphql-yoga/pull/3570