### PR TITLE
Refactor GitHub alert capitalization styling

### DIFF
--- a/packages/nextra/src/client/hocs/with-github-alert.tsx
+++ b/packages/nextra/src/client/hocs/with-github-alert.tsx
@@ -26,9 +26,13 @@ export function withGitHubAlert(
     if (Array.isArray(props.children)) {
       const str = props.children[1].props.children
       if (typeof str === 'string') {
-        const alertName = str
-          .match(GITHUB_ALERT_RE)
-          ?.groups?.name!.toLowerCase()
+        const match = str.match(GITHUB_ALERT_RE)?.groups?.name
+
+        if (!match) {
+          return <Component {...props} />
+        }
+
+        const alertName = match.toLowerCase()
 
         if (alertName) {
           if (!GITHUB_ALERT_TYPES.has(alertName)) {

--- a/packages/nextra/src/client/hocs/with-github-alert.tsx
+++ b/packages/nextra/src/client/hocs/with-github-alert.tsx
@@ -40,9 +40,14 @@ export function withGitHubAlert(
             ...props,
             type: alertName as T,
             children: [
-              <b key={0} style={{
-                textTransform: 'capitalize',
-              }}>{alertName}</b>,
+              <b
+                key={0}
+                style={{
+                  textTransform: 'capitalize'
+                }}
+              >
+                {alertName}
+              </b>,
               ...props.children.slice(2)
             ]
           })

--- a/packages/nextra/src/client/hocs/with-github-alert.tsx
+++ b/packages/nextra/src/client/hocs/with-github-alert.tsx
@@ -36,13 +36,13 @@ export function withGitHubAlert(
               `Invalid GitHub alert type: "${alertName}". Should be one of: ${GITHUB_ALERTS.join(', ')}.`
             )
           }
-          const capitalizedName =
-            alertName[0]!.toUpperCase() + alertName.slice(1)
           return fn({
             ...props,
             type: alertName as T,
             children: [
-              <b key={0}>{capitalizedName}</b>,
+              <b key={0} style={{
+                textTransform: 'capitalize',
+              }}>{alertName}</b>,
               ...props.children.slice(2)
             ]
           })


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Titles should displayed as they are and modified via css to allow control and easier overrided by the users.

more reliable (text isn't modified) also better performance (no js) and more typesafe (non-null assertion)

contributes to: https://github.com/shuding/nextra/issues/4087

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

Replace manual capitalization of GitHub alert names with CSS styling for improved consistency and maintainability.

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
