### PR TITLE
Refactor footer prop types to be optional and to use ReactNode and enhance reactNode validation

### DIFF
--- a/packages/nextra-theme-docs/src/layout.tsx
+++ b/packages/nextra-theme-docs/src/layout.tsx
@@ -1,7 +1,7 @@
 /* eslint sort-keys: error */
 import { ThemeProvider } from 'next-themes'
 import { Search, SkipNavLink } from 'nextra/components'
-import { element, stringOrElement } from 'nextra/schemas'
+import { element, reactNode, stringOrElement } from 'nextra/schemas'
 import type { FC, ReactNode } from 'react'
 import { Fragment } from 'react'
 import { z } from 'zod'
@@ -30,7 +30,7 @@ const theme = z.strictObject({
       labels: z.string().default('feedback')
     })
     .default({}),
-  footer: element,
+  footer: reactNode.optional(),
   i18n: z
     .array(
       z.strictObject({

--- a/packages/nextra-theme-docs/src/stores/config.tsx
+++ b/packages/nextra-theme-docs/src/stores/config.tsx
@@ -26,7 +26,7 @@ export const ConfigProvider: FC<{
   children: ReactNode
   pageMap: PageMapItem[]
   navbar: ReactElement
-  footer: ReactElement
+  footer: ReactNode
 }> = ({ children, pageMap, navbar, footer }) => {
   const pathname = useFSRoute()
 

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -72,12 +72,34 @@ export const element = z.custom<ReactElement<Record<string, unknown>>>(
   isValidElement,
   { message: 'Must be React.ReactElement' }
 )
+
+/**
+ * https://react.dev/reference/react/isValidElement#react-elements-vs-react-nodes
+ */
 export const reactNode = z.custom<ReactNode>(
-  data =>
-    isValidElement(data) ||
-    (Array.isArray(data) && data.every(value => isValidElement(value))),
-  { message: 'Must be React.ReactNode' }
-)
+  (data): data is ReactNode => {
+    // Check if it's a valid React element
+    if (isValidElement(data)) return true;
+    
+    // Check if it's null or undefined
+    if (data === null || data === undefined) return true;
+    
+    // Check if it's a string or number
+    if (typeof data === 'string' || typeof data === 'number') return true;
+    
+    // Check if it's a boolean
+    if (typeof data === 'boolean') return true;
+    
+    // Check if it's an array of React nodes
+    if (Array.isArray(data)) {
+      return data.every(item => reactNode.safeParse(item).success);
+    }
+    
+    // If it's none of the above, it's not a valid React node
+    return false;
+  },
+  { message: 'Must be a valid React node' }
+);
 
 export const stringOrElement = z.union([z.string(), element])
 

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -79,27 +79,27 @@ export const element = z.custom<ReactElement<Record<string, unknown>>>(
 export const reactNode = z.custom<ReactNode>(
   (data): data is ReactNode => {
     // Check if it's a valid React element
-    if (isValidElement(data)) return true;
-    
+    if (isValidElement(data)) return true
+
     // Check if it's null or undefined
-    if (data === null || data === undefined) return true;
-    
+    if (data === null || data === undefined) return true
+
     // Check if it's a string or number
-    if (typeof data === 'string' || typeof data === 'number') return true;
-    
+    if (typeof data === 'string' || typeof data === 'number') return true
+
     // Check if it's a boolean
-    if (typeof data === 'boolean') return true;
-    
+    if (typeof data === 'boolean') return true
+
     // Check if it's an array of React nodes
     if (Array.isArray(data)) {
-      return data.every(item => reactNode.safeParse(item).success);
+      return data.every(item => reactNode.safeParse(item).success)
     }
-    
+
     // If it's none of the above, it's not a valid React node
-    return false;
+    return false
   },
   { message: 'Must be a valid React node' }
-);
+)
 
 export const stringOrElement = z.union([z.string(), element])
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

this is a continuation of https://github.com/shuding/nextra/pull/4067 that allows to skip setting a footer entirely instead of having to provide `<></>` as a value to stop the footer from rendering and allows you to use react nodes which are more flexible

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
