### PR TITLE
closes #4850: fix non informative error output for bad meta field when using `z.prettifyError` on parsed `z.union` schema

### DIFF
--- a/.changeset/flat-rivers-make.md
+++ b/.changeset/flat-rivers-make.md
@@ -1,0 +1,5 @@
+---
+'nextra': patch
+---
+
+fix `z.prettifyError` that doesn't work well with union schemas

--- a/packages/nextra/src/server/schemas.ts
+++ b/packages/nextra/src/server/schemas.ts
@@ -186,7 +186,7 @@ export const reactNode = z.custom<ReactNode>(
   { error: 'Must be a valid React node' }
 )
 
-const stringOrElement = z.union([z.string(), element])
+export const stringOrElement = z.union([z.string(), element])
 
 export const pageThemeSchema = z.strictObject({
   breadcrumb: z.boolean().optional().meta({
@@ -238,7 +238,7 @@ export const pageThemeSchema = z.strictObject({
 
 const title = stringOrElement.optional()
 
-const linkSchema = z.strictObject({
+export const linkSchema = z.strictObject({
   title,
   href: z.string()
 })
@@ -294,6 +294,6 @@ export const metaSchema = z.union([
   menuSchema
 ])
 
-function transformTitle<T>(title: T) {
+export function transformTitle<T>(title: T) {
   return typeof title === 'string' || isValidElement(title) ? { title } : title
 }


### PR DESCRIPTION
## Why:

Closes: #4850 

<!-- If there's an existing issue for your change, please link to it above. -->

## What's being changed (if available, include any code snippets, screenshots, or gifs):

I've made the same safeParse checks, just for each type, one by one, thus the prettify can do its thing since parse response is not from union. This is how it looks with fix.

<img width="395" height="87" alt="image" src="https://github.com/user-attachments/assets/29e43693-984e-41dc-bf4a-f5e20075471e" />

`z.prettifyError` doesn't work well with unions, because it is reporting ton of issues for each union it checks, here is a simple example, where it just pulls out the `message: Invalid input` at the end (same issue as here):

<img width="1486" height="917" alt="image" src="https://github.com/user-attachments/assets/1171ddfe-d6c7-4be1-a608-611cfc778abc" />

<!-- Let us know what you are changing. Share anything that could provide the most context. -->

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View
      deployment** link in this PR's timeline (this link will be available after
      opening the PR).
