### PR TITLE
Add parameter to docs theme search component to specify a max character limit for search results

### DIFF
--- a/.changeset/red-deers-occur.md
+++ b/.changeset/red-deers-occur.md
@@ -1,0 +1,6 @@
+---
+'nextra-theme-docs': patch
+---
+
+Add parameter to docs theme search component to specify a max character limit
+for search results

--- a/packages/nextra-theme-docs/src/components/flexsearch.tsx
+++ b/packages/nextra-theme-docs/src/components/flexsearch.tsx
@@ -143,9 +143,11 @@ const loadIndexesImpl = async (
 }
 
 export function Flexsearch({
-  className
+  className,
+  maxResultLength
 }: {
-  className?: string
+  className?: string,
+  maxResultLength?: number
 }): ReactElement {
   const { locale = DEFAULT_LOCALE, basePath } = useRouter()
   const [loading, setLoading] = useState(false)
@@ -212,11 +214,11 @@ export function Flexsearch({
           children: (
             <>
               <div className="_text-base _font-semibold _leading-5">
-                <HighlightMatches match={search} value={title} />
+                <HighlightMatches match={search} value={title} maxResultLength={maxResultLength}/>
               </div>
               {content && (
                 <div className="excerpt _mt-1 _text-sm _leading-[1.35rem] _text-gray-600 dark:_text-gray-400 contrast-more:dark:_text-gray-50">
-                  <HighlightMatches match={search} value={content} />
+                  <HighlightMatches match={search} value={content} maxResultLength={maxResultLength}/>
                 </div>
               )}
             </>

--- a/packages/nextra-theme-docs/src/components/highlight-matches.tsx
+++ b/packages/nextra-theme-docs/src/components/highlight-matches.tsx
@@ -1,48 +1,85 @@
 import escapeStringRegexp from 'escape-string-regexp'
 import type { ReactElement, ReactNode } from 'react'
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 
 type MatchArgs = {
   value?: string
   match: string
+  maxResultLength?: number
+}
+
+const shortenUnmatchedText = (unmatchedText: string, maxLength: number, beginning: boolean, ending: boolean): string => {
+  if (unmatchedText.length > maxLength) {
+    if (beginning) {
+      return '...' + unmatchedText.slice(-maxLength)
+    } else if (ending) {
+      return unmatchedText.slice(0, maxLength) + '...'
+    } else {
+      return unmatchedText.slice(0, maxLength / 2) + '...' + unmatchedText.slice(-(maxLength / 2))
+    }
+  }
+  return ''
 }
 
 export const HighlightMatches = memo<MatchArgs>(function HighlightMatches({
   value,
-  match
+  match,
+  maxResultLength
 }: MatchArgs): ReactElement | null {
   if (!value) {
     return null
   }
-  const splitText = value.split('')
-  const escapedSearch = escapeStringRegexp(match.trim())
-  const regexp = new RegExp(escapedSearch.replaceAll(/\s+/g, '|'), 'ig')
-  let result
-  let index = 0
-  const content: (string | ReactNode)[] = []
 
-  while ((result = regexp.exec(value))) {
-    if (result.index === regexp.lastIndex) {
-      regexp.lastIndex++
-    } else {
-      const before = splitText.splice(0, result.index - index).join('')
-      const after = splitText
-        .splice(0, regexp.lastIndex - result.index)
-        .join('')
-      content.push(
-        before,
-        <span key={result.index} className="_text-primary-600">
-          {after}
-        </span>
-      )
-      index = regexp.lastIndex
+  const content = useMemo(() => {
+    const splitText = value.split('')
+    const escapedSearch = escapeStringRegexp(match.trim())
+    const regexp = new RegExp(escapedSearch.replaceAll(/\s+/g, '|'), 'ig')
+    let regexResult
+    let index = 0
+    const result: (string | ReactNode)[] = []
+  
+    while ((regexResult = regexp.exec(value))) {
+      if (regexResult.index === regexp.lastIndex) {
+        regexp.lastIndex++
+      } else {
+        const before = splitText.splice(0, regexResult.index - index).join('')
+        const after = splitText
+          .splice(0, regexp.lastIndex - regexResult.index)
+          .join('')
+        result.push(
+          before,
+          <span key={regexResult.index} className="_text-primary-600">
+            {after}
+          </span>
+        )
+        index = regexp.lastIndex
+      }
     }
-  }
+    result.push(splitText.join(''))
+    if (maxResultLength) {
+      const unmatchedText = result.flatMap(item => {
+        if (typeof item === 'string') {
+          return item
+        }
+        return undefined
+      }).filter(Boolean);
+      if (unmatchedText.join('').length > maxResultLength) {
+        return result.map((item, index) => {
+          if (typeof item === 'string') {
+            return shortenUnmatchedText(item, maxResultLength / unmatchedText.length, index === 0, index === result.length - 1)
+          } else {
+            return item
+          }
+        })
+      }
+    }
+    return result;
+
+  }, [value, match])
 
   return (
     <>
       {content}
-      {splitText.join('')}
     </>
   )
 })

--- a/packages/nextra-theme-docs/src/schemas.ts
+++ b/packages/nextra-theme-docs/src/schemas.ts
@@ -111,7 +111,7 @@ export const themeSchema = /* @__PURE__ */ (() =>
       link: z.string().startsWith('https://').optional()
     }),
     search: z.strictObject({
-      component: z.custom<ReactNode | FC<{ className?: string }>>(...reactNode),
+      component: z.custom<ReactNode | FC<{ className?: string, maxResultLength?: number }>>(...reactNode),
       emptyResult: z.custom<ReactNode | FC>(...reactNode),
       error: z.string().or(z.function().returns(z.string())),
       loading: z.custom<ReactNode | FC>(...reactNode),


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:
Some search results can be too long, we've seen this most for results that links to a table, it results in a bad experience for users when one of those search results takes up the whole space for the search results. This adds an optional property to the docs theme search component that will limit the length of the search results to the specified character limit. 

This is achieved by evaluating each search result, and only includes certain characters around matches to the search query. The amount of characters included before and after the matched substring is determined by the number of matches in the full result, and the total length specified

Closes: https://github.com/shuding/nextra/issues/4192

## What's being changed (if available, include any code snippets, screenshots, or gifs):

Example of a search result that is too long
![Screenshot 2025-02-10 at 4 54 39 PM](https://github.com/user-attachments/assets/b0322055-9373-4d4c-9807-4df0e5cd0459)

Same search result with changes applied, character limit set to 300
![Screenshot 2025-02-10 at 4 55 39 PM](https://github.com/user-attachments/assets/475cee98-09e5-4847-9704-a21ff72eb1f5)

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
