### PR TITLE
Fix: Received `false` for a non-boolean attribute `prefetch`. Allow override `next-mdx-import-source-file` in `turbopack.resolveAlias` option

### DIFF
--- a/.changeset/open-trains-wait.md
+++ b/.changeset/open-trains-wait.md
@@ -1,0 +1,7 @@
+---
+'nextra-theme-docs': patch
+'nextra': patch
+---
+
+- Fix: Received `false` for a non-boolean attribute `prefetch`.
+- Allow override `next-mdx-import-source-file` in `turbopack.resolveAlias` option

--- a/docs/app/docs/file-conventions/mdx-components-file/page.mdx
+++ b/docs/app/docs/file-conventions/mdx-components-file/page.mdx
@@ -12,9 +12,7 @@ description:
 The `mdx-components` file is **required**, you use it to customize styles via
 `useMDXComponents` function.
 
-## Exports
-
-### `useMDXComponents` function
+## `useMDXComponents` function
 
 The file must export a single function named `useMDXComponents`.
 
@@ -33,20 +31,43 @@ export function useMDXComponents(components) {
 }
 ```
 
-## Params
+## `useMDXComponents` signature
 
-### `components`
+<APIDocs code="export { useMDXComponents as default } from 'nextra/mdx-components'" />
 
-When defining MDX Components, the export function accepts a single parameter
-`components: MDXComponents`.
+## Errors
 
-- The key is the name of the HTML element to override.
-- The value is the component to render instead.
+### Module not found: Can't resolve `'next-mdx-import-source-file'`
+
+To fix this, update the `turbopack.resolveAlias` section in your `next.config` file:
+
+```diff filename="next.config.mjs"
+import nextra from 'nextra'
+
+const withNextra = nextra()
+
+export default withNextra({
++ turbopack: {
++   resolveAlias: {
++     // Path to your `mdx-components` file with extension
++     'next-mdx-import-source-file': './src/mdx-components.tsx'
++   }
++ }
+})
+```
 
 > [!TIP]
 >
-> You can keep `mdx-components` file in root of your project, or in
+> - You can keep `mdx-components` file in root of your project, or in
 > [`src` directory](./src-directory).
 >
-> The `.js`, `.jsx`, or `.tsx` file extensions can be used for `mdx-components`
+> - The `.js`, `.jsx`, or `.tsx` file extensions can be used for `mdx-components`
 > file.
+>
+>
+> - While importing `useMDXComponents`, alias it as `getMDXComponents` to avoid false positive error
+> from ESLint React Hooks plugin.
+> ``` filename="react-hooks/rules-of-hooks"
+> React Hook "useMDXComponents" cannot be called at the top level.
+> React Hooks must be called in a React function component or a custom React Hook function.
+> ```

--- a/docs/app/docs/file-conventions/mdx-components-file/page.mdx
+++ b/docs/app/docs/file-conventions/mdx-components-file/page.mdx
@@ -14,7 +14,8 @@ The `mdx-components` file is **required**, you use it to customize styles via
 
 ## Example
 
-The `mdx-components.js` file must export a single function named `useMDXComponents`.
+The `mdx-components.js` file must export a single function named
+`useMDXComponents`.
 
 ```ts filename="mdx-components.js"
 import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs' // nextra-theme-blog or your custom theme

