### PR TITLE
fix `::selection` styles, use `hsla` instead of `hsl` because it can overlap text with `::selection` background when `background-clip: text` is set

### DIFF
--- a/.changeset/honest-parrots-rest.md
+++ b/.changeset/honest-parrots-rest.md
@@ -1,0 +1,5 @@
+---
+"nextra": patch
+---
+
+fix `::selection` styles, use `hsla` instead of `hsl` because it can overlap text with `::selection` background when `background-clip: text` is set

--- a/packages/nextra/src/client/components/head.tsx
+++ b/packages/nextra/src/client/components/head.tsx
@@ -96,10 +96,7 @@ export const Head: FC<HeadProps> = ({ children, ...props }) => {
   --nextra-bg: ${backgroundColor.dark};
 }
 ::selection {
-  background: ${makePrimaryColor('+ 41%')};
-}
-.dark ::selection {
-  background: ${makePrimaryColor('- 11%')};
+  background: hsla(var(--nextra-primary-hue),var(--nextra-primary-saturation),var(--nextra-primary-lightness),.3);
 }
 html {
   background: rgb(var(--nextra-bg));
@@ -129,11 +126,4 @@ html {
       )}
     </head>
   )
-}
-
-function makePrimaryColor(val: string): string {
-  const h = 'var(--nextra-primary-hue)'
-  const s = 'var(--nextra-primary-saturation)'
-  const l = `calc(var(--nextra-primary-lightness) ${val})`
-  return `hsl(${h + s + l})`
 }


### PR DESCRIPTION
closes https://github.com/shuding/nextra/issues/3998