### PR TITLE
fix(docs): update source code link for blog theme example

### DIFF
--- a/docs/app/docs/blog-theme/start/page.mdx
+++ b/docs/app/docs/blog-theme/start/page.mdx
@@ -12,7 +12,7 @@ import { Steps } from 'nextra/components'
 > [!NOTE]
 >
 > An example of the blog theme can be found [here](https://demo.vercel.blog),
-> with source code [here](https://github.com/vercel/nextjs-portfolio-starter).
+> with source code [here](https://github.com/shuding/nextra/tree/main/examples/blog).
 
 Similar to the [Docs Theme](/docs/docs-theme/start), you can install the blog
 theme with the following commands:


### PR DESCRIPTION
## Why:

The current docs link for `nextra-theme-blog` points to [[nextjs-portfolio-starter](https://github.com/vercel/nextjs-portfolio-starter)](https://github.com/vercel/nextjs-portfolio-starter), which is outdated (Nextra 2, \~2 years old).
This can be confusing since the current version is Nextra 4.

## What's being changed:

* Updated the reference link to the official maintained blog example:
  * [nextra/examples/blog](https://github.com/shuding/nextra/tree/main/examples/blog)

Thanks to @dimaMachina for pointing this out in #4710

## Check off the following:

* [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).