### PR TITLE
Update Folders with Index Page to v4

### DIFF
--- a/docs/app/docs/file-conventions/meta-file/page.mdx
+++ b/docs/app/docs/file-conventions/meta-file/page.mdx
@@ -116,29 +116,46 @@ move directories around without having to change the `_meta` file.
 
 ### Folders with Index Page
 
-What if I want to have a folder with an index page? We can add a MDX page with
-the same name and in the same directory as the folder. Let's say we want to add
-`/fruits` route in the example above, we can create a `fruits.mdx` file in
-`content`:
+What if I want to have a folder with an index page? You should set asIndexPage: true in the front matter of docs/page.mdx when using the page file convention.
+When using the content directory convention, you can achieve the same result by setting asIndexPage: true in the front matter of docs/index.mdx
+
+#### Page File Convention
 
 <FileTree>
   <FileTree.Folder name="content" defaultOpen>
     <FileTree.Folder name="fruits" defaultOpen active>
       <FileTree.File name="_meta.js" />
+      <FileTree.File name="page.mdx" active />
       <FileTree.File name="apple.mdx" />
       <FileTree.File name="banana.mdx" />
     </FileTree.Folder>
     <FileTree.File name="_meta.js" />
     <FileTree.File name="about.mdx" />
     <FileTree.File name="contact.mdx" />
-    <FileTree.File name="fruits.mdx" active />
+    <FileTree.File name="index.mdx" />
+  </FileTree.Folder>
+</FileTree>
+
+#### Content Directory Convention
+
+<FileTree>
+  <FileTree.Folder name="content" defaultOpen>
+    <FileTree.Folder name="fruits" defaultOpen active>
+      <FileTree.File name="_meta.js" />
+      <FileTree.File name="index.mdx" active />
+      <FileTree.File name="apple.mdx" />
+      <FileTree.File name="banana.mdx" />
+    </FileTree.Folder>
+    <FileTree.File name="_meta.js" />
+    <FileTree.File name="about.mdx" />
+    <FileTree.File name="contact.mdx" />
     <FileTree.File name="index.mdx" />
   </FileTree.Folder>
 </FileTree>
 
 Then Nextra knows that the `fruits` key in `_meta` defines a folder with an
 index page. If you click that folder in the sidebar, it will open the folder and
-show you the `fruits.mdx` page at the same time.
+show you the `page.mdx`/`index.mdx` page at the same time.
 
 ## External Links
 

--- a/docs/app/docs/file-conventions/meta-file/page.mdx
+++ b/docs/app/docs/file-conventions/meta-file/page.mdx
@@ -116,35 +116,18 @@ move directories around without having to change the `_meta` file.
 
 ### Folders with Index Page
 
-What if I want to have a folder with an index page? You should set asIndexPage: true in the front matter of docs/page.mdx when using the page file convention.
-When using the content directory convention, you can achieve the same result by setting asIndexPage: true in the front matter of docs/index.mdx
-
-#### Page File Convention
+To create a folder with an index page (like a `/fruits` route), make a file named
+`content/fruits/index.mdx` or `app/fruits/page.mdx`. Add `asIndexPage: true` to the
+front matter to mark it as the index page.
 
 <FileTree>
+  **Using [`content` directory](/docs/file-conventions/content-directory)**
   <FileTree.Folder name="content" defaultOpen>
     <FileTree.Folder name="fruits" defaultOpen active>
       <FileTree.File name="_meta.js" />
-      <FileTree.File name="page.mdx" active />
       <FileTree.File name="apple.mdx" />
       <FileTree.File name="banana.mdx" />
-    </FileTree.Folder>
-    <FileTree.File name="_meta.js" />
-    <FileTree.File name="about.mdx" />
-    <FileTree.File name="contact.mdx" />
-    <FileTree.File name="index.mdx" />
-  </FileTree.Folder>
-</FileTree>
-
-#### Content Directory Convention
-
-<FileTree>
-  <FileTree.Folder name="content" defaultOpen>
-    <FileTree.Folder name="fruits" defaultOpen active>
-      <FileTree.File name="_meta.js" />
       <FileTree.File name="index.mdx" active />
-      <FileTree.File name="apple.mdx" />
-      <FileTree.File name="banana.mdx" />
     </FileTree.Folder>
     <FileTree.File name="_meta.js" />
     <FileTree.File name="about.mdx" />
