### PR TITLE
Remove margin-top from .nextra-steps so it's even

### DIFF
--- a/.changeset/hungry-planets-divide.md
+++ b/.changeset/hungry-planets-divide.md
@@ -1,0 +1,7 @@
+---
+"nextra": patch
+"nextra-theme-blog": patch
+"nextra-theme-docs": patch
+---
+
+Remove margin-top from `.nextra-steps` `:before` pseudo selector

--- a/packages/nextra/styles/steps.css
+++ b/packages/nextra/styles/steps.css
@@ -13,7 +13,7 @@
       @apply x:absolute x:size-[33px];
       @apply x:border-4 x:border-nextra-bg;
       @apply x:rounded-full x:text-neutral-400 x:text-base x:font-normal x:text-center x:-indent-px;
-      @apply x:mt-[3px] x:ms-[-41px];
+      @apply x:ms-[-41px];
       content: counter(var(--counter-id));
     }
   }


### PR DESCRIPTION
## Why:

The top margin in `.nextra-steps` is redundant and makes the step unaligned with the text.

## What's being changed (if available, include any code snippets, screenshots, or gifs):

### Before

<img width="582" alt="image" src="https://github.com/user-attachments/assets/97748859-665b-48cb-bb35-6d01f6e2c85e" />

### After

<img width="554" alt="image" src="https://github.com/user-attachments/assets/c716a937-bcfa-4f83-8104-8683cc23eeaa" />


## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
