### PR TITLE
fix(nextra-theme-docs): make LayoutPropsSchema.children optional

### DIFF
--- a/packages/nextra-theme-docs/src/schemas.tsx
+++ b/packages/nextra-theme-docs/src/schemas.tsx
@@ -88,7 +88,10 @@ export const LayoutPropsSchema = z.strictObject({
       description:
         'Rendered [`<Banner>` component](/docs/built-ins/banner). E.g. `<Banner {...bannerProps} />`'
     }),
-  children: reactNode,
+  // Optional so schema validation succeeds when the React Compiler hoists
+  // `children` out of props before `LayoutPropsSchema.safeParse` is called
+  // (compiled `Layout` parses `themeConfig` without `children`).
+  children: reactNode.optional(),
   copyPageButton: z.boolean().default(true).meta({
     description: 'Hide/show copy page content button.'
   }),


### PR DESCRIPTION

## Why this change is needed

The Layout component currently crashes on every render when used with React 19 and the React Compiler.

`<Layout>` throws on every render with:

```bash
Invalid input: expected ReactNode, received undefined → at "children"
```

This happens because the React Compiler hoists the children prop out of the props object before the schema validation runs. The schema expects children to be required, but by the time validation happens, children is gone, so the validation fails and throws an error.

This is reproducible with a fresh Next.js `15.5` install using `nextra-theme-docs`.

## What changed

Just one line in `schemas.tsx`: children is now marked as optional instead of required. This matches what actually happens at runtime, since the React Compiler removes children from props before validation.

The actual component behavior stays exactly the same. React always provides children to Layout when you write `<Layout>{children}</Layout>`, so making it optional in the schema doesn't break anything.

A more thorough fix would be to fully refactor `layout.tsx` to destructure children in the function signature and remove it from the schema entirely. I can do that as a followup if you prefer, but this PR keeps the change minimal and focused.