### PR TITLE
fix a sudden height jump on opening for `<detail>` element when his last children contain margins

### DIFF
--- a/.changeset/mean-pears-drive.md
+++ b/.changeset/mean-pears-drive.md
@@ -1,0 +1,7 @@
+---
+"nextra": patch
+"nextra-theme-blog": patch
+"nextra-theme-docs": patch
+---
+
+fix a sudden height jump on opening for `<detail>` element when his last children contain margins

--- a/packages/nextra/src/client/mdx-components/details.tsx
+++ b/packages/nextra/src/client/mdx-components/details.tsx
@@ -72,7 +72,7 @@ export const Details: FC<ComponentProps<'details'>> = ({
         isOpen={isOpen}
         className={cn(
           'x:*:pt-2',
-          'x:grid' // https://github.com/shuding/nextra/issues/4074
+          'x:grid' // fix sudden height jump on open state https://github.com/shuding/nextra/issues/4074
         )}
       >
         {restChildren}

--- a/packages/nextra/src/client/mdx-components/details.tsx
+++ b/packages/nextra/src/client/mdx-components/details.tsx
@@ -68,7 +68,13 @@ export const Details: FC<ComponentProps<'details'>> = ({
       data-expanded={isOpen ? '' : undefined}
     >
       {summaryElement}
-      <Collapse isOpen={isOpen} className="x:*:pt-2">
+      <Collapse
+        isOpen={isOpen}
+        className={cn(
+          'x:*:pt-2',
+          'x:grid' // https://github.com/shuding/nextra/issues/4074
+        )}
+      >
         {restChildren}
       </Collapse>
     </details>


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/4074