### PR TITLE
fix(remote-content): use correct repo link

### DIFF
--- a/docs/app/docs/advanced/remote/page.mdx
+++ b/docs/app/docs/advanced/remote/page.mdx
@@ -32,7 +32,7 @@ ${pageContent
 > [!NOTE]
 >
 > You can check out the
-> [SWR i18n example](https://github.com/shuding/nextra/blob/main/examples/swr-site/app/%5Blang%5D/remote/graphql-eslint/%5B%5B...slug%5D%5D/page.tsx)
+> [SWR i18n example](https://github.com/shuding/nextra/blob/main/examples/swr-site/app/%5Blang%5D/remote/graphql-yoga/%5B%5B...slug%5D%5D/page.tsx)
 > source code.
 
 <Steps>

--- a/docs/app/docs/advanced/remote/page.mdx
+++ b/docs/app/docs/advanced/remote/page.mdx
@@ -32,7 +32,7 @@ ${pageContent
 > [!NOTE]
 >
 > You can check out the
-> [SWR i18n example](https://github.com/shuding/nextra/blob/main/examples/swr-site/app/%5Blang%5D/remote/graphql-yoga/%5B%5B...slug%5D%5D/page.tsx)
+> [SWR i18n example](https://github.com/shuding/nextra/blob/main/examples/swr-site/app/%5Blang%5D/graphql-eslint/%5B%5B...slug%5D%5D/page.tsx)
 > source code.
 
 <Steps>


### PR DESCRIPTION
## Why:

The link to the remote content example changed.


## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
