### PR TITLE
add new nextra config option `unstable_shouldAddLocaleToLinks` to append locale to all links, for i18n websites which uses static exports and can't use Nextra middleware

### DIFF
--- a/.changeset/neat-yaks-develop.md
+++ b/.changeset/neat-yaks-develop.md
@@ -1,0 +1,5 @@
+---
+"nextra": patch
+---
+
+add new nextra config option `unstable_shouldAddLocaleToLinks` to append locale to all links, for i18n websites which uses static exports and can't use Nextra middleware

--- a/packages/nextra/src/client/hooks/use-fs-route.ts
+++ b/packages/nextra/src/client/hooks/use-fs-route.ts
@@ -5,7 +5,10 @@ const defaultLocale = process.env.NEXTRA_DEFAULT_LOCALE
 export function useFSRoute() {
   const pathname = usePathname()
   return (
-    (defaultLocale ? '/' + pathname.split('/').slice(2).join('/') : pathname)
+    (process.env.NEXTRA_SHOULD_ADD_LOCALE_TO_LINKS !== 'true' && defaultLocale
+      ? '/' + pathname.split('/').slice(2).join('/')
+      : pathname
+    )
       .replace(/\.html$/, '')
       .replace(/\/index(\/|$)/, '$1')
       .replace(/\/$/, '') || '/'

--- a/packages/nextra/src/server/index.ts
+++ b/packages/nextra/src/server/index.ts
@@ -61,8 +61,10 @@ const nextra: Nextra = nextraConfig => {
   const pageMapPlaceholderLoader = {
     loader: LOADER_PATH,
     options: {
-      contentDirBasePath: loaderOptions.contentDirBasePath,
-      contentDir: CONTENT_DIR
+      // Remove forward slash
+      contentDirBasePath: loaderOptions.contentDirBasePath.slice(1),
+      contentDir: CONTENT_DIR,
+      shouldAddLocaleToLinks: loaderOptions.unstable_shouldAddLocaleToLinks
     }
   }
 
@@ -95,7 +97,10 @@ const nextra: Nextra = nextraConfig => {
       env: {
         ...nextConfig.env,
         NEXTRA_LOCALES: JSON.stringify(pageMapLoader.options.locales),
-        NEXTRA_DEFAULT_LOCALE: defaultLocale
+        NEXTRA_DEFAULT_LOCALE: defaultLocale,
+        NEXTRA_SHOULD_ADD_LOCALE_TO_LINKS: String(
+          loaderOptions.unstable_shouldAddLocaleToLinks
+        )
       },
       experimental: {
         ...nextConfig.experimental,

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -69,7 +69,8 @@ export async function loader(
     contentDirBasePath,
     contentDir,
     locales,
-    whiteListTagsStyling
+    whiteListTagsStyling,
+    shouldAddLocaleToLinks
   } = this.getOptions()
   const { resourcePath, resourceQuery } = this
 
@@ -90,12 +91,16 @@ export async function loader(
       locale,
       contentDir
     })
-    const { pageMap, mdxPages } = convertToPageMap({
+    let { pageMap, mdxPages } = convertToPageMap({
       filePaths,
-      // Remove forward slash
-      basePath: contentDirBasePath.slice(1),
+      basePath: shouldAddLocaleToLinks
+        ? [locale, contentDirBasePath].filter(Boolean).join('/')
+        : contentDirBasePath,
       locale
     })
+    if (shouldAddLocaleToLinks && 'children' in pageMap[0]!) {
+      pageMap = pageMap[0].children
+    }
     const globalMetaPath = filePaths.find(filePath =>
       filePath.includes('/_meta.global.')
     )

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -64,7 +64,8 @@ export const nextraConfigSchema = z.strictObject({
       value => value.length === 1 || !value.endsWith('/'),
       value => ({ message: `"${value}" must not end with "/"` })
     )
-    .default('/')
+    .default('/'),
+  unstable_shouldAddLocaleToLinks: z.boolean().default(false)
 })
 
 export const element = z.custom<ReactElement>(isValidElement, {

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -12,6 +12,7 @@ export interface LoaderOptions extends z.infer<typeof nextraConfigSchema> {
   isPageImport?: boolean
   locales: string[]
   contentDir?: string
+  shouldAddLocaleToLinks?: boolean
 }
 
 type TPageItem = { name: string; route: string; __pagePath: string }


### PR DESCRIPTION
closes https://github.com/shuding/nextra/issues/3934