### PR TITLE
Add layout fill mode

### DIFF
--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -392,92 +392,97 @@ export const Sidebar: FC<{ toc: Heading[] }> = ({ toc }) => {
 
   return (
     <>
-      {includePlaceholder && hideSidebar && (
-        <div className="x:max-xl:hidden x:h-0 x:w-64 x:shrink-0" />
-      )}
-      <aside
-        id={sidebarControlsId}
-        className={cn(
-          'nextra-sidebar x:print:hidden',
-          'x:transition-all x:ease-in-out',
-          'x:max-md:hidden x:flex x:flex-col',
-          'x:h-[calc(100dvh-var(--nextra-menu-height))]',
-          'x:top-(--nextra-navbar-height) x:shrink-0',
-          isExpanded ? 'x:w-64' : 'x:w-20',
-          hideSidebar ? 'x:hidden' : 'x:sticky'
+      {includePlaceholder &&
+        hideSidebar &&
+        activeThemeContext.layout !== 'fill' && (
+          <div className="x:max-xl:hidden x:h-0 x:w-64 x:shrink-0" />
         )}
-      >
-        <div
+      {activeThemeContext.layout !== 'full' && (
+        <aside
+          id={sidebarControlsId}
           className={cn(
-            classes.wrapper,
-            'x:grow',
-            !isExpanded && 'no-scrollbar'
+            'nextra-sidebar x:print:hidden',
+            'x:transition-all x:ease-in-out',
+            'x:max-md:hidden x:flex x:flex-col',
+            'x:h-[calc(100dvh-var(--nextra-menu-height))]',
+            'x:top-(--nextra-navbar-height) x:shrink-0',
+            isExpanded ? 'x:w-64' : 'x:w-20',
+            hideSidebar ? 'x:hidden' : 'x:sticky'
           )}
-          ref={sidebarRef}
         >
-          {/* without !hideSidebar check <Collapse />'s inner.clientWidth on `layout: "raw"` will be 0 and element will not have width on initial loading */}
-          {(!hideSidebar || !isExpanded) && (
-            <Collapse isOpen={isExpanded} horizontal>
-              <Menu
-                // The sidebar menu, shows only the docs directories.
-                directories={docsDirectories}
-                anchors={anchors}
-                level={0}
-              />
-            </Collapse>
-          )}
-        </div>
-        {hasMenu && (
           <div
             className={cn(
-              'x:sticky x:bottom-0 x:bg-nextra-bg',
-              classes.footer,
-              !isExpanded && 'x:flex-wrap x:justify-center',
-              showToggleAnimation && [
-                'x:*:opacity-0',
-                isExpanded
-                  ? 'x:*:animate-[fade-in_1s_ease_.2s_forwards]'
-                  : 'x:*:animate-[fade-in2_1s_ease_.2s_forwards]'
-              ]
+              classes.wrapper,
+              'x:grow',
+              !isExpanded && 'no-scrollbar'
             )}
+            ref={sidebarRef}
           >
-            <LocaleSwitch
-              lite={!isExpanded}
-              className={isExpanded ? 'x:grow' : ''}
-            />
-            <ThemeSwitch
-              lite={!isExpanded || hasI18n}
-              className={!isExpanded || hasI18n ? '' : 'x:grow'}
-            />
-            {themeConfig.sidebar.toggleButton && (
-              <Button
-                aria-expanded={isExpanded}
-                aria-controls={sidebarControlsId}
-                title={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
-                className={({ hover }) =>
-                  cn(
-                    'x:rounded-md x:p-2 x:cursor-pointer',
-                    hover
-                      ? 'x:bg-gray-100 x:text-gray-900 x:dark:bg-primary-100/5 x:dark:text-gray-50'
-                      : 'x:text-gray-600 x:dark:text-gray-400'
-                  )
-                }
-                onClick={() => {
-                  setIsExpanded(prev => !prev)
-                  setToggleAnimation(true)
-                }}
-              >
-                <ExpandIcon
-                  height="12"
-                  className={cn(
-                    !isExpanded && 'x:*:first:origin-[35%] x:*:first:rotate-180'
-                  )}
+            {/* without !hideSidebar check <Collapse />'s inner.clientWidth on `layout: "raw"` will be 0 and element will not have width on initial loading */}
+            {(!hideSidebar || !isExpanded) && (
+              <Collapse isOpen={isExpanded} horizontal>
+                <Menu
+                  // The sidebar menu, shows only the docs directories.
+                  directories={docsDirectories}
+                  anchors={anchors}
+                  level={0}
                 />
-              </Button>
+              </Collapse>
             )}
           </div>
-        )}
-      </aside>
+          {hasMenu && (
+            <div
+              className={cn(
+                'x:sticky x:bottom-0 x:bg-nextra-bg',
+                classes.footer,
+                !isExpanded && 'x:flex-wrap x:justify-center',
+                showToggleAnimation && [
+                  'x:*:opacity-0',
+                  isExpanded
+                    ? 'x:*:animate-[fade-in_1s_ease_.2s_forwards]'
+                    : 'x:*:animate-[fade-in2_1s_ease_.2s_forwards]'
+                ]
+              )}
+            >
+              <LocaleSwitch
+                lite={!isExpanded}
+                className={isExpanded ? 'x:grow' : ''}
+              />
+              <ThemeSwitch
+                lite={!isExpanded || hasI18n}
+                className={!isExpanded || hasI18n ? '' : 'x:grow'}
+              />
+              {themeConfig.sidebar.toggleButton && (
+                <Button
+                  aria-expanded={isExpanded}
+                  aria-controls={sidebarControlsId}
+                  title={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
+                  className={({ hover }) =>
+                    cn(
+                      'x:rounded-md x:p-2 x:cursor-pointer',
+                      hover
+                        ? 'x:bg-gray-100 x:text-gray-900 x:dark:bg-primary-100/5 x:dark:text-gray-50'
+                        : 'x:text-gray-600 x:dark:text-gray-400'
+                    )
+                  }
+                  onClick={() => {
+                    setIsExpanded(prev => !prev)
+                    setToggleAnimation(true)
+                  }}
+                >
+                  <ExpandIcon
+                    height="12"
+                    className={cn(
+                      !isExpanded &&
+                        'x:*:first:origin-[35%] x:*:first:rotate-180'
+                    )}
+                  />
+                </Button>
+              )}
+            </div>
+          )}
+        </aside>
+      )}
     </>
   )
 }

--- a/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
@@ -28,18 +28,16 @@ export const ClientWrapper: MDXWrapper = ({
 
   return (
     <>
-      {themeContext.layout !== 'full' && (
+      {themeContext.layout !== 'full' && themeContext.toc && (
         <nav
           className="nextra-toc x:order-last x:max-xl:hidden x:w-64 x:shrink-0 x:print:hidden"
           aria-label="table of contents"
         >
-          {themeContext.toc && (
-            <TOC
-              toc={themeConfig.toc.float ? toc : []}
-              filePath={metadata.filePath}
-              pageTitle={metadata.title}
-            />
-          )}
+          <TOC
+            toc={themeConfig.toc.float ? toc : []}
+            filePath={metadata.filePath}
+            pageTitle={metadata.title}
+          />
         </nav>
       )}
       <article

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -79,7 +79,7 @@ const pageThemeSchema = z.strictObject({
   breadcrumb: z.boolean().optional(),
   collapsed: z.boolean().optional(),
   footer: z.boolean().optional(),
-  layout: z.enum(['default', 'full']).optional(),
+  layout: z.enum(['default', 'full', 'fill']).optional(),
   navbar: z.boolean().optional(),
   pagination: z.boolean().optional(),
   sidebar: z.boolean().optional(),


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Introduce a new layout option 'fill' to enhance improve layout flexibility. Update related components to accommodate this new layout mode.

fill mode basically makes the main content take up all available space without discarding everything else unlike full mode

Closes: https://github.com/shuding/nextra/issues/4036

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

tested all kinds of combinations with different types and everything works as expected with no regressions from my testing

type page, layout fill, toc true
![image](https://github.com/user-attachments/assets/1f5c5c8f-63da-4fd5-be0f-59d0e026d07d)

type doc, layout fill, sidebar true, toc false
![image](https://github.com/user-attachments/assets/f37834ef-8d39-4bf5-aaf3-930d03b5608c)

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