@@ -152,6 +135,39 @@ When using the content directory convention, you can achieve the same result by 
     <FileTree.File name="index.mdx" />
   </FileTree.Folder>
 </FileTree>
+
+<FileTree>
+  **Using [`page.mdx` files](/docs/file-conventions/page-file)**
+  <FileTree.Folder name="app" open>
+    <FileTree.Folder name="fruits" open active>
+      <FileTree.File name="_meta.js" />
+      <FileTree.Folder name="apple">
+        <FileTree.File name="page.mdx" />
+      </FileTree.Folder>
+      <FileTree.Folder name="banana">
+        <FileTree.File name="page.mdx" />
+      </FileTree.Folder>
+      <FileTree.File name="page.mdx" active />
+    </FileTree.Folder>
+    <FileTree.File name="_meta.js" />
+    <FileTree.Folder name="about">
+      <FileTree.File name="page.mdx" />
+    </FileTree.Folder>
+    <FileTree.Folder name="contact">
+      <FileTree.File name="page.mdx" />
+    </FileTree.Folder>
+    <FileTree.File name="page.mdx" />
+  </FileTree.Folder>
+</FileTree>
+
+<div className='inline-flex'>
+```mdx filename="content/fruits/index.mdx or app/fruits/page.mdx" copy=false
+---
+asIndexPage: true
+---
+```
+
+</div>
 
 Then Nextra knows that the `fruits` key in `_meta` defines a folder with an
 index page. If you click that folder in the sidebar, it will open the folder and

--- a/docs/app/docs/file-conventions/meta-file/page.mdx
+++ b/docs/app/docs/file-conventions/meta-file/page.mdx
@@ -116,9 +116,12 @@ move directories around without having to change the `_meta` file.
 
 ### Folders with Index Page
 
-To create a folder with an index page (like a `/fruits` route), make a file named
-`content/fruits/index.mdx` or `app/fruits/page.mdx`. Add `asIndexPage: true` to the
-front matter to mark it as the index page.
+To create a folder with an index page, add `asIndexPage: true` to its front
+matter.
+
+For example, to create a `/fruits` route, setting `asIndexPage: true` tells
+Nextra that `/fruits` is a folder with an index page. Clicking the folder in the
+sidebar will expand it and display the MDX page.
 
 <FileTree>
   **Using [`content` directory](/docs/file-conventions/content-directory)**
@@ -168,10 +171,6 @@ asIndexPage: true
 ```
 
 </div>
-
-Then Nextra knows that the `fruits` key in `_meta` defines a folder with an
-index page. If you click that folder in the sidebar, it will open the folder and
-show you the `page.mdx`/`index.mdx` page at the same time.
 
 ## External Links
 

--- a/docs/app/docs/file-conventions/meta-file/page.mdx
+++ b/docs/app/docs/file-conventions/meta-file/page.mdx
@@ -141,8 +141,8 @@ sidebar will expand it and display the MDX page.
 
 <FileTree>
   **Using [`page.mdx` files](/docs/file-conventions/page-file)**
-  <FileTree.Folder name="app" open>
-    <FileTree.Folder name="fruits" open active>
+  <FileTree.Folder name="app" defaultOpen>
+    <FileTree.Folder name="fruits" defaultOpen active>
       <FileTree.File name="_meta.js" />
       <FileTree.Folder name="apple">
         <FileTree.File name="page.mdx" />

--- a/docs/app/docs/file-conventions/page.mdx
+++ b/docs/app/docs/file-conventions/page.mdx
@@ -46,7 +46,7 @@ from filenames.
 For example if you have the following structure:
 
 <FileTree>
-  **With [`content` directory](/docs/file-conventions/content-directory)**
+  **Using [`content` directory](/docs/file-conventions/content-directory)**
   <FileTree.Folder name="app" defaultOpen>
     <FileTree.Folder name="[[...mdxPath]]" defaultOpen>
       <FileTree.File name="page.jsx" />
@@ -66,7 +66,7 @@ For example if you have the following structure:
 </FileTree>
 
 <FileTree>
-  **With [`page.mdx` files](/docs/file-conventions/page-file)**
+  **Using [`page.mdx` files](/docs/file-conventions/page-file)**
   <FileTree.Folder name="app" defaultOpen>
     <FileTree.Folder name="about" defaultOpen>
       <FileTree.Folder name="legal" defaultOpen>


### PR DESCRIPTION
Update Folders with Index Page to the new format

## Why:

The Old format does not work anymore in v4.

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
