### PR TITLE
handle non-"\w" characters

### DIFF
--- a/packages/nextra/src/client/pages.ts
+++ b/packages/nextra/src/client/pages.ts
@@ -7,7 +7,10 @@ import { logger } from '../server/utils.js'
 export async function importPage(pathSegments: string[] = [], lang = '') {
   const RouteToFilepath = await getRouteToFilepath(lang)
 
-  const pagePath = RouteToFilepath[pathSegments.join('/')]
+  const path = pathSegments.join('/')
+  const decodePath = decodeURI(path) // handle non-"\w" characters
+
+  const pagePath = RouteToFilepath[decodePath]
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module -- Require statement enables Fast Refresh
     return require(`private-next-content-dir/${lang && `${lang}/`}${pagePath}`)

--- a/packages/nextra/src/server/page-map/to-ast.ts
+++ b/packages/nextra/src/server/page-map/to-ast.ts
@@ -6,9 +6,14 @@ import { createAstObject } from '../utils.js'
 function cleanFilePath(filePath: string): string {
   // Remove extension
   const { dir, name } = path.parse(filePath)
+
+  const path = `${dir.replace(/^(src\/)?content\/?/, '')}_${name}`
+  // handle non-"\w" characters
+  const encodePath = encodeURI(path)
+
   return (
     // Remove `content` prefix
-    `${dir.replace(/^(src\/)?content\/?/, '')}_${name}`
+    encodePath
       .replaceAll(/[\W_]+/g, '_')
       // Remove leading `_`
       .replace(/^_/, '')

--- a/packages/nextra/src/server/page-map/to-page-map.ts
+++ b/packages/nextra/src/server/page-map/to-page-map.ts
@@ -80,7 +80,7 @@ export function convertToPageMap({
       }
       const item = {
         name: key || 'index',
-        route: `/${path}`
+        route: `/${encodeURI(path)}` // handle non-"\w" characters
       }
       const keys = Object.keys(value)
       const isFolder = keys.length > 1 || (keys.length === 1 && keys[0] !== '')


### PR DESCRIPTION
## Why:

Currently, only mdx files named with `\w` can be processed correctly.

![image](https://github.com/user-attachments/assets/dc165774-a880-488b-a8e4-64471b00cb84)

Because `cleanFilePath` use `.replaceAll(/[\W_]+/g, '_')` handle filename, so other character will be drop. and finnal can't generate/get correctly route.

## What's being changed

handle route use `encodeURI` and `decodeURI`, This will handle more filenames.

1. `fillPageMap` use `encodeURI`, this can handle (allmost) file paths as `\w` supported characters.
2. `cleanFilePath` use `encodeURI`, this can matches the results generated by `fillPageMap`
3. clint use `decodeURI`, this can get correctly file path.

## preview link

[error case](https://stackblitz.com/edit/vitejs-vite-2sjt2wk6)

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
