### PR TITLE
Updated docs/advanced/table

### DIFF
--- a/docs/app/docs/advanced/table/page.mdx
+++ b/docs/app/docs/advanced/table/page.mdx
@@ -36,7 +36,7 @@ elements with components provided by `useMDXComponents(){:js}`[^1].
 
 > [!TIP]
 >
-> Instead, use the [built-in `<Table>` component](/docs/guide/built-ins/table)
+> Instead, use the [built-in `<Table>` component](/docs/built-ins/table)
 > available via `nextra/components`.
 
 ## Changing default behaviour


### PR DESCRIPTION
fixed link to built-ins/table

## Why:
Broken link

Closes:
https://github.com/shuding/nextra/issues/4708

## What's being changed (if available, include any code snippets, screenshots, or gifs):
just removed `guide` from URL linking to the `built-ins/table`

## Check off the following:

- [x] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
