### PR TITLE
feat(nextra): add maxResults prop to Search component

### DIFF
--- a/.changeset/search-max-results.md
+++ b/.changeset/search-max-results.md
@@ -1,0 +1,7 @@
+---
+"nextra": patch
+---
+
+Add `maxResults` prop to `<Search>` to cap how many Pagefind results are hydrated and rendered. Prevents browser freezes ("Page Unresponsive") on large docs sites where a short query can match hundreds of pages. Defaults to 12; pass a higher value to keep previous behavior.
+
+The previous implementation called `o.data()` on every result returned by Pagefind and rendered them all on the main thread. On large sites, a short query can match hundreds of pages, fetching hundreds of fragment JSON files and rendering hundreds of result components — long enough to block the main thread for 15+ seconds and trigger Chrome's "Page Unresponsive" dialog. The search dropdown only shows ~10 results at a time, so the rest of that work is hydrating fragments the user will never see.

--- a/packages/nextra/src/client/components/search.tsx
+++ b/packages/nextra/src/client/components/search.tsx
@@ -78,6 +78,14 @@ interface SearchProps extends InputProps {
   className?: string
   searchOptions?: PagefindSearchOptions
   /**
+   * Maximum number of Pagefind results to hydrate and render. Caps how many
+   * result fragments are fetched via `.data()` and turned into DOM nodes per
+   * query, preventing browser freezes ("Page Unresponsive") on large docs
+   * sites where a short query can match hundreds of pages.
+   * @default 12
+   */
+  maxResults?: number
+  /**
    * Callback function that triggers whenever the search input changes.
    *
    * This prop is **not serializable** and cannot be used directly in a server-side layout.
@@ -145,6 +153,7 @@ export const Search: FC<SearchProps> = ({
   loading = 'Loading…',
   placeholder = 'Search documentation…',
   searchOptions,
+  maxResults = 12,
   onSearch,
   ...props
 }) => {
@@ -186,7 +195,9 @@ export const Search: FC<SearchProps> = ({
       )
       if (!response) return
 
-      const data = await Promise.all(response.results.map(o => o.data()))
+      const data = await Promise.all(
+        response.results.slice(0, maxResults).map(o => o.data())
+      )
       setIsLoading(false)
       setError('')
       setResults(


### PR DESCRIPTION
## Problem

`<Search>` (packages/nextra/src/client/components/search.tsx) currently fetches the fragment JSON for **every** result Pagefind returns, then renders every one as a DOM node with `dangerouslySetInnerHTML`:

```ts
const response = await window.pagefind.debouncedSearch(value, searchOptions)
const data = await Promise.all(response.results.map(o => o.data()))
setResults(data.map(...))
```

On large docs sites a short query can match hundreds of pages. The browser then:

- fetches hundreds of fragment JSON files in parallel
- runs `.data()` for each one
- renders hundreds of `<Result>` components on the main thread

In practice this blocks the main thread for 15+ seconds and Chrome shows the "Page Unresponsive" dialog.

The dropdown itself only shows ~10 results at a time, so 99% of that work is hydrating fragments the user will never see.

## Reproduction

Docs site with several hundred indexed pages. Typing any 1–2 character query (very common at the start of typing) returns hundreds of matches, and the search dropdown hangs the tab.

## Solution

Add an optional `maxResults` prop to `<Search>` (default **12**) and slice `response.results` before calling `.data()` on each:

```ts
const data = await Promise.all(
  response.results.slice(0, maxResults).map(o => o.data())
)
```

This caps the per-query work (fragment fetches + result DOM nodes) at a sensible default while letting consumers opt back into the previous behavior by passing a higher value (e.g. `<Search maxResults={Infinity} />`).

Pagefind already returns results in relevance order, so slicing the top N is the right cut — and matches what users actually scan in the dropdown anyway.