### PR TITLE
fix(nextra): use repository.workdir() for GIT_ROOT to support git worktrees

### DIFF
--- a/.changeset/fix-git-root-worktree.md
+++ b/.changeset/fix-git-root-worktree.md
@@ -1,0 +1,9 @@
+---
+"nextra": patch
+---
+
+Fix `GIT_ROOT` resolution for git worktrees so MDX `getFileLatestModifiedDateAsync` lookups don't hang `next build`.
+
+`repository.path()` returns `<repo>/.git/worktrees/<name>/` inside a worktree, so `path.join(repository.path(), '..')` resolved to `<repo>/.git/worktrees/` — the wrong directory. Every per-file timestamp lookup then walked the full history from a path that didn't exist relative to the calculated root, taking ~1.6 s per file (a 110-file site went from ~1.8 s total to ~176 s).
+
+`repository.workdir()` returns the correct working directory for both regular checkouts and worktrees, with a fallback to the old behaviour for bare repositories where `workdir()` is undefined.

--- a/packages/nextra/src/server/loader.ts
+++ b/packages/nextra/src/server/loader.ts
@@ -45,8 +45,17 @@ const repository = await (async () => {
   }
 })()
 
-// repository.path() returns the `/path/to/repo/.git`, we need the parent directory of it
-const GIT_ROOT = repository ? path.join(repository.path(), '..') : ''
+// `repository.workdir()` returns the working directory for both regular checkouts
+// and git worktrees. Fall back to `path.join(repository.path(), '..')` for bare
+// repositories where `workdir()` is undefined. In a worktree, `repository.path()`
+// points at `<repo>/.git/worktrees/<name>/`, so joining with `..` resolves to the
+// wrong directory and breaks `getFileLatestModifiedDateAsync`.
+const GIT_ROOT = repository
+  ? (repository.workdir() || path.join(repository.path(), '..')).replace(
+      /\/$/,
+      ''
+    )
+  : ''
 
 const DEFAULT_TRANSFORMERS = transformerTwoslash({
   renderer: twoslashRenderer(),


### PR DESCRIPTION
## Why: Running `next build` on a Nextra docs site from inside a [git worktree](https://git-scm.com/docs/git-worktree) hangs (or takes ~100× longer than expected) because every MDX page's git-timestamp lookup walks the entire commit history from the wrong root.

Closes: #4996

`loader.ts` calculates `GIT_ROOT` as:

```ts
// repository.path() returns the `/path/to/repo/.git`, we need the parent directory of it
const GIT_ROOT = repository ? path.join(repository.path(), '..') : ''
```

In a normal checkout `repository.path()` returns `<repo>/.git/`, so this works. In a **git worktree** it returns `<repo>/.git/worktrees/<name>/`, so `GIT_ROOT` becomes `<repo>/.git/worktrees/` — a directory that contains no source files. Every subsequent `getFileLatestModifiedDateAsync(path.relative(GIT_ROOT, mdxPath))` call then asks libgit2 to walk the full history looking for a path like `../../docs/content/foo.mdx`, which is enormously slow.

## What's being changed:

Use `repository.workdir()` instead of `path.join(repository.path(), '..')`. `workdir()` is provided by `@napi-rs/simple-git` (already a dependency) and returns the actual working directory for both regular checkouts **and** worktrees. For bare repositories — where `workdir()` returns `undefined` — fall back to the previous behaviour, preserving the existing contract.

The trailing-slash strip keeps the resulting path shape consistent with the previous `path.join(..., '..')` output, which downstream `path.relative(GIT_ROOT, ...)` calls rely on.

Already validated downstream via `pnpm patch` on Nextra 4.6.1 in our monorepo — `next build` from a git worktree went from timing out at 90 s+ to completing in ~25 s, and a regular checkout build is unchanged.

## Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).
- [x] Linked an issue (#4996)
- [x] Added a changeset (`patch` for `nextra`)