### PR TITLE
Fix capitalization of alert name in GitHub alert HOC

### DIFF
--- a/.changeset/nice-weeks-dream.md
+++ b/.changeset/nice-weeks-dream.md
@@ -1,0 +1,5 @@
+---
+"nextra": patch
+---
+
+improve github alert syntax name in DOM

--- a/packages/nextra/src/client/hocs/with-github-alert.tsx
+++ b/packages/nextra/src/client/hocs/with-github-alert.tsx
@@ -40,9 +40,8 @@ export function withGitHubAlert(
             ...props,
             type: alertName as T,
             children: [
-              <b key={0}>
-                {alertName[0]!.toUpperCase()}
-                {alertName.slice(1)}
+              <b key={0} className='x:capitalize'>
+                {alertName}
               </b>,
               ...props.children.slice(2)
             ]

--- a/packages/nextra/src/client/hocs/with-github-alert.tsx
+++ b/packages/nextra/src/client/hocs/with-github-alert.tsx
@@ -36,13 +36,13 @@ export function withGitHubAlert(
               `Invalid GitHub alert type: "${alertName}". Should be one of: ${GITHUB_ALERTS.join(', ')}.`
             )
           }
+          const capitalizedName =
+            alertName[0]!.toUpperCase() + alertName.slice(1)
           return fn({
             ...props,
             type: alertName as T,
             children: [
-              <b key={0} className='x:capitalize'>
-                {alertName}
-              </b>,
+              <b key={0}>{capitalizedName}</b>,
               ...props.children.slice(2)
             ]
           })


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

css has capitalize support

![image](https://github.com/user-attachments/assets/f3176e0e-5a0c-46ad-8729-b7e402bf916d)


<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

no visual changes

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
