### PR TITLE
Option for Preprocessors with Schemas and Types

### DIFF
--- a/packages/nextra/src/server/compile.ts
+++ b/packages/nextra/src/server/compile.ts
@@ -85,9 +85,17 @@ export async function compileMdx(
     remarkPlugins,
     rehypePlugins,
     recmaPlugins,
+    preprocessors,
     rehypePrettyCodeOptions,
     providerImportSource = 'next-mdx-import-source-file'
   } = mdxOptions
+
+  for (const preprocessor of preprocessors ?? []) {
+    source = preprocessor({
+      filePath,
+      fileContent: source
+    });
+  }
 
   const format =
     _format === 'detect' ? (filePath.endsWith('.mdx') ? 'mdx' : 'md') : _format

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -18,6 +18,13 @@ export const mathJaxOptionsSchema = z.strictObject({
   config: z.custom<MathJax3Config>().optional()
 })
 
+export const markdownPreprocessorSchema = z.function()
+  .args(z.strictObject({
+    filePath: z.string(),
+    fileContent: z.string()
+  }))
+  .returns(z.string())
+
 export const nextraConfigSchema = z.strictObject({
   defaultShowCopyCode: z.boolean().optional(),
   search: z
@@ -52,6 +59,7 @@ export const nextraConfigSchema = z.strictObject({
       rehypePlugins: z.custom<ProcessorOptions['rehypePlugins']>(),
       remarkPlugins: z.custom<ProcessorOptions['remarkPlugins']>(),
       recmaPlugins: z.custom<ProcessorOptions['recmaPlugins']>(),
+      preprocessors: z.array(markdownPreprocessorSchema).optional(),
       format: z.enum(['detect', 'mdx', 'md']).optional(),
       rehypePrettyCodeOptions: z.custom<RehypePrettyCodeOptions>().default({})
     })

--- a/packages/nextra/src/types.ts
+++ b/packages/nextra/src/types.ts
@@ -7,7 +7,8 @@ import type {
   menuSchema,
   metaSchema,
   nextraConfigSchema,
-  separatorItemSchema
+  separatorItemSchema,
+  markdownPreprocessorSchema
 } from './server/schemas.js'
 
 export interface LoaderOptions extends z.infer<typeof nextraConfigSchema> {
@@ -93,6 +94,8 @@ export type ReadingTime = {
 export type NextraConfig = z.input<typeof nextraConfigSchema>
 
 export type MathJaxOptions = z.infer<typeof mathJaxOptionsSchema>
+
+export type MarkdownPreprocessor = z.infer<typeof markdownPreprocessorSchema>
 
 export type Nextra = (
   nextraConfig: NextraConfig


### PR DESCRIPTION
## Why:

Adds support for custom markdown preprocessors. This allows users to transform raw markdown content before it's processed by the MDX compiler, much like in Docusaurus. Personally, [I use this to convert Obsidian `[[Wiki-Links]]` to `[Markdown](Links)`](https://github.com/marcchehab/nextra/blob/main/sites/luz/lib/preprocess-wiki-links.ts).

(I used this approach in Nextra v3 already. Obsidian-compatability makes for a lovely writing experience. Now with Nextra ^4 I'm trying to move all my adaptations out of the nextra package so I can update it more easily in the future.)

## What's being changed (if available, include any code snippets, screenshots, or gifs):

- Added preprocessors option to mdxOptions in Nextra configuration schema in `compile.ts`
- Defined Zod schemas in `schemas.ts` and Types in `types.ts`

(Zod is new to me so I'm not sure that makes sense the way I do it.)

I'm interested to hear what you think :) Best, Marc

## Check off the following:

- [X] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
