### PR TITLE
fix: theme toggle lite mode on mobile

### DIFF
--- a/packages/nextra-theme-docs/src/components/theme-switch.tsx
+++ b/packages/nextra-theme-docs/src/components/theme-switch.tsx
@@ -45,7 +45,7 @@ export function ThemeSwitch({
         name: (
           <div className="_flex _items-center _gap-2 _capitalize">
             <IconToUse />
-            <span className={lite ? 'md:_hidden' : ''}>
+            <span className={lite ? '_hidden' : ''}>
               {mounted ? options[theme as keyof typeof options] : options.light}
             </span>
           </div>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

lite mode on mobile doesn't work, now it behaves like locale switch

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

before
![image](https://github.com/user-attachments/assets/8538d7e9-fc31-46c5-b939-ef65338dda83)

after
![image](https://github.com/user-attachments/assets/e12a7bf5-e571-4acc-ac1d-be3c60eac9fd)

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
