### PR TITLE
fix steps background on dark mode / fix headings anchor link color on dark mode

### DIFF
--- a/.changeset/big-nails-end.md
+++ b/.changeset/big-nails-end.md
@@ -1,0 +1,8 @@
+---
+"nextra": patch
+"nextra-theme-blog": patch
+"nextra-theme-docs": patch
+---
+
+fix steps background on dark mode
+fix headings anchor link color on dark mode

--- a/packages/nextra/styles/steps.css
+++ b/packages/nextra/styles/steps.css
@@ -1,27 +1,20 @@
 .nextra-steps {
-  --counter-bg: var(--x-color-gray-100);
-
   h2,
   h3,
   h4,
   h5,
   h6 {
     counter-increment: var(--counter-id);
-    /* resets from nextra-theme-docs */
+    /* Resets from nextra-theme-docs */
     @apply x:border-0 x:pb-0 x:font-semibold x:tracking-tight x:mt-8 x:text-2xl;
-
+    /* https://github.com/tailwindlabs/tailwindcss/issues/15597#issuecomment-2582673546 */
+    @apply x:before:bg-gray-100 x:dark:before:bg-neutral-800;
     &:before {
       @apply x:absolute x:size-[33px];
       @apply x:border-4 x:border-nextra-bg;
-      /* @apply x:bg-gray-100 x:dark:bg-neutral-800; */
       @apply x:rounded-full x:text-neutral-400 x:text-base x:font-normal x:text-center x:-indent-px;
       @apply x:mt-[3px] x:ms-[-41px];
       content: counter(var(--counter-id));
-      background: var(--counter-bg);
     }
   }
-}
-
-.dark .nextra-steps {
-  --counter-bg: var(--x-color-neutral-800);
 }

--- a/packages/nextra/styles/steps.css
+++ b/packages/nextra/styles/steps.css
@@ -1,4 +1,6 @@
 .nextra-steps {
+  --counter-bg: var(--x-color-gray-100);
+
   h2,
   h3,
   h4,
@@ -10,10 +12,16 @@
 
     &:before {
       @apply x:absolute x:size-[33px];
-      @apply x:border-4 x:border-nextra-bg x:bg-gray-100 x:dark:bg-neutral-800;
+      @apply x:border-4 x:border-nextra-bg;
+      /* @apply x:bg-gray-100 x:dark:bg-neutral-800; */
       @apply x:rounded-full x:text-neutral-400 x:text-base x:font-normal x:text-center x:-indent-px;
       @apply x:mt-[3px] x:ms-[-41px];
       content: counter(var(--counter-id));
+      background: var(--counter-bg);
     }
   }
+}
+
+.dark .nextra-steps {
+  --counter-bg: var(--x-color-neutral-800);
 }

--- a/packages/nextra/styles/subheading-anchor.css
+++ b/packages/nextra/styles/subheading-anchor.css
@@ -1,7 +1,4 @@
 .subheading-anchor {
-  --default-color: var(--x-color-gray-300);
-  --linked-color: var(--x-color-gray-400);
-
   @apply x:ms-1;
 
   /* to avoid conflicts with docs heading which has class `target:_animate-[fade-in_1.5s]` */
@@ -16,20 +13,14 @@
     @apply x:opacity-100;
   }
 
-  :target > &:after {
-    /* @apply x:text-gray-400; */
-    /* @apply x:dark:text-neutral-500; */
-    color: var(--linked-color);
+  :target > & {
+    /* https://github.com/tailwindlabs/tailwindcss/issues/15597#issuecomment-2582673546 */
+    @apply x:after:text-gray-400 x:dark:after:text-neutral-500;
   }
 
   &:after {
     @apply x:content-['#'] x:px-1;
-    /* @apply x:text-gray-300 x:dark:text-neutral-700; */
-    color: var(--default-color);
   }
-}
-
-.dark .subheading-anchor {
-  --default-color: var(--x-color-neutral-500);
-  --linked-color: var(--x-color-neutral-700);
+  /* https://github.com/tailwindlabs/tailwindcss/issues/15597#issuecomment-2582673546 */
+  @apply x:after:text-gray-300 x:dark:after:text-neutral-700;
 }

--- a/packages/nextra/styles/subheading-anchor.css
+++ b/packages/nextra/styles/subheading-anchor.css
@@ -1,4 +1,7 @@
 .subheading-anchor {
+  --default-color: var(--x-color-gray-300);
+  --linked-color: var(--x-color-gray-400);
+
   @apply x:ms-1;
 
   /* to avoid conflicts with docs heading which has class `target:_animate-[fade-in_1.5s]` */
@@ -14,12 +17,19 @@
   }
 
   :target > &:after {
-    @apply x:text-gray-400;
-    @apply x:dark:text-neutral-500;
+    /* @apply x:text-gray-400; */
+    /* @apply x:dark:text-neutral-500; */
+    color: var(--linked-color);
   }
 
   &:after {
     @apply x:content-['#'] x:px-1;
-    @apply x:text-gray-300 x:dark:text-neutral-700;
+    /* @apply x:text-gray-300 x:dark:text-neutral-700; */
+    color: var(--default-color);
   }
+}
+
+.dark .subheading-anchor {
+  --default-color: var(--x-color-neutral-500);
+  --linked-color: var(--x-color-neutral-700);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

In Tailwind CSS v4 beta, the `@apply` directive does not behave as expected when used with dark theme utility classes on pseudo-elements. 

While the root cause is unclear, this PR introduces a temporary workaround for release candidate users. If it is not suitable, feel free to close it.

<img width="399" alt="image" src="https://github.com/user-attachments/assets/54b73511-746d-46fb-af2a-49872c147aa8" />

Closes:

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<img width="399" alt="image" src="https://github.com/user-attachments/assets/14282370-fdf7-4074-a8b3-50d65a7905f8" />

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
