### PR TITLE
Ability to render TOC in type page

### DIFF
--- a/.changeset/twelve-hotels-nail.md
+++ b/.changeset/twelve-hotels-nail.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+allow change `_meta` file `theme.toc` property with `type: 'page'`

--- a/docs/app/_meta.global.tsx
+++ b/docs/app/_meta.global.tsx
@@ -178,13 +178,17 @@ export default {
   blog: {
     type: 'page',
     theme: {
-      typesetting: 'article'
+      typesetting: 'article',
+      breadcrumb: false,
+      toc: false
     }
   },
   about: {
     type: 'page',
     theme: {
-      typesetting: 'article'
+      typesetting: 'article',
+      toc: true,
+      breadcrumb: false
     }
   },
   showcase: {
@@ -192,7 +196,8 @@ export default {
     theme: {
       typesetting: 'article',
       layout: 'full',
-      timestamp: false
+      timestamp: false,
+      breadcrumb: false
     }
   },
   sponsors: {
@@ -200,7 +205,8 @@ export default {
     theme: {
       typesetting: 'article',
       layout: 'full',
-      timestamp: false
+      timestamp: false,
+      breadcrumb: false
     }
   }
 }

--- a/docs/app/_meta.global.tsx
+++ b/docs/app/_meta.global.tsx
@@ -179,16 +179,13 @@ export default {
     type: 'page',
     theme: {
       typesetting: 'article',
-      breadcrumb: false,
       toc: false
     }
   },
   about: {
     type: 'page',
     theme: {
-      typesetting: 'article',
-      toc: true,
-      breadcrumb: false
+      typesetting: 'article'
     }
   },
   showcase: {
@@ -196,8 +193,7 @@ export default {
     theme: {
       typesetting: 'article',
       layout: 'full',
-      timestamp: false,
-      breadcrumb: false
+      timestamp: false
     }
   },
   sponsors: {
@@ -205,8 +201,7 @@ export default {
     theme: {
       typesetting: 'article',
       layout: 'full',
-      timestamp: false,
-      breadcrumb: false
+      timestamp: false
     }
   }
 }

--- a/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
@@ -50,7 +50,7 @@ export const ClientWrapper: MDXWrapper = ({
             'nextra-body-typesetting-article'
         )}
       >
-        {themeContext.breadcrumb && (
+        {themeContext.breadcrumb && activeType !== 'page' && (
           <Breadcrumb activePath={activePath} />
         )}
         {children}

--- a/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
@@ -33,7 +33,7 @@ export const ClientWrapper: MDXWrapper = ({
           className="nextra-toc x:order-last x:max-xl:hidden x:w-64 x:shrink-0 x:print:hidden"
           aria-label="table of contents"
         >
-          {themeContext.toc && activeType !== 'page' && (
+          {themeContext.toc && (
             <TOC
               toc={themeConfig.toc.float ? toc : []}
               filePath={metadata.filePath}

--- a/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
@@ -50,7 +50,7 @@ export const ClientWrapper: MDXWrapper = ({
             'nextra-body-typesetting-article'
         )}
       >
-        {themeContext.breadcrumb && activeType !== 'page' && (
+        {themeContext.breadcrumb && (
           <Breadcrumb activePath={activePath} />
         )}
         {children}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

this pr gives the user more control and adheres to user expectation.
implicit, undocumented, and no workaround behavior like this should be avoided.

Closes: #4081
Closes: https://github.com/shuding/nextra/issues/4030

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

http://localhost:3000/about

before
![image](https://github.com/user-attachments/assets/28b2a480-e8b2-4dc0-90b0-a3a82d1b6f0e)

after
![image](https://github.com/user-attachments/assets/f689685a-f5a2-4400-aaaa-6b7b2d5a1b33)


<!-- Let us know what you are changing. Share anything that could provide the most context. -->

docusaurus allows rendering toc on regular pages which is useful and i need this
![image](https://github.com/user-attachments/assets/edd029ed-3728-4c37-8b16-f20085b3d47c)

I realize this changes previous behavior but this is needed and it's best to do it now while v4 is new and very few people are using it.

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
