### PR TITLE
fix(nextra): use addBasePath for Pagefind baseUrl

### DIFF
--- a/.changeset/fix-pagefind-basepath.md
+++ b/.changeset/fix-pagefind-basepath.md
@@ -1,0 +1,7 @@
+---
+"nextra": patch
+---
+
+Fix Pagefind search not working when using `basePath` in Next.js config
+
+When deploying Nextra to a subpath (e.g., `basePath: '/docs'`), the Pagefind search would fail to load index files because `baseUrl` was hardcoded to `'/'` instead of using `addBasePath('/')`.

--- a/packages/nextra/src/client/components/search.tsx
+++ b/packages/nextra/src/client/components/search.tsx
@@ -29,7 +29,7 @@ export async function importPagefind() {
     /* webpackIgnore: true */ addBasePath('/_pagefind/pagefind.js')
   )
   await window.pagefind!.options({
-    baseUrl: '/'
+    baseUrl: addBasePath('/')
     // ... more search options
   })
 }


### PR DESCRIPTION
## Summary

When deploying Nextra to a subpath using Next.js `basePath` config (e.g., `basePath: '/docs'`), the Pagefind search fails to load index files with the error:

```
Failed to load search index. TypeError: 'text/html' is not a valid JavaScript MIME type.
```

This happens because the Pagefind `baseUrl` option is hardcoded to `'/'`, causing it to request files from `/_pagefind/` instead of `/docs/_pagefind/`.

## Fix

Use `addBasePath('/')` for the Pagefind `baseUrl` option, consistent with how the `pagefind.js` import is already handled on the line above.

## Test plan

- [x] Tested on a Nextra site deployed to a subpath (`/foundation`)
- [x] Search now correctly loads index files from the subpath