### PR TITLE
Update page.mdx

### DIFF
--- a/docs/app/docs/guide/ssg/page.mdx
+++ b/docs/app/docs/guide/ssg/page.mdx
@@ -42,7 +42,7 @@ export async function getUpdatedAt() {
   const mdx = `${starsComponent}
 
 The number above was generated at build time via MDX server components. With
-[Incremental Static Regeneration](https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration)
+[Incremental Static Regeneration](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration)
 enabled, it will be kept up to date.
 
 ---

--- a/docs/app/docs/guide/ssg/page.mdx
+++ b/docs/app/docs/guide/ssg/page.mdx
@@ -6,14 +6,18 @@ import { compileMdx } from 'nextra/compile'
 import { Callout } from 'nextra/components'
 import { MDXRemote } from 'nextra/mdx-remote'
 
-# Next.js SSG
+# Next.js Static Rendering
 
-With Next.js, you can pre-render your page using
-[Static Generation (SSG)](https://nextjs.org/docs/basic-features/pages#static-generation-recommended).
-Your pages will be generated at build time and statically served to visitors. It
-can also be cached by a CDN to maximize the performance.
+[Static Rendering](https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default)
+is default server rendering strategy, where routes are rendered at **build
+time** or in the background after
+[data revalidation](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration).
+The result is cached and can be distributed via a
+[Content Delivery Network (CDN)](https://developer.mozilla.org/docs/Glossary/CDN)
+for optimal performance.
 
-This is supported by Nextra too. Here's an example:
+Static rendering is ideal for routes with non-personalized data that can be
+determined at build time, such as blog posts or product pages.
 
 <SSGPage />
 

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -293,16 +293,16 @@ const IndexPage: FC = () => {
               <p className="mr-6">
                 You can leverage the hybrid rendering power from Next.js with
                 your Markdown content including{' '}
-                <Link href="https://nextjs.org/docs/app/getting-started/layouts-and-pages">
-                  SSG
+                <Link href="https://nextjs.org/docs/app/building-your-application/rendering/server-components">
+                  Server Components
                 </Link>
                 ,{' '}
-                <Link href="https://nextjs.org/docs/app/getting-started/layouts-and-pages">
-                  SSR
+                <Link href="https://nextjs.org/docs/app/building-your-application/rendering/client-components">
+                  Client Components
                 </Link>
                 , and{' '}
                 <Link href="https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration">
-                  ISR
+                  Incremental Static Regeneration (ISR)
                 </Link>
                 .
               </p>

--- a/examples/docs/src/content/features/ssg.mdx
+++ b/examples/docs/src/content/features/ssg.mdx
@@ -1,11 +1,15 @@
-# Next.js SSG
+# Next.js Static Rendering
 
-With Next.js, you can pre-render your page using
-[Static Generation (SSG)](https://nextjs.org/docs/basic-features/pages#static-generation-recommended).
-Your pages will be generated at build time and statically served to visitors. It
-can also be cached by a CDN to maximize the performance.
+[Static Rendering](https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default)
+is default server rendering strategy, where routes are rendered at **build
+time** or in the background after
+[data revalidation](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration).
+The result is cached and can be distributed via a
+[Content Delivery Network (CDN)](https://developer.mozilla.org/docs/Glossary/CDN)
+for optimal performance.
 
-This is supported by Nextra too. Here's an example:
+Static rendering is ideal for routes with non-personalized data that can be
+determined at build time, such as blog posts or product pages.
 
 export async function Stars() {
   let stars = 0
@@ -22,7 +26,7 @@ export async function Stars() {
 > Nextra has <Stars /> stars on GitHub!
 
 The number above was generated at build time via MDX server components. With
-[Incremental Static Regeneration](https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration)
+[Incremental Static Regeneration](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration)
 enabled, it will be kept up to date.
 
 ---


### PR DESCRIPTION
Updated url for ISR documentation on NextJS Documentation as the previous link was outdated and error404

## Why:
Outdated/Invalid link to nextjs documentation for ISR

Closes:
Nothing

## What's being changed (if available, include any code snippets, screenshots, or gifs):
Changed the URL given for ISR documentation to match the one found via nextJS docs. 

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