--- a/docs/app/docs/file-conventions/mdx-components-file/page.mdx
+++ b/docs/app/docs/file-conventions/mdx-components-file/page.mdx
@@ -39,7 +39,8 @@ export function useMDXComponents(components) {
 
 ### Module not found: Can't resolve `'next-mdx-import-source-file'`
 
-To fix this, update the `turbopack.resolveAlias` section in your `next.config` file:
+To fix this, update the `turbopack.resolveAlias` section in your `next.config`
+file:
 
 ```diff filename="next.config.mjs"
 import nextra from 'nextra'
@@ -59,15 +60,13 @@ export default withNextra({
 > [!TIP]
 >
 > - You can keep `mdx-components` file in root of your project, or in
-> [`src` directory](./src-directory).
+>   [`src` directory](./src-directory).
+> - The `.js`, `.jsx`, or `.tsx` file extensions can be used for
+>   `mdx-components` file.
+> - When importing `useMDXComponents`, alias it as `getMDXComponents` to avoid a
+>   false positive error from the ESLint React Hooks plugin.
 >
-> - The `.js`, `.jsx`, or `.tsx` file extensions can be used for `mdx-components`
-> file.
->
->
-> - While importing `useMDXComponents`, alias it as `getMDXComponents` to avoid false positive error
-> from ESLint React Hooks plugin.
-> ``` filename="react-hooks/rules-of-hooks"
+> ```bash filename="react-hooks/rules-of-hooks"
 > React Hook "useMDXComponents" cannot be called at the top level.
 > React Hooks must be called in a React function component or a custom React Hook function.
 > ```

--- a/docs/app/docs/file-conventions/mdx-components-file/page.mdx
+++ b/docs/app/docs/file-conventions/mdx-components-file/page.mdx
@@ -12,9 +12,9 @@ description:
 The `mdx-components` file is **required**, you use it to customize styles via
 `useMDXComponents` function.
 
-## `useMDXComponents` function
+## Example
 
-The file must export a single function named `useMDXComponents`.
+The `mdx-components.js` file must export a single function named `useMDXComponents`.
 
 ```ts filename="mdx-components.js"
 import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs' // nextra-theme-blog or your custom theme
@@ -33,7 +33,7 @@ export function useMDXComponents(components) {
 
 ## `useMDXComponents` signature
 
-<APIDocs code="export { useMDXComponents as default } from 'nextra/mdx-components'" />
+<APIDocs code="export { useMDXComponents as default } from 'nextra/mdx-components' " />
 
 ## Errors
 

--- a/docs/app/docs/file-conventions/mdx-components-file/page.mdx
+++ b/docs/app/docs/file-conventions/mdx-components-file/page.mdx
@@ -34,7 +34,7 @@ export function useMDXComponents(components) {
 
 ## `useMDXComponents` signature
 
-<APIDocs code="export { useMDXComponents as default } from 'nextra/mdx-components' " />
+<APIDocs code="export { useMDXComponents as default } from 'nextra/mdx-components'" />
 
 ## Errors
 

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -59,7 +59,9 @@ export default $`
           LastUpdated:
             'https://github.com/shuding/nextra/blob/main/packages/nextra-theme-docs/src/components/last-updated.tsx',
           MDXRemote:
-            'https://github.com/shuding/nextra/blob/main/packages/nextra/src/client/mdx-remote.tsx'
+            'https://github.com/shuding/nextra/blob/main/packages/nextra/src/client/mdx-remote.tsx',
+          MDXComponents:
+            'https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4c3811099cbe9ee60151c11a679b780d0ba785bf/types/mdx/types.d.ts#L65'
         }}
       />
     )

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -109,6 +109,7 @@ const config: Config = tseslint.config(
       'sonarjs/no-array-index-key': 'off', // todo
       'sonarjs/no-unstable-nested-components': 'off', // todo
 
+      'sonarjs/no-redundant-optional': 'off', // doesn't work well with tsconfig's `exactOptionalPropertyTypes: true`
       'sonarjs/no-duplicate-in-composite': 'off', // covered by @typescript-eslint/no-duplicate-type-constituents
       'sonarjs/deprecation': 'off', // covered by @typescript-eslint/no-deprecated
       'sonarjs/no-unused-vars': 'off',

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -227,14 +227,13 @@ const File: FC<{
   if (item.type === 'separator') {
     return <Separator title={item.title} />
   }
-
+  const href = (item as PageItem).href || item.route
   return (
     <li className={cn({ active })}>
       <Anchor
-        href={(item as PageItem).href || item.route}
+        href={href}
         className={cn(classes.link, active ? classes.active : classes.inactive)}
         onFocus={onFocus}
-        // @ts-expect-error -- ignore
         prefetch={false}
       >
         {item.title}

--- a/packages/nextra/src/client/mdx-components.ts
+++ b/packages/nextra/src/client/mdx-components.ts
@@ -33,7 +33,7 @@ export type MDXComponents = NestedMDXComponents & {
 
 /**
  * Get current MDX components.
- * @returns The current set of MDX components
+ * @returns The current set of MDX components.
  */
 export const useMDXComponents = <T extends Readonly<MDXComponents>>(
   /**

--- a/packages/nextra/src/client/mdx-components.ts
+++ b/packages/nextra/src/client/mdx-components.ts
@@ -3,17 +3,32 @@ import type { MDXWrapper } from '../types.js'
 import { ImageZoom } from './components/image-zoom.js'
 import { Anchor } from './mdx-components/anchor.js'
 
-interface NestedMDXComponents {
-  [key: string]: NestedMDXComponents | FC<any> | keyof JSX.IntrinsicElements
+/**
+ * A valid JSX string component.
+ */
+type StringComponent = keyof JSX.IntrinsicElements
+
+/**
+ * Any allowed JSX component.
+ */
+type Component<Props> = FC<Props> | StringComponent
+
+export interface NestedMDXComponents {
+  [key: string]: NestedMDXComponents | Component<any>
 }
 
+/**
+ * MDX components may be passed as the `components`.
+ *
+ * The key is the name of the element to override. The value is the component to render instead.
+ */
 export type MDXComponents = NestedMDXComponents & {
-  [Key in Exclude<keyof JSX.IntrinsicElements, 'img'>]?:
-    | FC<ComponentPropsWithoutRef<Key>>
-    | keyof JSX.IntrinsicElements
+  [Key in StringComponent]?: FC<ComponentPropsWithoutRef<Key>>
 } & {
+  /**
+   * If a wrapper component is defined, the MDX content will be wrapped inside of it.
+   */
   wrapper?: MDXWrapper
-  img?: FC<ComponentPropsWithoutRef<typeof ImageZoom>>
 }
 
 /**

--- a/packages/nextra/src/client/mdx-components.ts
+++ b/packages/nextra/src/client/mdx-components.ts
@@ -16,9 +16,19 @@ export type MDXComponents = NestedMDXComponents & {
   img?: FC<ComponentPropsWithoutRef<typeof ImageZoom>>
 }
 
+/**
+ * Get current MDX components.
+ * @returns The current set of MDX components
+ */
 export const useMDXComponents = <T extends Readonly<MDXComponents>>(
+  /**
+   * An object where:
+   * - The key is the name of the HTML element to override.
+   * - The value is the component to render instead.
+   * @remarks `MDXComponents`
+   */
   components: T
-) => {
+): T => {
   return {
     img: ImageZoom,
     a: Anchor,

--- a/packages/nextra/src/client/mdx-components/anchor.tsx
+++ b/packages/nextra/src/client/mdx-components/anchor.tsx
@@ -7,7 +7,7 @@ import { LinkArrowIcon } from '../icons/index.js'
 type NextLinkProps = ComponentPropsWithoutRef<typeof Link>
 
 type Props = Omit<NextLinkProps, 'href'> & {
-  href?: NextLinkProps['href'] | undefined
+  href: NextLinkProps['href'] | undefined
 }
 
 export const Anchor: FC<Props> = ({ href = '', prefetch, ...props }) => {

--- a/packages/nextra/src/client/mdx-components/anchor.tsx
+++ b/packages/nextra/src/client/mdx-components/anchor.tsx
@@ -4,32 +4,39 @@ import type { ComponentPropsWithoutRef, FC } from 'react'
 import { EXTERNAL_URL_RE } from '../../server/constants.js'
 import { LinkArrowIcon } from '../icons/index.js'
 
-export const Anchor: FC<ComponentPropsWithoutRef<'a'>> = ({
-  href = '',
-  ...props
-}) => {
+type NextLinkProps = ComponentPropsWithoutRef<typeof Link>
+
+type Props = Omit<NextLinkProps, 'href'> & {
+  href?: NextLinkProps['href']
+}
+
+export const Anchor: FC<Props> = ({ href = '', prefetch, ...props }) => {
   props = {
     ...props,
     className: cn('x:focus-visible:nextra-focus', props.className)
   }
-  if (EXTERNAL_URL_RE.test(href)) {
-    const { children } = props
-    return (
-      <a href={href} target="_blank" rel="noreferrer" {...props}>
-        {children}
-        {typeof children === 'string' && (
-          <>
-            &thinsp;
-            <LinkArrowIcon
-              // based on font-size
-              height="1em"
-              className="x:inline x:align-baseline x:shrink-0"
-            />
-          </>
-        )}
-      </a>
-    )
+  if (typeof href === 'string') {
+    if (href.startsWith('#')) {
+      return <a href={href} {...props} />
+    }
+    if (EXTERNAL_URL_RE.test(href)) {
+      const { children } = props
+      return (
+        <a href={href} target="_blank" rel="noreferrer" {...props}>
+          {children}
+          {typeof children === 'string' && (
+            <>
+              &thinsp;
+              <LinkArrowIcon
+                // based on font-size
+                height="1em"
+                className="x:inline x:align-baseline x:shrink-0"
+              />
+            </>
+          )}
+        </a>
+      )
+    }
   }
-  const ComponentToUse = href.startsWith('#') ? 'a' : Link
-  return <ComponentToUse href={href} {...props} />
+  return <Link href={href} prefetch={prefetch} {...props} />
 }

--- a/packages/nextra/src/client/mdx-components/anchor.tsx
+++ b/packages/nextra/src/client/mdx-components/anchor.tsx
@@ -7,7 +7,7 @@ import { LinkArrowIcon } from '../icons/index.js'
 type NextLinkProps = ComponentPropsWithoutRef<typeof Link>
 
 type Props = Omit<NextLinkProps, 'href'> & {
-  href: NextLinkProps['href'] | undefined
+  href?: NextLinkProps['href'] | undefined
 }
 
 export const Anchor: FC<Props> = ({ href = '', prefetch, ...props }) => {

--- a/packages/nextra/src/client/mdx-components/anchor.tsx
+++ b/packages/nextra/src/client/mdx-components/anchor.tsx
@@ -7,7 +7,7 @@ import { LinkArrowIcon } from '../icons/index.js'
 type NextLinkProps = ComponentPropsWithoutRef<typeof Link>
 
 type Props = Omit<NextLinkProps, 'href'> & {
-  href?: NextLinkProps['href']
+  href?: NextLinkProps['href'] | undefined
 }
 
 export const Anchor: FC<Props> = ({ href = '', prefetch, ...props }) => {

--- a/packages/nextra/src/server/index.ts
+++ b/packages/nextra/src/server/index.ts
@@ -117,11 +117,8 @@ const nextra: Nextra = nextraConfig => {
         }
       },
       resolveAlias: {
-        ...turbopackConfig.resolveAlias,
         'next-mdx-import-source-file':
           '@vercel/turbopack-next/mdx-import-source',
-        'private-next-root-dir/*': './*',
-        'private-next-content-dir/*': `./${CONTENT_DIR}/*`,
         // Fixes when Turbopack is enabled: Module not found: Can't resolve '@theguild/remark-mermaid/mermaid'
         '@theguild/remark-mermaid/mermaid': path.relative(
           CWD,
@@ -131,7 +128,10 @@ const nextra: Nextra = nextraConfig => {
             'dist',
             'mermaid.js'
           )
-        )
+        ),
+        ...turbopackConfig.resolveAlias,
+        'private-next-root-dir/*': './*',
+        'private-next-content-dir/*': `./${CONTENT_DIR}/*`
       }
     } satisfies NextConfig['turbopack']
 


### PR DESCRIPTION
fix https://github.com/shuding/nextra/issues/4419