### PR TITLE
Specify custom id for toc link to the typesetting section

### DIFF
--- a/docs/app/docs/file-conventions/meta-file/page.mdx
+++ b/docs/app/docs/file-conventions/meta-file/page.mdx
@@ -365,7 +365,7 @@ export default {
 }
 ```
 
-##### Typesetting
+##### Typesetting [#typesetting-section]
 
 The `typesetting` option controls typesetting details like font features,
 heading styles and components like `<li>` and `<code>`. There are


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes: N/A

<!-- If there's an existing issue for your change, please link to it above. -->

On the [meta-file page](https://nextra.site/docs/file-conventions/meta-file), two anchor elements have the same `typesetting` id, which causes the TOC links to jump to the wrong section.

## What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

I specified a custom id `#typesetting-section` for the heading to ensure the TOC link works as expected.

https://github.com/user-attachments/assets/234674d0-b88b-4f52-9254-1fda9b46b808

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
