### PR TITLE
[v4] fix unclickable `type: menu` on mobile nav

### DIFF
--- a/.changeset/tasty-nails-cover.md
+++ b/.changeset/tasty-nails-cover.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+dd

--- a/.changeset/tasty-nails-cover.md
+++ b/.changeset/tasty-nails-cover.md
@@ -2,4 +2,4 @@
 "nextra-theme-docs": patch
 ---
 
-dd
+fix unclickable `type: menu` on mobile nav

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -102,8 +102,8 @@ const Folder: FC<FolderProps> = ({ item: _item, anchors, onFocus, level }) => {
     if (isClickOnIcon) {
       event.preventDefault()
     }
-    const open = el.parentElement!.classList.contains('open')
-    TreeState[item.route] = !open
+    const isOpen = el.parentElement!.classList.contains('open')
+    TreeState[item.route] = !isOpen
     rerender({})
   }
 

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -59,9 +59,16 @@ type FolderProps = {
   level: number
 }
 
-const Folder: FC<FolderProps> = ({ item, anchors, onFocus, level }) => {
+const Folder: FC<FolderProps> = ({ item: _item, anchors, onFocus, level }) => {
   const routeOriginal = useFSRoute()
   const route = routeOriginal.split('#', 1)[0]!
+
+  const item = {
+    ..._item,
+    children:
+      _item.type === 'menu' ? getMenuChildren(_item as any) : _item.children
+  }
+
   const hasRoute = !!item.route // for item.type === 'menu' will be ''
   const active = hasRoute && [route, route + '/'].includes(item.route + '/')
   const activeRouteInside =
@@ -95,9 +102,8 @@ const Folder: FC<FolderProps> = ({ item, anchors, onFocus, level }) => {
     if (isClickOnIcon) {
       event.preventDefault()
     }
-    const isOpen = el.parentElement!.classList.contains('open')
-    const route = el.getAttribute('href') || el.dataset.href || ''
-    TreeState[route] = !isOpen
+    const open = el.parentElement!.classList.contains('open')
+    TreeState[item.route] = !open
     rerender({})
   }
 
@@ -157,10 +163,7 @@ const Folder: FC<FolderProps> = ({ item, anchors, onFocus, level }) => {
           <Menu
             className={classes.border}
             // @ts-expect-error -- fixme
-            directories={
-              // @ts-expect-error -- fixme
-              item.type === 'menu' ? getMenuChildren(item) : item.children
-            }
+            directories={item.children}
             anchors={anchors}
             level={level}
           />

--- a/packages/nextra/src/client/components/banner/index.tsx
+++ b/packages/nextra/src/client/components/banner/index.tsx
@@ -24,7 +24,8 @@ export const Banner: FC<{
         CLASS_NAME,
         'x:max-md:sticky x:top-0 x:z-20 x:flex x:items-center',
         'x:text-slate-50 x:dark:text-white x:bg-neutral-900 x:dark:bg-[linear-gradient(1deg,#383838,#212121)]',
-        'x:px-2 x:print:hidden'
+        'x:px-2',
+        'x:print:[display:none]' // to not match `x:[.nextra-banner:not([class$=hidden])~&]` class
       )}
     >
       <div className="x:w-full x:whitespace-nowrap x:overflow-x-auto x:text-center x:font-medium x:text-sm">


### PR DESCRIPTION
cc @hasparus this fixx bug with https://github.com/graphql-hive/console/blob/12f74af0a74d29534c50362b341cf8d9d659c014/packages/web/docs/src/app/layout.tsx#L38-L39