### PR TITLE
Add `x:cursor-pointer` style to the `backToTop` component

### DIFF
--- a/.changeset/slimy-beans-grin.md
+++ b/.changeset/slimy-beans-grin.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+add the missing `cursor-pointer` style in the `<BackToTop>` component

--- a/packages/nextra-theme-docs/src/components/back-to-top.tsx
+++ b/packages/nextra-theme-docs/src/components/back-to-top.tsx
@@ -30,7 +30,7 @@ export const BackToTop: FC<{
       disabled={hidden}
       className={({ disabled }) =>
         cn(
-          'x:flex x:items-center x:gap-1.5',
+          'x:flex x:items-center x:gap-1.5 x:cursor-pointer',
           'x:whitespace-nowrap', // Safari
           disabled ? 'x:opacity-0' : 'x:opacity-100',
           className


### PR DESCRIPTION
## Why:

Matches the styling of other `toc` links

## What's being changed (if available, include any code snippets, screenshots, or gifs):

Adds `x:cursor-pointer` to the `backToTop` component

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
