### PR TITLE
Add theme switch option to navbar props

### DIFF
--- a/packages/nextra-theme-docs/src/components/navbar/index.tsx
+++ b/packages/nextra-theme-docs/src/components/navbar/index.tsx
@@ -7,6 +7,7 @@ import { element, reactNode } from 'nextra/schemas'
 import type { FC } from 'react'
 import { z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
+import { ThemeSwitch } from '../theme-switch'
 import { ClientNavbar } from './index.client'
 
 export const NavbarPropsSchema = z.strictObject({
@@ -31,6 +32,10 @@ export const NavbarPropsSchema = z.strictObject({
     .describe(`Icon of the chat link.
 @remarks \`ReactNode\`
 @default <DiscordIcon />`),
+  themeSwitch: z
+    .boolean()
+    .default(true)
+    .describe('Show or hide the theme select button.'),
   className: z.string().optional().describe('CSS class name.'),
   align: z
     .enum(['left', 'right'])
@@ -54,7 +59,8 @@ export const Navbar: FC<NavbarProps> = props => {
     chatLink,
     chatIcon,
     className,
-    align
+    align,
+    themeSwitch
   } = data
 
   const logoClass = cn(
@@ -100,6 +106,7 @@ export const Navbar: FC<NavbarProps> = props => {
           <div className={logoClass}>{logo}</div>
         )}
         <ClientNavbar className={align === 'left' ? 'x:me-auto' : ''}>
+          {themeSwitch && <ThemeSwitch lite />}
           {projectLink && <Anchor href={projectLink}>{projectIcon}</Anchor>}
           {chatLink && <Anchor href={chatLink}>{chatIcon}</Anchor>}
           {children}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Introduce a theme switch option in the navbar props to allow users to show or hide the theme select button.

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
