### PR TITLE
fix(nextra-theme-docs): include children in LayoutPropsSchema.safeParse to fix Zod 4.4.x compatibility

### DIFF
--- a/.changeset/fix-zod-44-children-nonoptional.md
+++ b/.changeset/fix-zod-44-children-nonoptional.md
@@ -1,0 +1,5 @@
+---
+"nextra-theme-docs": patch
+---
+
+Fix Zod 4.4.x compatibility: include `children` in `LayoutPropsSchema.safeParse` so it is not treated as non-optional

--- a/packages/nextra-theme-docs/src/__tests__/layout-props.test-d.ts
+++ b/packages/nextra-theme-docs/src/__tests__/layout-props.test-d.ts
@@ -5,14 +5,14 @@ import type { LayoutProps } from '../types.generated'
 
 describe('Assert types', () => {
   test('LayoutProps should be identical', () => {
-    const WithoutLoose = z.strictObject({
+    const _WithoutLoose = z.strictObject({
       ...LayoutPropsSchema.shape,
       nextThemes: z
         .strictObject(LayoutPropsSchema.shape.nextThemes.unwrap().shape)
         .optional()
     })
 
-    type Expected = z.input<typeof WithoutLoose>
+    type Expected = z.input<typeof _WithoutLoose>
     type Actual = LayoutProps
     assertType<IsEqual<Expected, Actual>>(true)
     return expectTypeOf<Actual>().toEqualTypeOf<Expected>

--- a/packages/nextra-theme-docs/src/layout.tsx
+++ b/packages/nextra-theme-docs/src/layout.tsx
@@ -11,11 +11,11 @@ import type { LayoutProps } from './types.generated'
 export type ThemeConfigProps = z.infer<typeof LayoutPropsSchema>
 
 export const Layout: FC<LayoutProps> = ({ children, ...themeConfig }) => {
-  const { data, error } = LayoutPropsSchema.safeParse(themeConfig)
+  const { data, error } = LayoutPropsSchema.safeParse({ children, ...themeConfig })
   if (error) {
     throw z.prettifyError(error)
   }
-  const { footer, navbar, pageMap, nextThemes, banner, ...rest } = data
+  const { footer, navbar, pageMap, nextThemes, banner, children: _, ...rest } = data
 
   return (
     <ThemeConfigProvider value={rest}>

--- a/packages/nextra-theme-docs/src/layout.tsx
+++ b/packages/nextra-theme-docs/src/layout.tsx
@@ -10,11 +10,8 @@ import type { LayoutProps } from './types.generated'
 
 export type ThemeConfigProps = z.infer<typeof LayoutPropsSchema>
 
-export const Layout: FC<LayoutProps> = ({ children, ...themeConfig }) => {
-  const { data, error } = LayoutPropsSchema.safeParse({
-    children,
-    ...themeConfig
-  })
+export const Layout: FC<LayoutProps> = (props) => {
+  const { data, error } = LayoutPropsSchema.safeParse(props)
   if (error) {
     throw z.prettifyError(error)
   }
@@ -24,7 +21,7 @@ export const Layout: FC<LayoutProps> = ({ children, ...themeConfig }) => {
     pageMap,
     nextThemes,
     banner,
-    children: _,
+    children,
     ...rest
   } = data
 

--- a/packages/nextra-theme-docs/src/layout.tsx
+++ b/packages/nextra-theme-docs/src/layout.tsx
@@ -11,11 +11,22 @@ import type { LayoutProps } from './types.generated'
 export type ThemeConfigProps = z.infer<typeof LayoutPropsSchema>
 
 export const Layout: FC<LayoutProps> = ({ children, ...themeConfig }) => {
-  const { data, error } = LayoutPropsSchema.safeParse({ children, ...themeConfig })
+  const { data, error } = LayoutPropsSchema.safeParse({
+    children,
+    ...themeConfig
+  })
   if (error) {
     throw z.prettifyError(error)
   }
-  const { footer, navbar, pageMap, nextThemes, banner, children: _, ...rest } = data
+  const {
+    footer,
+    navbar,
+    pageMap,
+    nextThemes,
+    banner,
+    children: _,
+    ...rest
+  } = data
 
   return (
     <ThemeConfigProvider value={rest}>

--- a/packages/nextra-theme-docs/src/types.generated.ts
+++ b/packages/nextra-theme-docs/src/types.generated.ts
@@ -113,7 +113,7 @@ export interface LayoutProps {
     /**
      * @default "class"
      */
-    attribute?: 'class' | `data-${string}` | ('class' | `data-${string}`)[]
+    attribute?: ('class' | `data-${string}`)[] | 'class' | `data-${string}`
 
     /**
      * @default "system"

--- a/packages/tsdoc/src/__tests__/snapshots/layout-props.ts
+++ b/packages/tsdoc/src/__tests__/snapshots/layout-props.ts
@@ -113,7 +113,7 @@ interface $ {
     /**
      * @default "class"
      */
-    attribute?: 'class' | `data-${string}` | ('class' | `data-${string}`)[]
+    attribute?: ('class' | `data-${string}`)[] | 'class' | `data-${string}`
 
     /**
      * @default "system"


### PR DESCRIPTION
## Problem

Upgrading Zod to 4.4.0 causes a prerender failure in `next build` for any page that doesn't go through the nextra MDX wrapper (e.g. plain Next.js Server Component pages colocated in a nextra app). The error is:

```
✖ Invalid input: expected nonoptional, received undefined
  → at children
```

This is caused by a breaking change in Zod 4.4.0's `$ZodObject` property iteration. Previously, when a required key was **absent** from the parsed object, `z.custom(fn)` would be called with `undefined` and validation would pass if `fn(undefined)` returned `true`. As of 4.4.0, Zod emits an `"invalid_type: expected nonoptional"` error for absent required keys _before_ calling the custom validator, regardless of what the validator would return.

The root cause is in `layout.tsx`. `children` is destructured out of props before `safeParse` is called, so it is never a key in the input object:

```tsx
// children is stripped — `'children' in themeConfig` is false
export const Layout: FC<LayoutProps> = ({ children, ...themeConfig }) => {
  const { data, error } = LayoutPropsSchema.safeParse(themeConfig)
```

`LayoutPropsSchema` declares `children: reactNode` as required. With Zod ≤4.3.6 the `reactNode` custom validator accepted `undefined` and the parse succeeded. With Zod 4.4.x the parse fails.

## Fix

Include `children` in the `safeParse` input so the key is present, and explicitly destructure it out of `data` so it does not flow into the `rest` object passed to `ThemeConfigProvider` (which already excludes `children` via `Omit<ThemeConfigProps, ... | 'children'>` in `theme-config.ts`):

```tsx
export const Layout: FC<LayoutProps> = ({ children, ...themeConfig }) => {
  const { data, error } = LayoutPropsSchema.safeParse({ children, ...themeConfig })
  if (error) {
    throw z.prettifyError(error)
  }
  const { footer, navbar, pageMap, nextThemes, banner, children: _, ...rest } = data
```

The schema is unchanged — `children` remains required in `LayoutPropsSchema`, which keeps the existing type test in `layout-props.test-d.ts` passing.

May be related to #4989.

## Test plan

- [ ] `pnpm test` passes in `packages/nextra-theme-docs`
- [ ] Upgrade `zod` to `^4.4.0` in `packages/nextra-theme-docs/package.json` and confirm `next build` succeeds on a nextra app that includes non-MDX pages
