### PR TITLE
Remove requirement `page.{jsx,tsx}` pages to have exported `metadata` object

### DIFF
--- a/.changeset/spotty-carrots-jump.md
+++ b/.changeset/spotty-carrots-jump.md
@@ -1,0 +1,7 @@
+---
+"nextra": patch
+"nextra-theme-blog": patch
+"nextra-theme-docs": patch
+---
+
+Remove requirement `page.{jsx,tsx}` pages to have exported `metadata` object

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -49,7 +49,7 @@ export const metadata: Metadata = {
 
 const banner = (
   <Banner dismissible={false}>
-    🎉 Nextra 4.0 is released. Dima Machina is looking{' '}
+    🎉 Nextra 4.0 is released. dimaMachina is looking{' '}
     <Link href="https://github.com/dimaMachina">
       for a new job or consulting
     </Link>

--- a/examples/docs/src/app/blog/page.jsx
+++ b/examples/docs/src/app/blog/page.jsx
@@ -1,5 +1,3 @@
-export const metadata = {}
-
 export default function BlogPage() {
   return (
     <h1

--- a/examples/docs/src/app/layout.jsx
+++ b/examples/docs/src/app/layout.jsx
@@ -37,6 +37,7 @@ export default async function RootLayout({ children }) {
       chatLink="https://discord.gg/hEM84NMkRv"
     />
   )
+  const pageMap = await getPageMap()
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
       <Head faviconGlyph="✦" />
@@ -48,7 +49,7 @@ export default async function RootLayout({ children }) {
           editLink="Edit this page on GitHub"
           docsRepositoryBase="https://github.com/shuding/nextra/blob/main/examples/docs"
           sidebar={{ defaultMenuCollapseLevel: 1 }}
-          pageMap={await getPageMap()}
+          pageMap={pageMap}
         >
           {children}
         </Layout>

--- a/examples/docs/src/app/page.jsx
+++ b/examples/docs/src/app/page.jsx
@@ -1,5 +1,3 @@
-export const metadata = {}
-
 export default function IndexPage() {
   return (
     <h1

--- a/examples/docs/src/app/showcase/(overview)/page.jsx
+++ b/examples/docs/src/app/showcase/(overview)/page.jsx
@@ -1,9 +1,3 @@
-/**
- * @see https://github.com/shuding/nextra/issues/4148
- */
-
-export const metadata = {}
-
 export default function Page() {
   return (
     <h1

--- a/examples/docs/src/content/themes/docs/bleed.mdx
+++ b/examples/docs/src/content/themes/docs/bleed.mdx
@@ -1,6 +1,6 @@
-export const metadata = {
-  sidebarTitle: 'Bleed'
-}
+---
+sidebarTitle: Bleed
+---
 
 # Bleed Component
 

--- a/examples/docs/src/content/themes/docs/callout.mdx
+++ b/examples/docs/src/content/themes/docs/callout.mdx
@@ -1,6 +1,6 @@
-export const metadata = {
-  sidebarTitle: 'Callout'
-}
+---
+sidebarTitle: Callout
+---
 
 # Callout Component
 

--- a/examples/docs/src/content/themes/docs/tabs.mdx
+++ b/examples/docs/src/content/themes/docs/tabs.mdx
@@ -1,6 +1,6 @@
-export const metadata = {
-  sidebarTitle: 'Tabs'
-}
+---
+sidebarTitle: Tabs
+---
 
 # Tabs Component
 

--- a/packages/nextra/src/server/__tests__/to-js.test.ts
+++ b/packages/nextra/src/server/__tests__/to-js.test.ts
@@ -120,7 +120,7 @@ describe('convertPageMapToJs()', () => {
       }, {
         name: "blog",
         route: "/blog",
-        frontMatter: src_app_blog_page.metadata ?? src_app_blog_page.generateMetadata?.()
+        frontMatter: src_app_blog_page.metadata ?? src_app_blog_page.generateMetadata?.({})
       }, {
         name: "index",
         route: "/",
@@ -128,7 +128,7 @@ describe('convertPageMapToJs()', () => {
       }, {
         name: "showcase",
         route: "/showcase",
-        frontMatter: src_app_showcase_overview_page.metadata ?? src_app_showcase_overview_page.generateMetadata?.()
+        frontMatter: src_app_showcase_overview_page.metadata ?? src_app_showcase_overview_page.generateMetadata?.({})
       }, {
         name: "advanced",
         route: "/advanced",

--- a/packages/nextra/src/server/__tests__/to-js.test.ts
+++ b/packages/nextra/src/server/__tests__/to-js.test.ts
@@ -120,7 +120,7 @@ describe('convertPageMapToJs()', () => {
       }, {
         name: "blog",
         route: "/blog",
-        frontMatter: src_app_blog_page
+        frontMatter: src_app_blog_page.metadata ?? src_app_blog_page.generateMetadata()
       }, {
         name: "index",
         route: "/",
@@ -128,7 +128,7 @@ describe('convertPageMapToJs()', () => {
       }, {
         name: "showcase",
         route: "/showcase",
-        frontMatter: src_app_showcase_overview_page
+        frontMatter: src_app_showcase_overview_page.metadata ?? src_app_showcase_overview_page.generateMetadata()
       }, {
         name: "advanced",
         route: "/advanced",

--- a/packages/nextra/src/server/__tests__/to-js.test.ts
+++ b/packages/nextra/src/server/__tests__/to-js.test.ts
@@ -15,6 +15,161 @@ describe('convertPageMapToJs()', () => {
     const { pageMap, mdxPages } = convertToPageMap({ filePaths })
 
     const result = convertPageMapToJs({ pageMap, mdxPages })
-    expect(result).toMatchInlineSnapshot()
+    expect(result).toMatchInlineSnapshot(`
+      "import { normalizePageMap } from 'nextra/page-map'
+
+      import meta from "private-next-root-dir/src/content/_meta.js";
+      import features_meta from "private-next-root-dir/src/content/features/_meta.js";
+      import {metadata as features_i18n} from "private-next-root-dir/src/content/features/i18n.mdx?metadata";
+      import {metadata as features_image} from "private-next-root-dir/src/content/features/image.mdx?metadata";
+      import {metadata as features_latex} from "private-next-root-dir/src/content/features/latex.mdx?metadata";
+      import {metadata as features_mdx} from "private-next-root-dir/src/content/features/mdx.mdx?metadata";
+      import {metadata as features_ssg} from "private-next-root-dir/src/content/features/ssg.mdx?metadata";
+      import {metadata as features_themes} from "private-next-root-dir/src/content/features/themes.mdx?metadata";
+      import themes_meta from "private-next-root-dir/src/content/themes/_meta.js";
+      import themes_blog_meta from "private-next-root-dir/src/content/themes/blog/_meta.js";
+      import {metadata as themes_blog_index} from "private-next-root-dir/src/content/themes/blog/index.mdx?metadata";
+      import themes_docs_meta from "private-next-root-dir/src/content/themes/docs/_meta.js";
+      import {metadata as themes_docs_bleed} from "private-next-root-dir/src/content/themes/docs/bleed.mdx?metadata";
+      import {metadata as themes_docs_callout} from "private-next-root-dir/src/content/themes/docs/callout.mdx?metadata";
+      import {metadata as themes_docs_configuration} from "private-next-root-dir/src/content/themes/docs/configuration.mdx?metadata";
+      import {metadata as themes_docs_index} from "private-next-root-dir/src/content/themes/docs/index.mdx?metadata";
+      import {metadata as themes_docs_tabs} from "private-next-root-dir/src/content/themes/docs/tabs.mdx?metadata";
+      import {metadata as src_app_blog_page} from "private-next-root-dir/src/app/blog/page.jsx";
+      import {metadata as index} from "private-next-root-dir/src/content/index.mdx?metadata";
+      import {metadata as src_app_showcase_overview_page} from "private-next-root-dir/src/app/showcase/(overview)/page.jsx";
+      import {metadata as advanced_code_highlighting} from "private-next-root-dir/src/content/advanced/code-highlighting.mdx?metadata";
+      import {metadata as get_started} from "private-next-root-dir/src/content/get-started.mdx?metadata";
+      import {metadata as mermaid} from "private-next-root-dir/src/content/mermaid.mdx?metadata";
+      import {metadata as page} from "private-next-root-dir/src/content/page.mdx?metadata";
+
+      export const pageMap = normalizePageMap([{
+        data: meta
+      }, {
+        name: "features",
+        route: "/features",
+        children: [{
+          data: features_meta
+        }, {
+          name: "i18n",
+          route: "/features/i18n",
+          frontMatter: features_i18n
+        }, {
+          name: "image",
+          route: "/features/image",
+          frontMatter: features_image
+        }, {
+          name: "latex",
+          route: "/features/latex",
+          frontMatter: features_latex
+        }, {
+          name: "mdx",
+          route: "/features/mdx",
+          frontMatter: features_mdx
+        }, {
+          name: "ssg",
+          route: "/features/ssg",
+          frontMatter: features_ssg
+        }, {
+          name: "themes",
+          route: "/features/themes",
+          frontMatter: features_themes
+        }]
+      }, {
+        name: "themes",
+        route: "/themes",
+        children: [{
+          data: themes_meta
+        }, {
+          name: "blog",
+          route: "/themes/blog",
+          children: [{
+            data: themes_blog_meta
+          }, {
+            name: "index",
+            route: "/themes/blog",
+            frontMatter: themes_blog_index
+          }]
+        }, {
+          name: "docs",
+          route: "/themes/docs",
+          children: [{
+            data: themes_docs_meta
+          }, {
+            name: "bleed",
+            route: "/themes/docs/bleed",
+            frontMatter: themes_docs_bleed
+          }, {
+            name: "callout",
+            route: "/themes/docs/callout",
+            frontMatter: themes_docs_callout
+          }, {
+            name: "configuration",
+            route: "/themes/docs/configuration",
+            frontMatter: themes_docs_configuration
+          }, {
+            name: "index",
+            route: "/themes/docs",
+            frontMatter: themes_docs_index
+          }, {
+            name: "tabs",
+            route: "/themes/docs/tabs",
+            frontMatter: themes_docs_tabs
+          }]
+        }]
+      }, {
+        name: "blog",
+        route: "/blog",
+        frontMatter: src_app_blog_page
+      }, {
+        name: "index",
+        route: "/",
+        frontMatter: index
+      }, {
+        name: "showcase",
+        route: "/showcase",
+        frontMatter: src_app_showcase_overview_page
+      }, {
+        name: "advanced",
+        route: "/advanced",
+        children: [{
+          name: "code-highlighting",
+          route: "/advanced/code-highlighting",
+          frontMatter: advanced_code_highlighting
+        }]
+      }, {
+        name: "get-started",
+        route: "/get-started",
+        frontMatter: get_started
+      }, {
+        name: "mermaid",
+        route: "/mermaid",
+        frontMatter: mermaid
+      }, {
+        name: "page",
+        route: "/page",
+        frontMatter: page
+      }])
+
+      export const RouteToFilepath = {
+        "": "index.mdx",
+        "advanced/code-highlighting": "advanced/code-highlighting.mdx",
+        "features/i18n": "features/i18n.mdx",
+        "features/image": "features/image.mdx",
+        "features/latex": "features/latex.mdx",
+        "features/mdx": "features/mdx.mdx",
+        "features/ssg": "features/ssg.mdx",
+        "features/themes": "features/themes.mdx",
+        "get-started": "get-started.mdx",
+        "mermaid": "mermaid.mdx",
+        "page": "page.mdx",
+        "themes/blog": "themes/blog/index.mdx",
+        "themes/docs/bleed": "themes/docs/bleed.mdx",
+        "themes/docs/callout": "themes/docs/callout.mdx",
+        "themes/docs/configuration": "themes/docs/configuration.mdx",
+        "themes/docs": "themes/docs/index.mdx",
+        "themes/docs/tabs": "themes/docs/tabs.mdx"
+      }"
+    `)
   })
 })

--- a/packages/nextra/src/server/__tests__/to-js.test.ts
+++ b/packages/nextra/src/server/__tests__/to-js.test.ts
@@ -1,0 +1,20 @@
+import path from 'node:path'
+import { CWD } from '../constants.js'
+import { findMetaAndPageFilePaths } from '../page-map/find-meta-and-page-file-paths.js'
+import { convertToPageMap } from '../page-map/to-page-map.js'
+import { convertPageMapToJs } from '../page-map/to-js.js'
+
+describe('convertPageMapToJs()', () => {
+  it('should work for docs example', async () => {
+    const cwd = path.join(CWD, '..', '..', 'examples', 'docs')
+    const filePaths = await findMetaAndPageFilePaths({
+      dir: path.join(cwd, 'src/app'),
+      cwd,
+      contentDir: 'src/content'
+    })
+    const { pageMap, mdxPages } = convertToPageMap({ filePaths })
+
+    const result = convertPageMapToJs({ pageMap, mdxPages })
+    expect(result).toMatchInlineSnapshot()
+  })
+})

--- a/packages/nextra/src/server/__tests__/to-js.test.ts
+++ b/packages/nextra/src/server/__tests__/to-js.test.ts
@@ -1,8 +1,8 @@
 import path from 'node:path'
 import { CWD } from '../constants.js'
 import { findMetaAndPageFilePaths } from '../page-map/find-meta-and-page-file-paths.js'
-import { convertToPageMap } from '../page-map/to-page-map.js'
 import { convertPageMapToJs } from '../page-map/to-js.js'
+import { convertToPageMap } from '../page-map/to-page-map.js'
 
 describe('convertPageMapToJs()', () => {
   it('should work for docs example', async () => {
@@ -35,9 +35,9 @@ describe('convertPageMapToJs()', () => {
       import {metadata as themes_docs_configuration} from "private-next-root-dir/src/content/themes/docs/configuration.mdx?metadata";
       import {metadata as themes_docs_index} from "private-next-root-dir/src/content/themes/docs/index.mdx?metadata";
       import {metadata as themes_docs_tabs} from "private-next-root-dir/src/content/themes/docs/tabs.mdx?metadata";
-      import {metadata as src_app_blog_page} from "private-next-root-dir/src/app/blog/page.jsx";
+      import * as src_app_blog_page from "private-next-root-dir/src/app/blog/page.jsx";
       import {metadata as index} from "private-next-root-dir/src/content/index.mdx?metadata";
-      import {metadata as src_app_showcase_overview_page} from "private-next-root-dir/src/app/showcase/(overview)/page.jsx";
+      import * as src_app_showcase_overview_page from "private-next-root-dir/src/app/showcase/(overview)/page.jsx";
       import {metadata as advanced_code_highlighting} from "private-next-root-dir/src/content/advanced/code-highlighting.mdx?metadata";
       import {metadata as get_started} from "private-next-root-dir/src/content/get-started.mdx?metadata";
       import {metadata as mermaid} from "private-next-root-dir/src/content/mermaid.mdx?metadata";

--- a/packages/nextra/src/server/__tests__/to-js.test.ts
+++ b/packages/nextra/src/server/__tests__/to-js.test.ts
@@ -120,7 +120,7 @@ describe('convertPageMapToJs()', () => {
       }, {
         name: "blog",
         route: "/blog",
-        frontMatter: src_app_blog_page.metadata ?? src_app_blog_page.generateMetadata()
+        frontMatter: src_app_blog_page.metadata ?? src_app_blog_page.generateMetadata?.()
       }, {
         name: "index",
         route: "/",
@@ -128,7 +128,7 @@ describe('convertPageMapToJs()', () => {
       }, {
         name: "showcase",
         route: "/showcase",
-        frontMatter: src_app_showcase_overview_page.metadata ?? src_app_showcase_overview_page.generateMetadata()
+        frontMatter: src_app_showcase_overview_page.metadata ?? src_app_showcase_overview_page.generateMetadata?.()
       }, {
         name: "advanced",
         route: "/advanced",

--- a/packages/nextra/src/server/page-map/get.ts
+++ b/packages/nextra/src/server/page-map/get.ts
@@ -1,7 +1,7 @@
 import type { Folder, PageMapItem } from '../../types.js'
 
 function importPageMap(lang = ''): Promise<{
-  pageMap: PageMapItem[]
+  pageMap: Promise<PageMapItem[]>
   RouteToFilepath: Record<string, string>
 }> {
   return import(`./placeholder.js?lang=${lang}`)
@@ -13,7 +13,7 @@ export async function getPageMap(route = '/') {
   const segments = route.split('/')
   // Remove 1 or 2 items from the beginning of the array
   const lang = segments.splice(0, defaultLocale ? 2 : 1).at(-1)!
-  let { pageMap } = await importPageMap(lang)
+  let pageMap = await importPageMap(lang).then(result => result.pageMap)
 
   let segment: string | undefined
   while ((segment = segments.shift())) {

--- a/packages/nextra/src/server/page-map/to-ast.ts
+++ b/packages/nextra/src/server/page-map/to-ast.ts
@@ -61,19 +61,14 @@ export function convertPageMapToAst(
                 type: 'CallExpression',
                 callee: {
                   type: 'MemberExpression',
-                  object: {
-                    type: 'Identifier',
-                    name: importName
-                  },
+                  object: { type: 'Identifier', name: importName },
                   optional: false,
                   computed: false,
-                  property: {
-                    type: 'Identifier',
-                    name: 'generateMetadata'
-                  }
+                  property: { type: 'Identifier', name: 'generateMetadata' }
                 },
                 optional: true,
-                arguments: []
+                // First argument is object of type `{ params, searchParams }`
+                arguments: [createAstObject({})]
               }
             }
       })

--- a/packages/nextra/src/server/page-map/to-ast.ts
+++ b/packages/nextra/src/server/page-map/to-ast.ts
@@ -72,7 +72,7 @@ export function convertPageMapToAst(
                     name: 'generateMetadata'
                   }
                 },
-                optional: false,
+                optional: true,
                 arguments: []
               }
             }

--- a/packages/nextra/src/server/page-map/to-ast.ts
+++ b/packages/nextra/src/server/page-map/to-ast.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import type { ArrayExpression } from 'estree'
 import type { Import, TItem } from '../../types.js'
+import { MARKDOWN_EXTENSION_RE } from '../constants.js'
 import { createAstObject } from '../utils.js'
 
 function cleanFilePath(filePath: string): string {
@@ -38,7 +39,43 @@ export function convertPageMapToAst(
       return createAstObject({
         name: item.name,
         route: item.route,
-        frontMatter: { type: 'Identifier', name: importName }
+        frontMatter: MARKDOWN_EXTENSION_RE.test(filePath)
+          ? { type: 'Identifier', name: importName }
+          : {
+              type: 'LogicalExpression',
+              left: {
+                type: 'MemberExpression',
+                object: {
+                  type: 'Identifier',
+                  name: importName
+                },
+                computed: false,
+                optional: false,
+                property: {
+                  type: 'Identifier',
+                  name: 'metadata'
+                }
+              },
+              operator: '??',
+              right: {
+                type: 'CallExpression',
+                callee: {
+                  type: 'MemberExpression',
+                  object: {
+                    type: 'Identifier',
+                    name: importName
+                  },
+                  optional: false,
+                  computed: false,
+                  property: {
+                    type: 'Identifier',
+                    name: 'generateMetadata'
+                  }
+                },
+                optional: false,
+                arguments: []
+              }
+            }
       })
     }
     const filePath = item.__metaPath

--- a/packages/nextra/src/server/page-map/to-ast.ts
+++ b/packages/nextra/src/server/page-map/to-ast.ts
@@ -45,16 +45,10 @@ export function convertPageMapToAst(
               type: 'LogicalExpression',
               left: {
                 type: 'MemberExpression',
-                object: {
-                  type: 'Identifier',
-                  name: importName
-                },
+                object: { type: 'Identifier', name: importName },
+                property: { type: 'Identifier', name: 'metadata' },
                 computed: false,
-                optional: false,
-                property: {
-                  type: 'Identifier',
-                  name: 'metadata'
-                }
+                optional: false
               },
               operator: '??',
               right: {
@@ -62,9 +56,9 @@ export function convertPageMapToAst(
                 callee: {
                   type: 'MemberExpression',
                   object: { type: 'Identifier', name: importName },
+                  property: { type: 'Identifier', name: 'generateMetadata' },
                   optional: false,
-                  computed: false,
-                  property: { type: 'Identifier', name: 'generateMetadata' }
+                  computed: false
                 },
                 optional: true,
                 // First argument is object of type `{ params, searchParams }`

--- a/packages/nextra/src/server/page-map/to-js.ts
+++ b/packages/nextra/src/server/page-map/to-js.ts
@@ -29,15 +29,20 @@ export function convertPageMapToJs({
           value: `private-next-root-dir/${filePath}${isMdx ? METADATA_ONLY_RQ : ''}`
         },
         specifiers: [
-          {
-            local: { type: 'Identifier', name: importName },
-            ...(isMeta
-              ? { type: 'ImportDefaultSpecifier' }
-              : {
-                  type: 'ImportSpecifier',
-                  imported: { type: 'Identifier', name: 'metadata' }
-                })
-          }
+          isMeta || isMdx
+            ? {
+                local: { type: 'Identifier', name: importName },
+                ...(isMeta
+                  ? { type: 'ImportDefaultSpecifier' }
+                  : {
+                      type: 'ImportSpecifier',
+                      imported: { type: 'Identifier', name: 'metadata' }
+                    })
+              }
+            : {
+                type: 'ImportNamespaceSpecifier',
+                local: { type: 'Identifier', name: importName }
+              }
         ]
       }
     }


### PR DESCRIPTION
closes https://github.com/shuding/nextra/issues/4147
closes https://github.com/shuding/nextra/discussions/3828
closes https://github.com/shuding/nextra/issues/4142