### PR TITLE
fix `TypeError: page.generateMetadata is not a function` when using with `withSentryConfig` plugin

### DIFF
--- a/.changeset/tender-forks-type.md
+++ b/.changeset/tender-forks-type.md
@@ -1,0 +1,7 @@
+---
+'nextra': patch
+'nextra-theme-blog': patch
+'nextra-theme-docs': patch
+---
+
+fix `TypeError: page.generateMetadata is not a function` when using with `withSentryConfig` plugin

--- a/packages/nextra/src/client/components/search.tsx
+++ b/packages/nextra/src/client/components/search.tsx
@@ -298,7 +298,7 @@ export const Search: FC<SearchProps> = ({
       >
         {error ? (
           <>
-            <InformationCircleIcon height="20" className="x:shrink-0" />
+            <InformationCircleIcon height="1.25em" className="x:shrink-0" />
             <div className="x:grid">
               <b className="x:mb-2">{errorText}</b>
               {error}

--- a/packages/nextra/src/server/page-map/index.ts
+++ b/packages/nextra/src/server/page-map/index.ts
@@ -9,7 +9,17 @@ export { createIndexPage, getIndexPageMap } from './index-page.js'
 export function getMetadata(
   page:
     | { metadata: Metadata }
-    | { generateMetadata: (props: object) => Promise<Metadata> }
+    | { generateMetadata?: (props: object) => Promise<Metadata> }
 ): Promise<Metadata> | Metadata {
-  return 'generateMetadata' in page ? page.generateMetadata({}) : page.metadata
+  if (
+    'generateMetadata' in page &&
+    // `@sentry/nextjs` makes `generateMetadata` getter function which can be `undefined`
+    page.generateMetadata
+  ) {
+    return page.generateMetadata({})
+  }
+  if ('metadata' in page) {
+    return page.metadata
+  }
+  return {}
 }


### PR DESCRIPTION
fixes https://github.com/shuding/nextra/issues/4367