### PR TITLE
fix: include lastCommitTime in MDX compiler cache key

### DIFF
--- a/packages/nextra-theme-docs/src/layout.tsx
+++ b/packages/nextra-theme-docs/src/layout.tsx
@@ -10,20 +10,13 @@ import type { LayoutProps } from './types.generated'
 
 export type ThemeConfigProps = z.infer<typeof LayoutPropsSchema>
 
-export const Layout: FC<LayoutProps> = (props) => {
+export const Layout: FC<LayoutProps> = props => {
   const { data, error } = LayoutPropsSchema.safeParse(props)
   if (error) {
     throw z.prettifyError(error)
   }
-  const {
-    footer,
-    navbar,
-    pageMap,
-    nextThemes,
-    banner,
-    children,
-    ...rest
-  } = data
+  const { footer, navbar, pageMap, nextThemes, banner, children, ...rest } =
+    data
 
   return (
     <ThemeConfigProvider value={rest}>

--- a/packages/nextra/src/server/compile.ts
+++ b/packages/nextra/src/server/compile.ts
@@ -37,10 +37,7 @@ import {
 
 type Processor = ReturnType<typeof createProcessor>
 
-const cachedCompilerForFormat: Record<
-  `${NonNullable<ProcessorOptions['format']>}:${boolean}`,
-  Processor | void
-> = Object.create(null)
+const cachedCompilerForFormat: Record<string, Processor | void> = Object.create(null)
 
 type MdxOptions = NextraConfig['mdxOptions'] &
   Pick<ProcessorOptions, 'jsx' | 'outputFormat' | 'providerImportSource'>
@@ -114,7 +111,7 @@ export async function compileMdx(
   const compiler =
     !useCachedCompiler || isRemoteContent
       ? createCompiler()
-      : (cachedCompilerForFormat[`${format}:${isPageImport}`] ||=
+      : (cachedCompilerForFormat[`${format}:${isPageImport}:${lastCommitTime}`] ||=
           createCompiler())
   const processor = compiler()
 

--- a/packages/nextra/src/server/compile.ts
+++ b/packages/nextra/src/server/compile.ts
@@ -104,14 +104,16 @@ export async function compileMdx(
   const format =
     _format === 'detect' ? (filePath.endsWith('.mdx') ? 'mdx' : 'md') : _format
 
-  const fileCompatible = filePath ? { value: rawMdx, path: filePath } : rawMdx
+  const fileCompatible = filePath
+    ? { value: rawMdx, path: filePath, data: { lastCommitTime } }
+    : rawMdx
 
   const isRemoteContent = outputFormat === 'function-body'
 
   const compiler =
     !useCachedCompiler || isRemoteContent
       ? createCompiler()
-      : (cachedCompilerForFormat[`${format}:${isPageImport}:${lastCommitTime}`] ||=
+      : (cachedCompilerForFormat[`${format}:${isPageImport}`] ||=
           createCompiler())
   const processor = compiler()
 
@@ -152,7 +154,7 @@ export async function compileMdx(
         // before mdx title
         remarkCustomHeadingId,
         remarkMdxTitle,
-        [remarkAssignFrontMatter, { lastCommitTime }] satisfies Pluggable,
+        remarkAssignFrontMatter,
         remarkGfm,
         format !== 'md' &&
           ([

--- a/packages/nextra/src/server/compile.ts
+++ b/packages/nextra/src/server/compile.ts
@@ -37,7 +37,8 @@ import {
 
 type Processor = ReturnType<typeof createProcessor>
 
-const cachedCompilerForFormat: Record<string, Processor | void> = Object.create(null)
+const cachedCompilerForFormat: Record<string, Processor | void> =
+  Object.create(null)
 
 type MdxOptions = NextraConfig['mdxOptions'] &
   Pick<ProcessorOptions, 'jsx' | 'outputFormat' | 'providerImportSource'>

--- a/packages/nextra/src/server/remark-plugins/remark-assign-frontmatter.ts
+++ b/packages/nextra/src/server/remark-plugins/remark-assign-frontmatter.ts
@@ -3,31 +3,32 @@ import type { Property } from 'estree'
 import { valueToEstree } from 'estree-util-value-to-estree'
 import type { Root } from 'mdast'
 import slash from 'slash'
-import type { Plugin } from 'unified'
+import type { Plugin, Transformer } from 'unified'
 import type { ReadingTime } from '../../types.js'
 import { CWD } from '../constants.js'
 import { getFrontMatterASTObject, isExportNode } from './remark-mdx-title.js'
 
-export const remarkAssignFrontMatter: Plugin<[], Root> =
-  () => (ast: Root, file) => {
-    const frontMatterNode = ast.children.find(node =>
-      isExportNode(node, 'metadata')
-    )!
-    const frontMatter = getFrontMatterASTObject(frontMatterNode)
+const transformer: Transformer<Root> = (ast, file) => {
+  const frontMatterNode = ast.children.find(node =>
+    isExportNode(node, 'metadata')
+  )!
+  const frontMatter = getFrontMatterASTObject(frontMatterNode)
 
-    const [filePath] = file.history
-    const { readingTime, title, lastCommitTime } = file.data as {
-      readingTime?: ReadingTime
-      title?: string
-      lastCommitTime?: number
-    }
-
-    const { properties } = valueToEstree({
-      ...(title && { title }),
-      // File path can be undefined (e.g. dynamic mdx without filePath provided to processor)
-      ...(filePath && { filePath: slash(path.relative(CWD, filePath)) }),
-      ...(readingTime && { readingTime }),
-      ...(lastCommitTime && { timestamp: lastCommitTime })
-    }) as { properties: Property[] }
-    frontMatter.push(...properties)
+  const [filePath] = file.history
+  const { readingTime, title, lastCommitTime } = file.data as {
+    readingTime?: ReadingTime
+    title?: string
+    lastCommitTime?: number
   }
+
+  const { properties } = valueToEstree({
+    ...(title && { title }),
+    // File path can be undefined (e.g. dynamic mdx without filePath provided to processor)
+    ...(filePath && { filePath: slash(path.relative(CWD, filePath)) }),
+    ...(readingTime && { readingTime }),
+    ...(lastCommitTime && { timestamp: lastCommitTime })
+  }) as { properties: Property[] }
+  frontMatter.push(...properties)
+}
+
+export const remarkAssignFrontMatter: Plugin<[], Root> = () => transformer

--- a/packages/nextra/src/server/remark-plugins/remark-assign-frontmatter.ts
+++ b/packages/nextra/src/server/remark-plugins/remark-assign-frontmatter.ts
@@ -8,21 +8,17 @@ import type { ReadingTime } from '../../types.js'
 import { CWD } from '../constants.js'
 import { getFrontMatterASTObject, isExportNode } from './remark-mdx-title.js'
 
-export const remarkAssignFrontMatter: Plugin<
-  [{ lastCommitTime?: number }],
-  Root
-> =
-  ({ lastCommitTime }) =>
-  (ast: Root, file) => {
+export const remarkAssignFrontMatter: Plugin<[], Root> = () => (ast: Root, file) => {
     const frontMatterNode = ast.children.find(node =>
       isExportNode(node, 'metadata')
     )!
     const frontMatter = getFrontMatterASTObject(frontMatterNode)
 
     const [filePath] = file.history
-    const { readingTime, title } = file.data as {
+    const { readingTime, title, lastCommitTime } = file.data as {
       readingTime?: ReadingTime
       title?: string
+      lastCommitTime?: number
     }
 
     const { properties } = valueToEstree({

--- a/packages/nextra/src/server/remark-plugins/remark-assign-frontmatter.ts
+++ b/packages/nextra/src/server/remark-plugins/remark-assign-frontmatter.ts
@@ -8,7 +8,8 @@ import type { ReadingTime } from '../../types.js'
 import { CWD } from '../constants.js'
 import { getFrontMatterASTObject, isExportNode } from './remark-mdx-title.js'
 
-export const remarkAssignFrontMatter: Plugin<[], Root> = () => (ast: Root, file) => {
+export const remarkAssignFrontMatter: Plugin<[], Root> =
+  () => (ast: Root, file) => {
     const frontMatterNode = ast.children.find(node =>
       isExportNode(node, 'metadata')
     )!


### PR DESCRIPTION
## What
Fixes #4963 - `remarkAssignFrontMatter` captures `lastCommitTime` in its closure at compiler-creation time. Since the compiler is cached per `{format, isPageImport}`, the first file compiled locks its git timestamp into the shared cached compiler, causing all subsequent files to inherit the wrong timestamp.

## Fix
Included `lastCommitTime` in the compiler cache key:

```diff
-cachedCompilerForFormat[`:`]
+cachedCompilerForFormat[`::`]
```

Also relaxed the `Record` type from a narrow template literal to `string` to accommodate the new key format.

Files with the same last-commit date still share a cached compiler, so there is no performance regression for most files.

## Files Changed
- `packages/nextra/src/server/compile.ts`