### PR TITLE
Fix the signature of transformTitle

### DIFF
--- a/.changeset/rotten-llamas-drum.md
+++ b/.changeset/rotten-llamas-drum.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Fix `MetaRecord` type so it's no longer `unknown`

--- a/.changeset/rotten-llamas-drum.md
+++ b/.changeset/rotten-llamas-drum.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"nextra": patch
 ---
 
 Fix `MetaRecord` type so it's no longer `unknown`

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -132,14 +132,13 @@ export const itemSchema = z.strictObject({
   theme: pageThemeSchema.optional()
 })
 
-export const metaSchema = z
-  .union([
-    stringOrElement.transform(transformTitle),
-    itemSchema,
-    linkSchema.extend({ type: z.enum(['page', 'doc']).optional() }),
-    separatorItemSchema,
-    menuSchema
-  ])
+export const metaSchema = z.union([
+  stringOrElement.transform(transformTitle),
+  itemSchema,
+  linkSchema.extend({ type: z.enum(['page', 'doc']).optional() }),
+  separatorItemSchema,
+  menuSchema
+])
 
 function transformTitle<T>(title: T) {
   return typeof title === 'string' || isValidElement(title) ? { title } : title

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -134,14 +134,13 @@ export const itemSchema = z.strictObject({
 
 export const metaSchema = z
   .union([
-    stringOrElement,
+    stringOrElement.transform(transformTitle),
     itemSchema,
     linkSchema.extend({ type: z.enum(['page', 'doc']).optional() }),
     separatorItemSchema,
     menuSchema
   ])
-  .transform(transformTitle)
 
-function transformTitle(title: unknown) {
+function transformTitle<T>(title: T) {
   return typeof title === 'string' || isValidElement(title) ? { title } : title
 }


### PR DESCRIPTION
## Why:

`transformTitle` is changing the `MetaRecord` type to `unknown`. By adding that generic parameter `T`, we allow it to preserve the type.

I took liberty of moving `transformTitle` up, because there's only one union constituent accepting a string. This also makes the `MetaRecord` type more readable in error messages. @dimaMachina Let me know if that makes sense.

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
