### PR TITLE
Conditionally render footer content based on theme configuration to fix wasted space

### DIFF
--- a/packages/nextra-theme-docs/src/components/footer.tsx
+++ b/packages/nextra-theme-docs/src/components/footer.tsx
@@ -21,14 +21,16 @@ export function Footer({ menu }: { menu?: boolean }): ReactElement {
           renderComponent(themeConfig.themeSwitch.component)}
       </div>
       <hr className="dark:_border-neutral-800" />
-      <div
-        className={cn(
-          '_mx-auto _flex _max-w-[90rem] _justify-center _py-12 _text-gray-600 dark:_text-gray-400 md:_justify-start',
-          '_pl-[max(env(safe-area-inset-left),1.5rem)] _pr-[max(env(safe-area-inset-right),1.5rem)]'
-        )}
-      >
-        {renderComponent(themeConfig.footer.content)}
-      </div>
+      {!!themeConfig.footer.content && (
+        <div
+          className={cn(
+            '_mx-auto _flex _max-w-[90rem] _justify-center _py-12 _text-gray-600 dark:_text-gray-400 md:_justify-start',
+            '_pl-[max(env(safe-area-inset-left),1.5rem)] _pr-[max(env(safe-area-inset-right),1.5rem)]'
+          )}
+        >
+          {renderComponent(themeConfig.footer.content)}
+        </div>
+      )}
     </footer>
   )
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Render the footer content only if it is defined in the theme configuration, improving the component's flexibility and responsiveness to theme changes.

Closes https://github.com/shuding/nextra/issues/4031

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

before
![image](https://github.com/user-attachments/assets/2b81a405-b3ea-4529-babd-91dcafcd666d)

after
![image](https://github.com/user-attachments/assets/46266362-e598-4343-9192-17a084965520)

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
