### PR TITLE
add trend image

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ the watch mode for both nextra and the theme in separated terminals.
    <img src="/docs/pages/showcase/xyflow.jpg" alt="xyflow preview" width="256">
  </a>
 </div>
+
+## Usage Trend
+
+[Usage Trend of nextra](https://npm-compare.com/nextra#timeRange=THREE_YEARS)
+  
+<a href="https://npm-compare.com/nextra#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/nextra.png" width="768" alt="NPM Usage Trend of nextra" />
+</a>


### PR DESCRIPTION
Hi, I’d like to add a dynamic [nextra trend image](https://npm-compare.com/nextra/#timeRange=THREE_YEARS) to the README. I believe we can help potential users better understand the growing popularity and adoption of `nextra`, giving them more confidence in choosing website generation framework.

By the way, I'm the maintainer of npm-compare.com, If there are other features or insights from npm-compare.com that you think could benefit `nextra`, I’d be more than happy to  implement them.

Thank you for considering my PR.