### PR TITLE
fix: theme toggle lite mode on mobile

### DIFF
--- a/.changeset/fresh-llamas-judge.md
+++ b/.changeset/fresh-llamas-judge.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+fix `ThemeSwitch#lite` prop

--- a/examples/swr-site/app/[lang]/layout.tsx
+++ b/examples/swr-site/app/[lang]/layout.tsx
@@ -75,7 +75,7 @@ export default async function RootLayout({ children, params }) {
       projectLink="https://github.com/vercel/swr"
       chatLink="https://discord.com"
     >
-      <LocaleSwitch />
+      <LocaleSwitch lite />
     </Navbar>
   )
   const footer = (

--- a/packages/nextra-theme-docs/src/components/locale-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/locale-switch.tsx
@@ -6,6 +6,7 @@ import { Select } from 'nextra/components'
 import { GlobeIcon } from 'nextra/icons'
 import type { FC } from 'react'
 import { useThemeConfig } from '../stores'
+import cn from 'clsx'
 
 const ONE_YEAR = 365 * 24 * 60 * 60 * 1000
 
@@ -17,13 +18,13 @@ interface LocaleSwitchProps {
 export const LocaleSwitch: FC<LocaleSwitchProps> = ({ lite, className }) => {
   const { i18n } = useThemeConfig()
   const pathname = usePathname()
-  if (!i18n.length) return null
+  if (!i18n.length) return
 
   const [, locale] = pathname.split('/', 2)
   return (
     <Select
       title="Change language"
-      className={className}
+      className={cn('x:flex x:items-center x:gap-2',className)}
       onChange={lang => {
         const date = new Date(Date.now() + ONE_YEAR)
         document.cookie = `NEXT_LOCALE=${lang}; expires=${date.toUTCString()}; path=/`
@@ -31,10 +32,10 @@ export const LocaleSwitch: FC<LocaleSwitchProps> = ({ lite, className }) => {
       }}
       value={locale!}
       selectedOption={
-        <span className="x:flex x:items-center x:gap-2">
+        <>
           <GlobeIcon height="12" />
           {!lite && i18n.find(l => locale === l.locale)?.name}
-        </span>
+        </>
       }
       options={i18n.map(l => ({
         id: l.locale,

--- a/packages/nextra-theme-docs/src/components/locale-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/locale-switch.tsx
@@ -1,12 +1,12 @@
 'use client'
 
+import cn from 'clsx'
 import { addBasePath } from 'next/dist/client/add-base-path'
 import { usePathname } from 'next/navigation'
 import { Select } from 'nextra/components'
 import { GlobeIcon } from 'nextra/icons'
 import type { FC } from 'react'
 import { useThemeConfig } from '../stores'
-import cn from 'clsx'
 
 const ONE_YEAR = 365 * 24 * 60 * 60 * 1000
 
@@ -24,7 +24,7 @@ export const LocaleSwitch: FC<LocaleSwitchProps> = ({ lite, className }) => {
   return (
     <Select
       title="Change language"
-      className={cn('x:flex x:items-center x:gap-2',className)}
+      className={cn('x:flex x:items-center x:gap-2', className)}
       onChange={lang => {
         const date = new Date(Date.now() + ONE_YEAR)
         document.cookie = `NEXT_LOCALE=${lang}; expires=${date.toUTCString()}; path=/`

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -349,8 +349,8 @@ export const MobileNav: FC = () => {
 
       {hasMenu && (
         <div className={cn(classes.footer, 'x:mt-auto')}>
-          <ThemeSwitch lite={hasI18n} className="x:grow" />
-          <LocaleSwitch />
+          <ThemeSwitch className='x:grow' />
+          <LocaleSwitch className='x:grow x:justify-end' />
         </div>
       )}
     </aside>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -349,8 +349,8 @@ export const MobileNav: FC = () => {
 
       {hasMenu && (
         <div className={cn(classes.footer, 'x:mt-auto')}>
-          <ThemeSwitch className='x:grow' />
-          <LocaleSwitch className='x:grow x:justify-end' />
+          <ThemeSwitch className="x:grow" />
+          <LocaleSwitch className="x:grow x:justify-end" />
         </div>
       )}
     </aside>

--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -17,7 +17,7 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({ lite, className }) => {
   const mounted = useMounted()
   const { darkMode, themeSwitch } = useThemeConfig()
   if (!darkMode) {
-    return null
+    return
   }
   const IconToUse = mounted && resolvedTheme === 'dark' ? MoonIcon : SunIcon
   const id = mounted ? (theme as keyof typeof themeSwitch) : 'light'
@@ -35,7 +35,7 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({ lite, className }) => {
       selectedOption={
         <span className="x:flex x:items-center x:gap-2 x:capitalize">
           <IconToUse height="12" />
-          <span className={lite ? 'x:hidden' : ''}>{themeSwitch[id]}</span>
+          {!lite && themeSwitch[id]}
         </span>
       }
     />

--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -35,7 +35,7 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({ lite, className }) => {
       selectedOption={
         <span className="x:flex x:items-center x:gap-2 x:capitalize">
           <IconToUse height="12" />
-          <span className={lite ? 'x:md:hidden' : ''}>{themeSwitch[id]}</span>
+          <span className={lite ? 'x:hidden' : ''}>{themeSwitch[id]}</span>
         </span>
       }
     />

--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import cn from 'clsx'
 import { useTheme } from 'next-themes'
 import { Select } from 'nextra/components'
 import { useMounted } from 'nextra/hooks'
@@ -23,7 +24,7 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({ lite, className }) => {
   const id = mounted ? (theme as keyof typeof themeSwitch) : 'light'
   return (
     <Select
-      className={className}
+      className={cn('x:flex x:items-center x:gap-2', className)}
       title="Change theme"
       options={[
         { id: 'light', name: themeSwitch.light },
@@ -33,10 +34,10 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({ lite, className }) => {
       onChange={setTheme}
       value={id}
       selectedOption={
-        <span className="x:flex x:items-center x:gap-2 x:capitalize">
+        <>
           <IconToUse height="12" />
           {!lite && themeSwitch[id]}
-        </span>
+        </>
       }
     />
   )


### PR DESCRIPTION
lite mode on mobile doesn't work, now it behaves like locale switch

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

before
![image](https://github.com/user-attachments/assets/8538d7e9-fc31-46c5-b939-ef65338dda83)

after
![image](https://github.com/user-attachments/assets/e12a7bf5-e571-4acc-ac1d-be3c60eac9fd)


## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
