### PR TITLE
v3: Add defaultOpen option to sidebar configuration

### DIFF
--- a/docs/pages/docs/docs-theme/theme-configuration.mdx
+++ b/docs/pages/docs/docs-theme/theme-configuration.mdx
@@ -386,6 +386,7 @@ Customize the entire navbar component.
 | sidebar.defaultMenuCollapseLevel | `number`  | Specifies the folder level at which the menu on the left is collapsed by default. Defaults to 2 |
 | sidebar.autoCollapse             | `boolean` | If true, automatically collapse inactive folders above `defaultMenuCollapseLevel`               |
 | sidebar.toggleButton             | `boolean` | Hide/show sidebar toggle button. Defaults to `false`                                            |
+| sidebar.defaultOpen              | `boolean` | Hide/show sidebar by default. Defaults to `true`                                                |
 
 </Table>
 

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -113,7 +113,8 @@ const config: DocsThemeConfig = {
   },
   sidebar: {
     defaultMenuCollapseLevel: 1,
-    toggleButton: true
+    toggleButton: true,
+    defaultOpen: true
   },
   footer: {
     content: (

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -347,8 +347,9 @@ export function Sidebar({
   includePlaceholder
 }: SideBarProps): ReactElement {
   const { menu, setMenu } = useMenu()
+  const themeConfig = useThemeConfig()
   const [focused, setFocused] = useState('')
-  const [showSidebar, setSidebar] = useState(true)
+  const [showSidebar, setSidebar] = useState(themeConfig.sidebar.defaultOpen)
   const [showToggleAnimation, setToggleAnimation] = useState(false)
 
   const anchors = useMemo(() => toc.filter(v => v.depth === 2), [toc])
@@ -377,7 +378,6 @@ export function Sidebar({
     }
   }, [menu])
 
-  const themeConfig = useThemeConfig()
   const hasI18n = themeConfig.i18n.length > 0
   const hasMenu =
     themeConfig.darkMode || hasI18n || themeConfig.sidebar.toggleButton

--- a/packages/nextra-theme-docs/src/constants.tsx
+++ b/packages/nextra-theme-docs/src/constants.tsx
@@ -159,7 +159,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   },
   sidebar: {
     defaultMenuCollapseLevel: 2,
-    toggleButton: true
+    toggleButton: true,
+    defaultOpen: true
   },
   themeSwitch: {
     component: ThemeSwitch,

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -121,7 +121,8 @@ export const themeSchema = /* @__PURE__ */ (() =>
     sidebar: z.strictObject({
       autoCollapse: z.boolean().optional(),
       defaultMenuCollapseLevel: z.number().min(1).int(),
-      toggleButton: z.boolean()
+      toggleButton: z.boolean(),
+      defaultOpen: z.boolean()
     }),
     themeSwitch: z.strictObject({
       component: z.custom<


### PR DESCRIPTION
Introduce a `defaultOpen` option to the sidebar configuration, allowing users to specify whether the sidebar should be open by default. This change enhances customization of the sidebar's initial state.

closes #4032

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).

