### PR TITLE
[v4] Don't focus search input on `⌘ + Shift + k` or `Ctrl + Shift + k`.

### DIFF
--- a/.changeset/blue-sloths-play.md
+++ b/.changeset/blue-sloths-play.md
@@ -1,0 +1,8 @@
+---
+"nextra": patch
+"nextra-theme-blog": patch
+"nextra-theme-docs": patch
+---
+
+Don't focus search input on `Ctrl + k` on non Mac devices.
+Don't focus search input on `⌘ + Shift + k` or `Ctrl + Shift + k`.

--- a/packages/nextra/src/client/components/search.tsx
+++ b/packages/nextra/src/client/components/search.tsx
@@ -136,7 +136,7 @@ export const Search: FC<SearchProps> = ({
   const inputRef = useRef<HTMLInputElement>(null!)
 
   useEffect(() => {
-    function handleKeyDown(event: globalThis.KeyboardEvent) {
+    function handleKeyDown(event: KeyboardEvent) {
       const el = document.activeElement
       if (
         !el ||
@@ -148,7 +148,8 @@ export const Search: FC<SearchProps> = ({
       if (
         event.key === '/' ||
         (event.key === 'k' &&
-          (event.metaKey /* for Mac */ || /* for non-Mac */ event.ctrlKey))
+          !event.shiftKey &&
+          (navigator.userAgent.includes('Mac') ? event.metaKey : event.ctrlKey))
       ) {
         event.preventDefault()
         // prevent to scroll to top


### PR DESCRIPTION
closes https://github.com/shuding/nextra/issues/3901