### PR TITLE
Conditionally render footer based on children presence to align with user expectation and remove empty space

### DIFF
--- a/.changeset/big-starfishes-punch.md
+++ b/.changeset/big-starfishes-punch.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+do not render default footer content if the `Footer#children` prop was not provided

--- a/examples/docs/src/app/layout.jsx
+++ b/examples/docs/src/app/layout.jsx
@@ -44,7 +44,7 @@ export default async function RootLayout({ children }) {
         <Layout
           banner={<Banner storageKey="Nextra 2">Nextra 2 Alpha</Banner>}
           navbar={navbar}
-          footer={<Footer />}
+          footer={<Footer>MIT {new Date().getFullYear()} © Nextra.</Footer>}
           editLink="Edit this page on GitHub"
           docsRepositoryBase="https://github.com/shuding/nextra/blob/main/examples/docs"
           sidebar={{ defaultMenuCollapseLevel: 1 }}

--- a/packages/nextra-theme-docs/src/components/footer/index.tsx
+++ b/packages/nextra-theme-docs/src/components/footer/index.tsx
@@ -18,7 +18,7 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
         </div>
       </Switchers>
       <hr className="nextra-border" />
-      {!!children && (
+      {children && (
         <footer
           className={cn(
             'x:mx-auto x:flex x:max-w-(--nextra-content-width) x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',

--- a/packages/nextra-theme-docs/src/components/footer/index.tsx
+++ b/packages/nextra-theme-docs/src/components/footer/index.tsx
@@ -18,16 +18,18 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
         </div>
       </Switchers>
       <hr className="nextra-border" />
-      <footer
-        className={cn(
-          'x:mx-auto x:flex x:max-w-(--nextra-content-width) x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
-          'x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]',
-          className
-        )}
-        {...props}
-      >
-        {children || `MIT ${new Date().getFullYear()} © Nextra.`}
-      </footer>
+      {!!children && (
+        <footer
+          className={cn(
+            'x:mx-auto x:flex x:max-w-(--nextra-content-width) x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
+            'x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]',
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </footer>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Render the footer content only if it is defined in the theme configuration, improving the component's flexibility and responsiveness to theme changes.

Closes https://github.com/shuding/nextra/issues/4031

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

before
![image](https://github.com/user-attachments/assets/2b81a405-b3ea-4529-babd-91dcafcd666d)

after
![image](https://github.com/user-attachments/assets/46266362-e598-4343-9192-17a084965520)

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
