### PR TITLE
Fixes issue 4351: Don't overwrite mdxOptions in loader.ts

### DIFF
--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -129,10 +129,10 @@ export async function loader(
   }
   return compileMdx(source, {
     mdxOptions: {
-      ...mdxOptions,
       jsx: true,
       outputFormat: 'program',
       format: 'detect',
+      ...mdxOptions,
       rehypePrettyCodeOptions: {
         ...mdxOptions.rehypePrettyCodeOptions,
         transformers: [


### PR DESCRIPTION
## Why: loader.ts overwrites some mdxOptions with presents. By moving the spread three lines down, we give users the control to overwrite these hardcoded values.

Closes: [Issue 4351](https://github.com/shuding/nextra/issues/4351)

## What's being changed (if available, include any code snippets, screenshots, or gifs):

This lets users overwrite all of the following hardcoded options, which are currently impossible to overwrite.
 ```
mdxOptions: {
      jsx: true,
      outputFormat: 'program',
      format: 'detect'
}
```

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
