### PR TITLE
fix `Could not parse expression with acorn` for inline math code in `development` mode without turbopack enabled

### DIFF
--- a/.changeset/flat-rabbits-accept.md
+++ b/.changeset/flat-rabbits-accept.md
@@ -1,0 +1,6 @@
+---
+"nextra": patch
+---
+
+fix `Could not parse expression with acorn` for inline math code in `development` mode without turbopack enabled
+

--- a/packages/nextra/src/server/compile-metadata.ts
+++ b/packages/nextra/src/server/compile-metadata.ts
@@ -1,6 +1,7 @@
 import { createProcessor } from '@mdx-js/mdx'
 import type { Program } from 'estree'
 import remarkFrontmatter from 'remark-frontmatter'
+import remarkMath from 'remark-math'
 import type { Plugin, Transformer } from 'unified'
 import {
   remarkAssignFrontMatter,
@@ -28,7 +29,8 @@ export async function compileMetadata(
       remarkMdxFrontMatter,
       remarkMdxTitle,
       [remarkAssignFrontMatter, { lastCommitTime }],
-      remarkExportOnlyMetadata
+      remarkExportOnlyMetadata,
+      remarkMath // https://github.com/shuding/nextra/issues/4164
     ],
     recmaPlugins: [recmaExportOnlyMetadata]
   })


### PR DESCRIPTION
fix https://github.com/shuding/nextra/issues/4164