### PR TITLE
fix: Improve doc content alignment

### DIFF
--- a/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
+++ b/packages/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
@@ -35,7 +35,7 @@ export const ClientWrapper: FC<Omit<ComponentProps<MDXWrapper>, 'toc'>> = ({
       <article
         className={cn(
           'x:w-full x:min-w-0 x:break-words x:min-h-[calc(100vh-var(--nextra-navbar-height))]',
-          'x:text-slate-700 x:dark:text-slate-200 x:pb-8 x:px-4 x:pt-4 x:md:px-12',
+          'x:text-slate-700 x:dark:text-slate-200 x:pb-8 x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)] x:pt-4 x:md:px-12',
           themeContext.typesetting === 'article' &&
             'nextra-body-typesetting-article'
         )}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can
review this pull request. By explaining why you're making a change (or linking to an issue) and
what changes you've made, we can triage your pull request to the best possible team for review.
-->

## Why:

Closes:
https://github.com/shuding/nextra/issues/4574

This PR addresses the issue described in #4574, where the navigation content margins were not aligned with the rest of the content on mobile devices.
<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

**Before changes (screenshot):**
![CleanShot 2025-06-22 at 22 29 46](https://github.com/user-attachments/assets/7f3662c9-abad-45a1-9d7d-99236317fc7e)

**After changes (screenshot):**
![CleanShot 2025-06-22 at 22 28 46](https://github.com/user-attachments/assets/a7cbcc28-5283-4826-8b44-daca2271c2e3)

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
